### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,8 @@
 name: Docker Build and Push
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/sha1n/mcp-acdc-server-go/security/code-scanning/1](https://github.com/sha1n/mcp-acdc-server-go/security/code-scanning/1)

In general, the fix is to explicitly declare a minimal `permissions` block so that the `GITHUB_TOKEN` is limited to the least privilege needed. Since this workflow only checks out code and interacts with Docker Hub (via secret-based auth) and does not update GitHub resources, it can safely operate with `contents: read` only.

The best way to fix this while preserving behavior is to add a `permissions` section at the workflow root (so it applies to all jobs) with `contents: read`. Concretely, in `.github/workflows/docker.yml`, after the `name: Docker Build and Push` line (or before `jobs:`), insert:

```yaml
permissions:
  contents: read
```

No additional imports or definitions are needed, as this is purely a YAML configuration change within the workflow. The existing steps (`actions/checkout`, `docker/*` actions) will continue to work, and the `GITHUB_TOKEN` will now be limited to read-only repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
