### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go-report-card.yml
+++ b/.github/workflows/go-report-card.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   refresh_go_report_card:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - name: Go report card
       uses: creekorful/goreportcard-action@v1.0


### PR DESCRIPTION
Potential fix for [https://github.com/sha1n/mcp-acdc-server-go/security/code-scanning/3](https://github.com/sha1n/mcp-acdc-server-go/security/code-scanning/3)

In general, the fix is to explicitly set a restrictive `permissions` block for the workflow or for the specific job, so that the `GITHUB_TOKEN` has only the access required. For a read-only analysis/reporting job like this, `contents: read` at the workflow or job level is typically sufficient, unless the action’s documentation explicitly requires additional scopes.

For this workflow, the best minimal change is to add a `permissions` block at the job level under `refresh_go_report_card`, directly alongside `runs-on`. This keeps the scope of permissions clear and does not alter the behavior of any other workflows. We will set `contents: read`, which allows the job to read repository contents (needed for analyzing code) but not write to the repo. Specifically, in `.github/workflows/go-report-card.yml`, after line 11 (`runs-on: ubuntu-latest`), add:

```yaml
    permissions:
      contents: read
```

No new imports or external libraries are required, as this is pure GitHub Actions YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
