### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/sha1n/mcp-acdc-server-go/security/code-scanning/2](https://github.com/sha1n/mcp-acdc-server-go/security/code-scanning/2)

In general, this problem is fixed by explicitly defining a `permissions` block to scope the `GITHUB_TOKEN` to the minimum needed. For a CI workflow that only needs to read the repository contents, `contents: read` is typically sufficient.

For this specific workflow in `.github/workflows/ci.yml`, the simplest and safest fix without changing behavior is to add a `permissions` block at the top level (so it applies to all jobs) granting only read access to repository contents. No current step requires write permissions or additional scopes. Add the block just below the `name: CI` line and above the `on:` trigger block:

```yaml
name: CI
permissions:
  contents: read

on:
  ...
```

No additional methods, imports, or definitions are needed; this is purely a YAML configuration change within the shown file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
