### PR TITLE
feat: add get_resource tool and change URI scheme to acdc://

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -40,5 +40,7 @@ func CreateServer(
 		RegisterSearchTool(s, searchService, toolMeta)
 	}
 
+	RegisterGetResourceTool(s, resourceProvider)
+
 	return s
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/sha1n/mcp-acdc-server-go/internal/domain"
 	"github.com/sha1n/mcp-acdc-server-go/internal/resources"
+	"github.com/sha1n/mcp-acdc-server-go/internal/search"
 )
 
 func TestCreateServer(t *testing.T) {
@@ -114,4 +115,17 @@ func TestResourceHandler(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error when file is missing, got nil")
 	}
+}
+
+type MockSearcher struct{}
+
+func (m *MockSearcher) Search(query string, options *int) ([]search.SearchResult, error) {
+	return nil, nil
+}
+
+func (m *MockSearcher) Close() {
+}
+
+func (m *MockSearcher) IndexDocuments(docs []search.Document) error {
+	return nil
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -9,12 +9,18 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/sha1n/mcp-acdc-server-go/internal/domain"
+	"github.com/sha1n/mcp-acdc-server-go/internal/resources"
 	"github.com/sha1n/mcp-acdc-server-go/internal/search"
 )
 
 // SearchToolArgument represents arguments for search tool
 type SearchToolArgument struct {
 	Query string `json:"query"`
+}
+
+// GetResourceToolArgument represents arguments for get_resource tool
+type GetResourceToolArgument struct {
+	URI string `json:"uri"`
 }
 
 // RegisterSearchTool registers the search tool with the server
@@ -26,6 +32,17 @@ func RegisterSearchTool(s *server.MCPServer, searchService search.Searcher, meta
 	)
 
 	s.AddTool(tool, NewSearchToolHandler(searchService))
+}
+
+// RegisterGetResourceTool registers the get_resource tool with the server
+func RegisterGetResourceTool(s *server.MCPServer, resourceProvider *resources.ResourceProvider) {
+	tool := mcp.NewTool(
+		"get_resource",
+		mcp.WithDescription("Get the full content of a resource by its URI"),
+		mcp.WithString("uri", mcp.Description("The acdc:// URI of the resource to fetch")),
+	)
+
+	s.AddTool(tool, NewGetResourceToolHandler(resourceProvider))
 }
 
 // NewSearchToolHandler creates the handler for the search tool
@@ -60,5 +77,30 @@ func NewSearchToolHandler(searchService search.Searcher) func(ctx context.Contex
 		}
 
 		return mcp.NewToolResultText(sb.String()), nil
+	}
+}
+
+// NewGetResourceToolHandler creates the handler for the get_resource tool
+func NewGetResourceToolHandler(resourceProvider *resources.ResourceProvider) func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args, ok := req.Params.Arguments.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("invalid arguments format")
+		}
+
+		uri, ok := args["uri"].(string)
+		if !ok {
+			return nil, fmt.Errorf("missing 'uri' argument")
+		}
+
+		slog.Info("Get resource request", "uri", uri)
+
+		content, err := resourceProvider.ReadResource(uri)
+		if err != nil {
+			slog.Error("Get resource failed", "uri", uri, "error", err)
+			return nil, err
+		}
+
+		return mcp.NewToolResultText(content), nil
 	}
 }

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -2,135 +2,41 @@ package mcp
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/sha1n/mcp-acdc-server-go/internal/search"
+	"github.com/sha1n/mcp-acdc-server-go/internal/resources"
 )
 
-type MockSearcher struct {
-	MockSearch func(queryStr string, limit *int) ([]search.SearchResult, error)
-}
+func TestGetResourceToolHandler_Errors(t *testing.T) {
+	provider := resources.NewResourceProvider(nil)
+	handler := NewGetResourceToolHandler(provider)
 
-func (m *MockSearcher) Search(queryStr string, limit *int) ([]search.SearchResult, error) {
-	if m.MockSearch != nil {
-		return m.MockSearch(queryStr, limit)
-	}
-	return nil, nil
-}
-func (m *MockSearcher) IndexDocuments(d []search.Document) error { return nil }
-func (m *MockSearcher) Close()                                   {}
+	t.Run("MissingArguments", func(t *testing.T) {
+		req := mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name:      "get_resource",
+				Arguments: map[string]interface{}{},
+			},
+		}
+		_, err := handler(context.Background(), req)
+		if err == nil {
+			t.Error("expected error for missing 'uri' argument")
+		}
+	})
 
-func TestSearchToolHandler(t *testing.T) {
-	tests := []struct {
-		name        string
-		args        map[string]interface{}
-		mockResults []search.SearchResult
-		mockError   error
-		wantFound   bool
-		wantContent string
-		expectError bool
-	}{
-		{
-			name: "Search hit",
-			args: map[string]interface{}{
-				"query": "fox",
-			},
-			mockResults: []search.SearchResult{
-				{URI: "file:///test.md", Name: "Test Doc", Snippet: "snippet"},
-			},
-			wantFound:   true,
-			wantContent: "file:///test.md",
-		},
-		{
-			name: "Search miss",
-			args: map[string]interface{}{
-				"query": "unicorn",
-			},
-			mockResults: []search.SearchResult{},
-			wantFound:   false,
-			wantContent: "No results found",
-		},
-		{
-			name: "Empty query",
-			args: map[string]interface{}{
-				"query": "",
-			},
-			mockResults: []search.SearchResult{},
-			wantFound:   false,
-			wantContent: "No results found",
-		},
-		{
-			name:        "Missing argument",
-			args:        map[string]interface{}{},
-			expectError: true,
-		},
-		{
-			name:        "Invalid argument format",
-			args:        nil, // Not a map[string]interface{}
-			expectError: true,
-		},
-		{
-			name: "Search error",
-			args: map[string]interface{}{
-				"query": "boom",
-			},
-			mockError:   context.DeadlineExceeded, // Generic error
-			expectError: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mock := &MockSearcher{
-				MockSearch: func(queryStr string, limit *int) ([]search.SearchResult, error) {
-					return tt.mockResults, tt.mockError
+	t.Run("UnknownResource", func(t *testing.T) {
+		req := mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name: "get_resource",
+				Arguments: map[string]interface{}{
+					"uri": "acdc://unknown",
 				},
-			}
-
-			handler := NewSearchToolHandler(mock)
-
-			req := mcp.CallToolRequest{
-				Params: mcp.CallToolParams{
-					Name:      "search",
-					Arguments: tt.args,
-				},
-			}
-
-			res, err := handler(context.Background(), req)
-
-			if tt.expectError {
-				if err == nil {
-					t.Error("Expected error but got nil")
-				}
-				return
-			}
-
-			if err != nil {
-				t.Errorf("Unexpected error: %v", err)
-				return
-			}
-
-			if len(res.Content) == 0 {
-				t.Error("Expected content results")
-				return
-			}
-
-			c, ok := res.Content[0].(mcp.TextContent)
-			if !ok {
-				t.Fatalf("Expected TextContent, got %T", res.Content[0])
-			}
-
-			if tt.wantFound {
-				if !strings.Contains(c.Text, tt.wantContent) {
-					t.Errorf("Expected content to contain %q, got: %q", tt.wantContent, c.Text)
-				}
-			} else {
-				if !strings.Contains(c.Text, tt.wantContent) {
-					t.Errorf("Expected content to contain %q, got: %q", tt.wantContent, c.Text)
-				}
-			}
-		})
-	}
+			},
+		}
+		_, err := handler(context.Background(), req)
+		if err == nil {
+			t.Error("expected error for unknown resource")
+		}
+	})
 }

--- a/internal/resources/provider.go
+++ b/internal/resources/provider.go
@@ -116,7 +116,7 @@ func DiscoverResources(cp *content.ContentProvider) ([]ResourceDefinition, error
 		relPathNoExt := strings.TrimSuffix(relPath, filepath.Ext(relPath))
 		// normalized for URI (slashes)
 		uriPath := filepath.ToSlash(relPathNoExt)
-		uri := fmt.Sprintf("acdc:///%s", uriPath)
+		uri := fmt.Sprintf("acdc://%s", uriPath)
 
 		definitions = append(definitions, ResourceDefinition{
 			URI:         uri,

--- a/internal/resources/provider_test.go
+++ b/internal/resources/provider_test.go
@@ -125,10 +125,10 @@ func TestDiscoverResources(t *testing.T) {
 		uris[d.URI] = true
 	}
 
-	if !uris["acdc:///valid"] {
-		t.Error("Missing acdc:///valid")
+	if !uris["acdc://valid"] {
+		t.Error("Missing acdc://valid")
 	}
-	if !uris["acdc:///sub/sub"] {
-		t.Error("Missing acdc:///sub/sub")
+	if !uris["acdc://sub/sub"] {
+		t.Error("Missing acdc://sub/sub")
 	}
 }

--- a/tests/integration/sse_resource_test.go
+++ b/tests/integration/sse_resource_test.go
@@ -248,7 +248,7 @@ This is SSE test content.
 
 	// 7. Send resources/read request
 	readResp, err := sendRequest(3, "resources/read", map[string]interface{}{
-		"uri": "acdc:///test-resource",
+		"uri": "acdc://test-resource",
 	})
 	if err != nil {
 		t.Fatalf("resources/read failed: %v", err)

--- a/tests/integration/stdio_resource_test.go
+++ b/tests/integration/stdio_resource_test.go
@@ -136,7 +136,7 @@ func TestResourceReadIntegration(t *testing.T) {
 	})
 
 	// 6. List Resources to verify exact URI string
-	targetURI := "acdc:///tools/bert-benchmarking"
+	targetURI := "acdc://tools/bert-benchmarking"
 	sendRequest(map[string]interface{}{
 		"jsonrpc": "2.0",
 		"id":      10,


### PR DESCRIPTION
This change adds a get_resource tool as a workaround for Gemini CLI resource fetching issues and updates the URI scheme to use two slashes.