### PR TITLE
feat: add CLI configuration arguments support

### DIFF
--- a/cmd/mcp-acdc/cli_test.go
+++ b/cmd/mcp-acdc/cli_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+func TestRegisterFlags_AllFlagsExist(t *testing.T) {
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	RegisterFlags(flags)
+
+	expectedFlags := []struct {
+		long  string
+		short string
+	}{
+		{"content-dir", "c"},
+		{"transport", "t"},
+		{"host", "H"},
+		{"port", "p"},
+		{"search-max-results", "m"},
+		{"auth-type", "a"},
+		{"auth-basic-username", "u"},
+		{"auth-basic-password", "P"},
+		{"auth-api-keys", "k"},
+	}
+
+	for _, ef := range expectedFlags {
+		f := flags.Lookup(ef.long)
+		if f == nil {
+			t.Errorf("Flag --%s not registered", ef.long)
+			continue
+		}
+		if f.Shorthand != ef.short {
+			t.Errorf("Flag --%s has wrong shorthand: expected -%s, got -%s", ef.long, ef.short, f.Shorthand)
+		}
+	}
+}
+
+func TestRegisterFlags_FlagDescriptions(t *testing.T) {
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	RegisterFlags(flags)
+
+	// Verify all flags have non-empty descriptions
+	flags.VisitAll(func(f *pflag.Flag) {
+		if f.Usage == "" {
+			t.Errorf("Flag --%s has empty description", f.Name)
+		}
+	})
+}
+
+func TestCLI_FlagParsing_ContentDir(t *testing.T) {
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	RegisterFlags(flags)
+
+	err := flags.Parse([]string{"--content-dir=/custom/path"})
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	val, err := flags.GetString("content-dir")
+	if err != nil {
+		t.Fatalf("GetString failed: %v", err)
+	}
+	if val != "/custom/path" {
+		t.Errorf("Expected '/custom/path', got '%s'", val)
+	}
+}
+
+func TestCLI_FlagParsing_ShortFlags(t *testing.T) {
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	RegisterFlags(flags)
+
+	err := flags.Parse([]string{"-t", "stdio", "-p", "9000", "-a", "basic"})
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	transport, _ := flags.GetString("transport")
+	port, _ := flags.GetInt("port")
+	authType, _ := flags.GetString("auth-type")
+
+	if transport != "stdio" {
+		t.Errorf("Expected transport 'stdio', got '%s'", transport)
+	}
+	if port != 9000 {
+		t.Errorf("Expected port 9000, got %d", port)
+	}
+	if authType != "basic" {
+		t.Errorf("Expected auth type 'basic', got '%s'", authType)
+	}
+}
+
+func TestCLI_FlagParsing_AuthAPIKeys(t *testing.T) {
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	RegisterFlags(flags)
+
+	err := flags.Parse([]string{"--auth-api-keys=key1,key2,key3"})
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	keys, err := flags.GetStringSlice("auth-api-keys")
+	if err != nil {
+		t.Fatalf("GetStringSlice failed: %v", err)
+	}
+
+	if len(keys) != 3 {
+		t.Fatalf("Expected 3 keys, got %d", len(keys))
+	}
+	if keys[0] != "key1" || keys[1] != "key2" || keys[2] != "key3" {
+		t.Errorf("Unexpected keys: %v", keys)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/blevesearch/bleve/v2 v2.5.7
 	github.com/mark3labs/mcp-go v0.43.2
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -46,7 +47,6 @@ require (
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -2,7 +2,10 @@ package config
 
 import (
 	"os"
+	"strings"
 	"testing"
+
+	"github.com/spf13/pflag"
 )
 
 func TestLoadSettings_Defaults(t *testing.T) {
@@ -16,8 +19,8 @@ func TestLoadSettings_Defaults(t *testing.T) {
 		t.Fatalf("Failed to load settings: %v", err)
 	}
 
-	if settings.Port != 8000 {
-		t.Errorf("Expected default port 8000, got %d", settings.Port)
+	if settings.Port != 8080 {
+		t.Errorf("Expected default port 8080, got %d", settings.Port)
 	}
 	if settings.Auth.Type != AuthTypeNone {
 		t.Errorf("Expected default auth type '%s', got '%s'", AuthTypeNone, settings.Auth.Type)
@@ -115,5 +118,307 @@ func TestLoadSettings_InvalidConfig(t *testing.T) {
 	_, err := LoadSettings()
 	if err == nil {
 		t.Fatal("Expected error for invalid port type")
+	}
+}
+
+// TestLoadSettingsWithFlags_CLIOverridesEnv verifies that CLI flags take priority over env vars
+func TestLoadSettingsWithFlags_CLIOverridesEnv(t *testing.T) {
+	// Set env var
+	t.Setenv("ACDC_MCP_PORT", "9090")
+	t.Setenv("ACDC_MCP_TRANSPORT", "sse")
+
+	// Create flags with different values
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.Int("port", 0, "")
+	flags.String("transport", "", "")
+	_ = flags.Set("port", "7777")
+	_ = flags.Set("transport", "stdio")
+
+	settings, err := LoadSettingsWithFlags(flags)
+	if err != nil {
+		t.Fatalf("Failed to load settings: %v", err)
+	}
+
+	// CLI should win
+	if settings.Port != 7777 {
+		t.Errorf("Expected CLI port 7777, got %d", settings.Port)
+	}
+	if settings.Transport != "stdio" {
+		t.Errorf("Expected CLI transport 'stdio', got '%s'", settings.Transport)
+	}
+}
+
+// TestLoadSettingsWithFlags_EnvOverridesDefault verifies env vars override defaults
+func TestLoadSettingsWithFlags_EnvOverridesDefault(t *testing.T) {
+	t.Setenv("ACDC_MCP_HOST", "192.168.1.1")
+
+	settings, err := LoadSettingsWithFlags(nil)
+	if err != nil {
+		t.Fatalf("Failed to load settings: %v", err)
+	}
+
+	// Default is 0.0.0.0, env should override
+	if settings.Host != "192.168.1.1" {
+		t.Errorf("Expected env host '192.168.1.1', got '%s'", settings.Host)
+	}
+}
+
+// TestLoadSettingsWithFlags_NilFlags is same as LoadSettings behavior
+func TestLoadSettingsWithFlags_NilFlags(t *testing.T) {
+	_ = os.Unsetenv("ACDC_MCP_PORT")
+
+	settings, err := LoadSettingsWithFlags(nil)
+	if err != nil {
+		t.Fatalf("Failed to load settings: %v", err)
+	}
+
+	// Should get default port
+	if settings.Port != 8080 {
+		t.Errorf("Expected default port 8080, got %d", settings.Port)
+	}
+}
+
+// TestLoadSettingsWithFlags_AllFlagTypes verifies all flag types work
+func TestLoadSettingsWithFlags_AllFlagTypes(t *testing.T) {
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.String("content-dir", "", "")
+	flags.String("transport", "", "")
+	flags.String("host", "", "")
+	flags.Int("port", 0, "")
+	flags.Int("search-max-results", 0, "")
+	flags.String("auth-type", "", "")
+	flags.String("auth-basic-username", "", "")
+	flags.String("auth-basic-password", "", "")
+	flags.StringSlice("auth-api-keys", nil, "")
+
+	_ = flags.Set("content-dir", "/custom/path")
+	_ = flags.Set("transport", "stdio")
+	_ = flags.Set("host", "localhost")
+	_ = flags.Set("port", "3000")
+	_ = flags.Set("search-max-results", "50")
+	_ = flags.Set("auth-type", "basic")
+	_ = flags.Set("auth-basic-username", "testuser")
+	_ = flags.Set("auth-basic-password", "testpass")
+
+	settings, err := LoadSettingsWithFlags(flags)
+	if err != nil {
+		t.Fatalf("Failed to load settings: %v", err)
+	}
+
+	if settings.ContentDir != "/custom/path" {
+		t.Errorf("Expected content-dir '/custom/path', got '%s'", settings.ContentDir)
+	}
+	if settings.Transport != "stdio" {
+		t.Errorf("Expected transport 'stdio', got '%s'", settings.Transport)
+	}
+	if settings.Host != "localhost" {
+		t.Errorf("Expected host 'localhost', got '%s'", settings.Host)
+	}
+	if settings.Port != 3000 {
+		t.Errorf("Expected port 3000, got %d", settings.Port)
+	}
+	if settings.Search.MaxResults != 50 {
+		t.Errorf("Expected max results 50, got %d", settings.Search.MaxResults)
+	}
+	if settings.Auth.Type != "basic" {
+		t.Errorf("Expected auth type 'basic', got '%s'", settings.Auth.Type)
+	}
+	if settings.Auth.Basic.Username != "testuser" {
+		t.Errorf("Expected username 'testuser', got '%s'", settings.Auth.Basic.Username)
+	}
+	if settings.Auth.Basic.Password != "testpass" {
+		t.Errorf("Expected password 'testpass', got '%s'", settings.Auth.Basic.Password)
+	}
+}
+
+// --- ValidateSettings Tests ---
+
+func TestValidateSettings_ValidNone(t *testing.T) {
+	s := &Settings{Auth: AuthSettings{Type: AuthTypeNone}}
+	if err := ValidateSettings(s); err != nil {
+		t.Errorf("Expected no error for valid none auth, got: %v", err)
+	}
+}
+
+func TestValidateSettings_ValidNone_EmptyType(t *testing.T) {
+	s := &Settings{Auth: AuthSettings{Type: ""}}
+	if err := ValidateSettings(s); err != nil {
+		t.Errorf("Expected no error for empty auth type, got: %v", err)
+	}
+}
+
+func TestValidateSettings_ValidBasic(t *testing.T) {
+	s := &Settings{
+		Auth: AuthSettings{
+			Type: AuthTypeBasic,
+			Basic: BasicAuthSettings{
+				Username: "admin",
+				Password: "secret",
+			},
+		},
+	}
+	if err := ValidateSettings(s); err != nil {
+		t.Errorf("Expected no error for valid basic auth, got: %v", err)
+	}
+}
+
+func TestValidateSettings_ValidAPIKey(t *testing.T) {
+	s := &Settings{
+		Auth: AuthSettings{
+			Type:    AuthTypeAPIKey,
+			APIKeys: []string{"key1", "key2"},
+		},
+	}
+	if err := ValidateSettings(s); err != nil {
+		t.Errorf("Expected no error for valid apikey auth, got: %v", err)
+	}
+}
+
+func TestValidateSettings_NoneWithCredentials(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings Settings
+	}{
+		{
+			name: "none with username",
+			settings: Settings{
+				Auth: AuthSettings{
+					Type:  AuthTypeNone,
+					Basic: BasicAuthSettings{Username: "admin"},
+				},
+			},
+		},
+		{
+			name: "none with password",
+			settings: Settings{
+				Auth: AuthSettings{
+					Type:  AuthTypeNone,
+					Basic: BasicAuthSettings{Password: "secret"},
+				},
+			},
+		},
+		{
+			name: "none with api keys",
+			settings: Settings{
+				Auth: AuthSettings{
+					Type:    AuthTypeNone,
+					APIKeys: []string{"key1"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateSettings(&tt.settings)
+			if err == nil {
+				t.Fatal("Expected error for none with credentials")
+			}
+			if !strings.Contains(err.Error(), "incompatible") {
+				t.Errorf("Expected 'incompatible' in error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateSettings_BasicAuthMissingUsername(t *testing.T) {
+	s := &Settings{
+		Auth: AuthSettings{
+			Type: AuthTypeBasic,
+			Basic: BasicAuthSettings{
+				Password: "secret",
+			},
+		},
+	}
+	err := ValidateSettings(s)
+	if err == nil {
+		t.Fatal("Expected error for basic auth without username")
+	}
+	if !strings.Contains(err.Error(), "username and password") {
+		t.Errorf("Expected 'username and password' in error, got: %v", err)
+	}
+}
+
+func TestValidateSettings_BasicAuthMissingPassword(t *testing.T) {
+	s := &Settings{
+		Auth: AuthSettings{
+			Type: AuthTypeBasic,
+			Basic: BasicAuthSettings{
+				Username: "admin",
+			},
+		},
+	}
+	err := ValidateSettings(s)
+	if err == nil {
+		t.Fatal("Expected error for basic auth without password")
+	}
+}
+
+func TestValidateSettings_BasicAuthWithAPIKeys(t *testing.T) {
+	s := &Settings{
+		Auth: AuthSettings{
+			Type: AuthTypeBasic,
+			Basic: BasicAuthSettings{
+				Username: "admin",
+				Password: "secret",
+			},
+			APIKeys: []string{"key1"},
+		},
+	}
+	err := ValidateSettings(s)
+	if err == nil {
+		t.Fatal("Expected error for basic + api keys")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("Expected 'mutually exclusive' in error, got: %v", err)
+	}
+}
+
+func TestValidateSettings_APIKeyMissingKeys(t *testing.T) {
+	s := &Settings{
+		Auth: AuthSettings{
+			Type: AuthTypeAPIKey,
+		},
+	}
+	err := ValidateSettings(s)
+	if err == nil {
+		t.Fatal("Expected error for apikey without keys")
+	}
+	if !strings.Contains(err.Error(), "requires at least one") {
+		t.Errorf("Expected 'requires at least one' in error, got: %v", err)
+	}
+}
+
+func TestValidateSettings_APIKeyWithBasicCreds(t *testing.T) {
+	s := &Settings{
+		Auth: AuthSettings{
+			Type:    AuthTypeAPIKey,
+			APIKeys: []string{"key1"},
+			Basic: BasicAuthSettings{
+				Username: "admin",
+			},
+		},
+	}
+	err := ValidateSettings(s)
+	if err == nil {
+		t.Fatal("Expected error for apikey + basic creds")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("Expected 'mutually exclusive' in error, got: %v", err)
+	}
+}
+
+func TestValidateSettings_UnknownAuthType(t *testing.T) {
+	s := &Settings{
+		Auth: AuthSettings{
+			Type: "oauth",
+		},
+	}
+	err := ValidateSettings(s)
+	if err == nil {
+		t.Fatal("Expected error for unknown auth type")
+	}
+	if !strings.Contains(err.Error(), "unknown auth-type") {
+		t.Errorf("Expected 'unknown auth-type' in error, got: %v", err)
 	}
 }

--- a/internal/search/service_test.go
+++ b/internal/search/service_test.go
@@ -11,7 +11,6 @@ import (
 func TestSearchService(t *testing.T) {
 	settings := config.SearchSettings{
 		MaxResults: 10,
-		HeapSizeMB: 10,
 	}
 	service := NewService(settings)
 	defer service.Close()


### PR DESCRIPTION
- Add CLI flags as alternative to environment variables for all settings
- Implement configuration priority: CLI > env > .env > defaults
- Add ValidateSettings for conflict detection (e.g., basic auth + API keys)
- Add short flag aliases (-t, -c, -p, -a, etc.)
- Remove unused HeapSizeMB setting (Bleve has no heap config)
- Change default port from 8000 to 8080
- Update README with comprehensive configuration documentation
- Add tests for CLI flag parsing, priority, and validation
