### PR TITLE
feat: add optional keywords field with search boosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ API keys must be provided via the `X-API-Key` header in HTTP requests.
 ### Content Metadata
 The server expects an `mcp-metadata.yaml` file in the root of your content directory to define server identity.
 
+For details on authoring resource files, including frontmatter format and search keyword boosting, see the [Authoring Resources Guide](docs/authoring-resources.md).
+
 ## 🛠️ Development
 
 Use the provided `Makefile` for common tasks:

--- a/docs/authoring-resources.md
+++ b/docs/authoring-resources.md
@@ -1,0 +1,233 @@
+# Authoring Resource Files
+
+This guide explains how to create and structure markdown resource files for the ACDC MCP server.
+
+## File Location
+
+Place all resource markdown files inside the `mcp-resources/` subdirectory of your content directory:
+
+```
+content/
+├── mcp-metadata.yaml
+└── mcp-resources/
+    ├── getting-started.md
+    ├── api/
+    │   └── endpoints.md
+    └── guides/
+        └── deployment.md
+```
+
+## Server Metadata (`mcp-metadata.yaml`)
+
+The `mcp-metadata.yaml` file in the root of your content directory defines server identity and tool descriptions. This file is **required** for the server to start.
+
+### Structure
+
+```yaml
+server:
+  name: "My Knowledge Base"
+  version: "1.0.0"
+  instructions: |
+    You are an assistant with access to documentation resources.
+    Use the search tool to find relevant information before answering.
+    Always cite resources by their URI when referencing them.
+
+tools:
+  - name: search
+    description: "Search for resources by query string"
+  - name: read
+    description: "Read a resource by its URI"
+```
+
+### Server Section
+
+| Field          | Required | Description                                                |
+| -------------- | -------- | ---------------------------------------------------------- |
+| `name`         | Yes      | Display name for the MCP server                            |
+| `version`      | Yes      | Server version string                                      |
+| `instructions` | Yes      | System prompt instructions for AI agents                   |
+
+#### The `instructions` Field
+
+The `instructions` field is particularly important—it provides **system-level guidance** to AI agents on how to use this server effectively. Well-crafted instructions significantly improve agent behavior.
+
+**What to include:**
+
+- **Context**: Describe what kind of information the server provides
+- **Usage guidance**: When and how agents should use the available tools
+- **Citation expectations**: How agents should reference resources in responses
+- **Constraints**: Any limitations or considerations agents should be aware of
+
+**Example instructions:**
+
+```yaml
+instructions: |
+  You have access to a technical documentation knowledge base.
+  
+  SEARCH FIRST: Before answering technical questions, use the search tool
+  to find relevant documentation. Search with specific terms.
+  
+  CITE SOURCES: When referencing information from resources, include
+  the resource URI so users can verify the information.
+  
+  COVERAGE: This knowledge base covers API documentation, deployment
+  guides, and troubleshooting. It does not cover billing or account
+  management topics.
+```
+
+### Tools Section
+
+The tools section defines metadata for the server's available tools. Each tool requires:
+
+| Field         | Required | Description                              |
+| ------------- | -------- | ---------------------------------------- |
+| `name`        | Yes      | Tool identifier (must be unique)         |
+| `description` | Yes      | Human-readable description of the tool   |
+
+> [!NOTE]
+> Tool names must be unique. Duplicate names will cause a validation error at startup.
+
+### Validation
+
+The server validates `mcp-metadata.yaml` at startup and will fail to start if:
+- `server.name` is missing or empty
+- `server.version` is missing or empty
+- `server.instructions` is missing or empty
+- Any tool is missing a `name` or `description`
+- Duplicate tool names exist
+
+## Resource Frontmatter Format
+
+Each resource file **must** start with YAML frontmatter containing required metadata:
+
+```yaml
+---
+name: "Resource Title"
+description: "A brief description of what this resource contains"
+keywords:
+  - keyword1
+  - keyword2
+  - keyword3
+---
+
+# Your Markdown Content
+
+The actual content of your resource goes here...
+```
+
+### Required Fields
+
+| Field         | Type   | Description                                      |
+| ------------- | ------ | ------------------------------------------------ |
+| `name`        | string | Display name for the resource                    |
+| `description` | string | Brief description shown in resource listings     |
+
+### Optional Fields
+
+| Field      | Type     | Description                             |
+| ---------- | -------- | --------------------------------------- |
+| `keywords` | string[] | List of keywords for search boosting    |
+
+## Keywords and Search Boosting
+
+Keywords provide a way to improve search relevance. When a search query matches a keyword, that document receives a **2x score boost** compared to matches in regular content.
+
+### How It Works
+
+The search service uses a disjunction query across three fields:
+
+| Field      | Boost | Description                              |
+| ---------- | ----- | ---------------------------------------- |
+| `name`     | 1.0x  | Resource title                           |
+| `content`  | 1.0x  | Markdown body content                    |
+| `keywords` | 2.0x  | Frontmatter keywords get boosted scores  |
+
+### Example
+
+Given two resources with identical content:
+
+**Resource A** (no keywords):
+```yaml
+---
+name: "Programming Guide"
+description: "General programming documentation"
+---
+Content about software development...
+```
+
+**Resource B** (with keywords):
+```yaml
+---
+name: "Programming Guide" 
+description: "General programming documentation"
+keywords:
+  - golang
+  - go
+  - development
+---
+Content about software development...
+```
+
+Searching for `"golang"` will rank **Resource B** higher because:
+1. Resource B matches "golang" in its keywords field (boosted 2x)
+2. Resource A has no keyword match
+
+### Best Practices for Keywords
+
+1. **Be specific**: Choose keywords that accurately represent the resource content
+2. **Include synonyms**: Add alternative terms users might search for
+3. **Keep it focused**: 3-7 keywords is typically sufficient
+4. **Use lowercase**: Keywords are analyzed with standard tokenization
+
+```yaml
+keywords:
+  - api
+  - rest
+  - http
+  - authentication
+  - oauth
+```
+
+## URI Generation
+
+Resource URIs are automatically generated from the file path:
+
+| File Path                           | Generated URI              |
+| ----------------------------------- | -------------------------- |
+| `mcp-resources/guide.md`            | `acdc://guide`             |
+| `mcp-resources/api/endpoints.md`    | `acdc://api/endpoints`     |
+| `mcp-resources/docs/setup/intro.md` | `acdc://docs/setup/intro`  |
+
+## Complete Example
+
+**File:** `content/mcp-resources/api/authentication.md`
+
+```yaml
+---
+name: "Authentication Guide"
+description: "How to authenticate API requests using tokens and API keys"
+keywords:
+  - auth
+  - authentication
+  - api-key
+  - bearer
+  - token
+  - security
+---
+
+# Authentication Guide
+
+This document explains the available authentication methods...
+
+## Bearer Tokens
+
+To authenticate using bearer tokens...
+
+## API Keys
+
+API keys can be passed via the `X-API-Key` header...
+```
+
+**Result:**
+- **URI**: `acdc://api/authentication`
+- **Search boost**: Queries matching "auth", "token", "security", etc. will rank this resource higher

--- a/internal/app/factory.go
+++ b/internal/app/factory.go
@@ -57,13 +57,13 @@ func CreateMCPServer(settings *config.Settings) (*server.MCPServer, func(), erro
 	var docs []search.Document
 	for _, d := range docsToIndex {
 		var keywords []string
-		if kw := d["keywords"]; kw != "" {
+		if kw := d[resources.FieldKeywords]; kw != "" {
 			keywords = strings.Split(kw, ",")
 		}
 		docs = append(docs, search.Document{
-			URI:      d["uri"],
-			Name:     d["name"],
-			Content:  d["content"],
+			URI:      d[resources.FieldURI],
+			Name:     d[resources.FieldName],
+			Content:  d[resources.FieldContent],
 			Keywords: keywords,
 		})
 	}

--- a/internal/resources/definitions.go
+++ b/internal/resources/definitions.go
@@ -1,5 +1,13 @@
 package resources
 
+// Field name constants for resource metadata
+const (
+	FieldURI      = "uri"
+	FieldName     = "name"
+	FieldContent  = "content"
+	FieldKeywords = "keywords"
+)
+
 // ResourceDefinition definition of an MCP resource
 type ResourceDefinition struct {
 	URI         string

--- a/internal/resources/provider.go
+++ b/internal/resources/provider.go
@@ -67,10 +67,10 @@ func (p *ResourceProvider) GetAllResourceContents() []map[string]string {
 			continue
 		}
 		results = append(results, map[string]string{
-			"uri":      defn.URI,
-			"name":     defn.Name,
-			"content":  content,
-			"keywords": strings.Join(defn.Keywords, ","),
+			FieldURI:      defn.URI,
+			FieldName:     defn.Name,
+			FieldContent:  content,
+			FieldKeywords: strings.Join(defn.Keywords, ","),
 		})
 	}
 	return results


### PR DESCRIPTION
- Add Keywords []string to search.Document and resources.ResourceDefinition
- Extract keywords from resource frontmatter in DiscoverResources()
- Implement query-time boosting (2x) using DisjunctionQuery
- Add 4 tests proving boosting works:
  - TestSearch_KeywordsBoosting: score comparison proof
  - TestSearch_KeywordsEmpty: nil/empty keywords handling
  - TestSearch_MultipleKeywords: multiple keywords searchable
  - TestSearch_KeywordsOnlyMatch: keywords-only matches