### PR TITLE
ci: switch from Cask to Formula and enable Docker release tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - 'master'
+    tags:
+      - 'v*'
   pull_request:
     branches:
       - 'master'
@@ -23,7 +25,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
-        if: github.ref == 'refs/heads/master'
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -37,6 +39,8 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}
 
@@ -45,7 +49,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.ref == 'refs/heads/master' }}
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - '*'
+      - 'v*'
 
 permissions:
   contents: write

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -66,7 +66,7 @@ changelog:
       - '^docs:'
       - '^test:'
 
-homebrew_casks:
+brews:
   - repository:
       owner: sha1n
       name: homebrew-tap
@@ -77,3 +77,6 @@ homebrew_casks:
 
     # Description placeholder
     description: "MCP ACDC Server"
+
+    # Directory in the repository to put the formula.
+    directory: Formula


### PR DESCRIPTION
- Update .goreleaser.yaml to publish as a Homebrew Formula (`brews`) instead of a Cask, suitable for CLI tools.
- Update Docker workflow to trigger on release tags (`v*`) and push semantic version tags to Docker Hub.
