### PR TITLE
feat: change default transport to stdio and add validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ See [Development Guide](docs/development.md) for build instructions.
 
 ## 🏃 Running
 
-### SSE Transport (default)
+### Stdio Transport (default)
 ```bash
 acdc-mcp --content-dir ./content
 ```
 
-### Stdio Transport
+### SSE Transport
 ```bash
-acdc-mcp --transport stdio --content-dir ./content
+acdc-mcp --transport sse --content-dir ./content
 ```
 
 ### Docker
@@ -77,7 +77,7 @@ docker run -p 8080:8080 \
 | Flag | Short | Environment Variable | Default |
 |------|-------|---------------------|---------|
 | `--content-dir` | `-c` | `ACDC_MCP_CONTENT_DIR` | `./content` |
-| `--transport` | `-t` | `ACDC_MCP_TRANSPORT` | `sse` |
+| `--transport` | `-t` | `ACDC_MCP_TRANSPORT` | `stdio` |
 | `--port` | `-p` | `ACDC_MCP_PORT` | `8080` |
 | `--auth-type` | `-a` | `ACDC_MCP_AUTH_TYPE` | `none` |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,9 +16,9 @@ When the same setting is specified in multiple places, the following priority ap
 | CLI Flag | Short | Environment Variable | Description | Default |
 |----------|-------|---------------------|-------------|---------|
 | `--content-dir` | `-c` | `ACDC_MCP_CONTENT_DIR` | Path to content directory | `./content` |
-| `--transport` | `-t` | `ACDC_MCP_TRANSPORT` | Transport type: `stdio` or `sse` | `sse` |
-| `--host` | `-H` | `ACDC_MCP_HOST` | Host for SSE server | `0.0.0.0` |
-| `--port` | `-p` | `ACDC_MCP_PORT` | Port for SSE server | `8080` |
+| `--transport` | `-t` | `ACDC_MCP_TRANSPORT` | Transport type: `stdio` or `sse` | `stdio` |
+| `--host` | `-H` | `ACDC_MCP_HOST` | Host for SSE server (SSE mode only) | `0.0.0.0` |
+| `--port` | `-p` | `ACDC_MCP_PORT` | Port for SSE server (SSE mode only) | `8080` |
 | `--search-max-results` | `-m` | `ACDC_MCP_SEARCH_MAX_RESULTS` | Maximum search results | `10` |
 
 ## Authentication Settings
@@ -32,19 +32,24 @@ When the same setting is specified in multiple places, the following priority ap
 
 ## Examples
 
-**CLI flags (stdio mode):**
+**CLI flags (stdio mode - default):**
 ```bash
-./bin/acdc-mcp -t stdio -c /path/to/content
+./bin/acdc-mcp -c /path/to/content
+```
+
+**CLI flags (SSE mode):**
+```bash
+./bin/acdc-mcp -t sse --port 9000
 ```
 
 **CLI flags (SSE with basic auth):**
 ```bash
-./bin/acdc-mcp --port 9000 --auth-type basic -u admin -P secret
+./bin/acdc-mcp -t sse --port 9000 --auth-type basic -u admin -P secret
 ```
 
 **Environment variables:**
 ```bash
-ACDC_MCP_TRANSPORT=stdio ACDC_MCP_CONTENT_DIR=/data ./bin/acdc-mcp
+ACDC_MCP_TRANSPORT=sse ACDC_MCP_CONTENT_DIR=/data ./bin/acdc-mcp
 ```
 
 **Using a `.env` file:**

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -62,7 +62,7 @@ func LoadSettingsWithFlags(flags *pflag.FlagSet) (*Settings, error) {
 	defaultContentDir := filepath.Join(cwd, "content")
 
 	v.SetDefault("content_dir", defaultContentDir)
-	v.SetDefault("transport", "sse")
+	v.SetDefault("transport", "stdio")
 	v.SetDefault("host", "0.0.0.0")
 	v.SetDefault("port", 8080)
 	v.SetDefault("search.max_results", 10)
@@ -129,6 +129,14 @@ func LoadSettingsWithFlags(flags *pflag.FlagSet) (*Settings, error) {
 // ValidateSettings checks for conflicting configurations.
 // Returns an error if the settings contain mutually exclusive or incomplete auth config.
 func ValidateSettings(s *Settings) error {
+	// Validate transport type
+	switch s.Transport {
+	case "stdio", "sse":
+		// valid
+	default:
+		return errors.New("transport must be 'stdio' or 'sse', got: " + s.Transport)
+	}
+
 	hasBasicCreds := s.Auth.Basic.Username != "" || s.Auth.Basic.Password != ""
 	hasAPIKeys := len(s.Auth.APIKeys) > 0
 


### PR DESCRIPTION
- Change default transport from 'sse' to 'stdio'
- Add transport validation (only 'stdio' and 'sse' are valid)
- Add integration test verifying HTTP port is not listening in stdio mode
- Update documentation to reflect new defaults

The transports are mutually exclusive by design:
- stdio mode: only stdio communication, no HTTP listener
- sse mode: only HTTP/SSE communication, stdin not processed
