### PR TITLE
feat: add --version/-v CLI flag

### DIFF
--- a/cmd/acdc-mcp/main.go
+++ b/cmd/acdc-mcp/main.go
@@ -30,13 +30,17 @@ func runMain(args []string, exit func(int)) {
 // Execute is the entry point for the CLI, extracted for testing
 func Execute(version, build, programName string, args []string) error {
 	rootCmd := &cobra.Command{
-		Use:   programName,
-		Short: "MCP ACDC Server",
-		Long:  "Agent Content Discovery Companion (ACDC) MCP Server",
+		Use:     programName,
+		Short:   "ACDC MCP Server",
+		Long:    "Agent Content Discovery Companion (ACDC) MCP Server",
+		Version: version,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runWithFlags(cmd.Flags(), version)
 		},
 	}
+
+	rootCmd.SetVersionTemplate(`{{.Version}}
+`)
 
 	app.RegisterFlags(rootCmd.Flags())
 	rootCmd.SetArgs(args)

--- a/cmd/acdc-mcp/main_test.go
+++ b/cmd/acdc-mcp/main_test.go
@@ -12,6 +12,20 @@ func TestExecute_Help(t *testing.T) {
 	}
 }
 
+func TestExecute_Version(t *testing.T) {
+	err := Execute("v1.2.3", "abc", "acdc-mcp", []string{"--version"})
+	if err != nil {
+		t.Errorf("Execute --version failed: %v", err)
+	}
+}
+
+func TestExecute_VersionShort(t *testing.T) {
+	err := Execute("v1.2.3", "abc", "acdc-mcp", []string{"-v"})
+	if err != nil {
+		t.Errorf("Execute -v failed: %v", err)
+	}
+}
+
 func TestExecute_UnknownFlag(t *testing.T) {
 	// Test unknown flag returns error
 	err := Execute("test", "test", "test", []string{"--unknown-flag"})
@@ -19,6 +33,7 @@ func TestExecute_UnknownFlag(t *testing.T) {
 		t.Error("Expected error for unknown flag")
 	}
 }
+
 func TestExecute_Run(t *testing.T) {
 	// Trigger runWithFlags by providing a valid transport but invalid settings that cause early exit
 	err := Execute("test", "test", "test", []string{"--transport", "sse", "--content-dir", "/non-existent"})

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -16,7 +16,7 @@
 
 - [x] [MCP] Add prompts support
 - [x] [MCP] Explore how to implement content based commands
-- [ ] [CLI] Implement version flags (`--version` / `-v`)
+- [x] [CLI] Implement version flags (`--version` / `-v`)
 - [ ] [CONTENT] Support Git repositories as content sources
   - [ ] [CONTENT] Implement scheduled synchronization and re-indexing (Note: Server metadata updates require reconnection)
 - [ ] [SEARCH] Support keyword boosting in the search API, so that agents can improve search quality based on context


### PR DESCRIPTION
- Use Cobra's built-in version support
- Display raw version tag only
- Update tests and task documentation
