### PR TITLE
feat: make resource URI scheme configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ build-docker:
 .PHONY: mcp-add-claude-dev
 mcp-add-claude-dev: go-build-current
 	@echo "  >  Adding acdc-dev to Claude Code..."
-	claude mcp add --transport stdio acdc-dev $(GOBIN)/$(PROGRAMNAME) -- --content-dir $(GOBASE)/examples/sample-content
+	claude mcp add --transport stdio acdc-dev $(GOBIN)/$(PROGRAMNAME) -- --content-dir $(GOBASE)/examples/sample-content --uri-scheme sha1n
 
 ## mcp-remove-claude-dev: Removes acdc-dev from Claude Code
 .PHONY: mcp-remove-claude-dev
@@ -201,7 +201,7 @@ mcp-remove-claude-dev:
 .PHONY: mcp-add-gemini-dev
 mcp-add-gemini-dev: go-build-current
 	@echo "  >  Adding acdc-dev to Gemini CLI..."
-	gemini mcp add acdc-dev $(GOBIN)/$(PROGRAMNAME) -- --content-dir $(GOBASE)/examples/sample-content
+	gemini mcp add acdc-dev $(GOBIN)/$(PROGRAMNAME) -- --content-dir $(GOBASE)/examples/sample-content --uri-scheme sha1n
 
 ## mcp-remove-gemini-dev: Removes acdc-dev from Gemini CLI
 .PHONY: mcp-remove-gemini-dev

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ readinessProbe:
 | `--content-dir` | `-c` | `ACDC_MCP_CONTENT_DIR` | `./content` |
 | `--transport` | `-t` | `ACDC_MCP_TRANSPORT` | `stdio` |
 | `--port` | `-p` | `ACDC_MCP_PORT` | `8080` |
+| `--uri-scheme` | `-s` | `ACDC_MCP_URI_SCHEME` | `acdc` |
 | `--search-max-results` | `-m` | `ACDC_MCP_SEARCH_MAX_RESULTS` | `10` |
 | `--search-keywords-boost` | — | `ACDC_MCP_SEARCH_KEYWORDS_BOOST` | `3.0` |
 | `--auth-type` | `-a` | `ACDC_MCP_AUTH_TYPE` | `none` |

--- a/docs/SPECIFICATIONS.md
+++ b/docs/SPECIFICATIONS.md
@@ -29,6 +29,7 @@ The server is configured via environment variables, command-line flags, or a `.e
 | `ACDC_MCP_AUTH_TYPE` | `--auth-type`, `-a` | Authentication mode for SSE: `none`, `basic`, `apikey`. | `none` |
 | `ACDC_MCP_AUTH_BASIC_USERNAME` | `--auth-basic-username`, `-u` | Username for Basic Auth. | - |
 | `ACDC_MCP_AUTH_BASIC_PASSWORD` | `--auth-basic-password`, `-P` | Password for Basic Auth. | - |
+| `ACDC_MCP_URI_SCHEME` | `--uri-scheme`, `-s` | URI scheme for resource URIs (RFC 3986 compliant). | `acdc` |
 | `ACDC_MCP_AUTH_API_KEYS` | `--auth-api-keys`, `-k` | Comma-separated list of valid API keys for `apikey` auth. | - |
 
 ---
@@ -68,8 +69,10 @@ tools:                  # Optional: Override default tool descriptions
 ### 2. Resources (`mcp-resources/`)
 
 -   **Discovery**: The server recursively scans `mcp-resources/` for `.md` files.
--   **URI Scheme**: `acdc://<relative_path_without_extension>`
+-   **URI Scheme**: `<scheme>://<relative_path_without_extension>` (default scheme: `acdc`)
     -   Example: `mcp-resources/docs/guide.md` -> `acdc://docs/guide`
+    -   With `--uri-scheme myorg`: `mcp-resources/docs/guide.md` -> `myorg://docs/guide`
+    -   The scheme must be RFC 3986 compliant (starts with a letter, followed by letters/digits/`+`/`-`/`.`).
     -   Windows backslashes are normalized to forward slashes.
 -   **File Format**: Must be Markdown with YAML Frontmatter.
 
@@ -120,7 +123,7 @@ Retrieves the full raw content of a resource.
 *   **Input Schema:**
     ```json
     {
-      "uri": "string (Required) - The acdc:// URI of the resource"
+      "uri": "string (Required) - The resource URI (e.g. acdc://path)"
     }
     ```
 *   **Behavior:**
@@ -135,7 +138,7 @@ Retrieves the full raw content of a resource.
 
 In addition to tools, the server exposes resources directly via the MCP `resources/list` capability.
 
-*   **URI**: Same as the `acdc://` URI used in tools.
+*   **URI**: Same as the `<scheme>://` URI used in tools (default scheme: `acdc`).
 *   **Name**: From frontmatter `name`.
 *   **Description**: From frontmatter `description`.
 *   **MIME Type**: `text/markdown`.

--- a/docs/authoring-resources.md
+++ b/docs/authoring-resources.md
@@ -193,13 +193,22 @@ keywords:
 
 ## URI Generation
 
-Resource URIs are automatically generated from the file path:
+Resource URIs are automatically generated from the file path using the configured URI scheme (default: `acdc`):
 
 | File Path                           | Generated URI              |
 | ----------------------------------- | -------------------------- |
 | `mcp-resources/guide.md`            | `acdc://guide`             |
 | `mcp-resources/api/endpoints.md`    | `acdc://api/endpoints`     |
 | `mcp-resources/docs/setup/intro.md` | `acdc://docs/setup/intro`  |
+
+The URI scheme can be customized via the `--uri-scheme` flag or `ACDC_MCP_URI_SCHEME` environment variable. For example, with `--uri-scheme myorg`:
+
+| File Path                           | Generated URI              |
+| ----------------------------------- | -------------------------- |
+| `mcp-resources/guide.md`            | `myorg://guide`            |
+| `mcp-resources/api/endpoints.md`    | `myorg://api/endpoints`    |
+
+See [Configuration Reference](configuration.md) for details.
 
 ## Complete Example
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,6 +19,7 @@ When the same setting is specified in multiple places, the following priority ap
 | `--transport` | `-t` | `ACDC_MCP_TRANSPORT` | Transport type: `stdio` or `sse` | `stdio` |
 | `--host` | `-H` | `ACDC_MCP_HOST` | Host for SSE server (SSE mode only) | `0.0.0.0` |
 | `--port` | `-p` | `ACDC_MCP_PORT` | Port for SSE server (SSE mode only) | `8080` |
+| `--uri-scheme` | `-s` | `ACDC_MCP_URI_SCHEME` | URI scheme for resources (e.g. `acdc`, `myorg`) | `acdc` |
 | `--search-max-results` | `-m` | `ACDC_MCP_SEARCH_MAX_RESULTS` | Maximum search results | `10` |
 | `--search-keywords-boost` | — | `ACDC_MCP_SEARCH_KEYWORDS_BOOST` | Boost for keywords matches | `3.0` |
 | `--search-name-boost` | — | `ACDC_MCP_SEARCH_NAME_BOOST` | Boost for name matches | `2.0` |
@@ -50,6 +51,13 @@ When the same setting is specified in multiple places, the following priority ap
 ./bin/acdc-mcp -t sse --port 9000 --auth-type basic -u admin -P secret
 ```
 
+**CLI flags (custom URI scheme):**
+```bash
+./bin/acdc-mcp -c /path/to/content --uri-scheme myorg
+```
+
+This produces resource URIs like `myorg://guides/getting-started` instead of the default `acdc://guides/getting-started`.
+
 **Environment variables:**
 ```bash
 ACDC_MCP_TRANSPORT=sse ACDC_MCP_CONTENT_DIR=/data ./bin/acdc-mcp
@@ -68,6 +76,7 @@ auth.basic.password=secret
 
 The server validates configuration at startup and will fail with a clear error if:
 
+- `--uri-scheme` is empty or doesn't match RFC 3986 (must start with a letter, then letters/digits/`+`/`-`/`.`)
 - `--auth-type=basic` is set without username/password
 - `--auth-type=apikey` is set without API keys
 - `--auth-type=none` is set with auth credentials (conflicting intent)

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -12,6 +12,7 @@ func RegisterFlags(flags *pflag.FlagSet) {
 	flags.Float64("search-keywords-boost", 0, "Boost for keywords matches")
 	flags.Float64("search-name-boost", 0, "Boost for name matches")
 	flags.Float64("search-content-boost", 0, "Boost for content matches")
+	flags.StringP("uri-scheme", "s", "", "URI scheme for resources (default: acdc)")
 	flags.StringP("auth-type", "a", "", "Authentication type: none, basic, or apikey")
 	flags.StringP("auth-basic-username", "u", "", "Basic auth username")
 	flags.StringP("auth-basic-password", "P", "", "Basic auth password")

--- a/internal/app/factory.go
+++ b/internal/app/factory.go
@@ -39,7 +39,7 @@ func CreateMCPServer(settings *config.Settings) (*mcpsdk.Server, func(), error) 
 	}
 
 	// Discover resources
-	resourceDefinitions, err := resources.DiscoverResources(cp)
+	resourceDefinitions, err := resources.DiscoverResources(cp, settings.Scheme)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to discover resources: %w", err)
 	}

--- a/internal/app/factory_test.go
+++ b/internal/app/factory_test.go
@@ -34,6 +34,7 @@ tools: []
 
 	settings := &config.Settings{
 		ContentDir: contentDir,
+		Scheme:     "acdc",
 		Search: config.SearchSettings{
 			InMemory:   true,
 			MaxResults: 10,
@@ -149,6 +150,7 @@ tools: []
 
 	settings := &config.Settings{
 		ContentDir: contentDir,
+		Scheme:     "acdc",
 		Search: config.SearchSettings{
 			InMemory:   true,
 			MaxResults: 10,
@@ -183,6 +185,7 @@ func TestCreateMCPServer_ResourceWithKeywords(t *testing.T) {
 
 	settings := &config.Settings{
 		ContentDir: contentDir,
+		Scheme:     "acdc",
 		Search:     config.SearchSettings{InMemory: true, MaxResults: 10},
 	}
 
@@ -214,6 +217,7 @@ tools: []
 
 	settings := &config.Settings{
 		ContentDir: contentDir,
+		Scheme:     "acdc",
 		Search: config.SearchSettings{
 			InMemory:   true,
 			MaxResults: 10,
@@ -310,6 +314,7 @@ func TestCreateMCPServer_PromptDiscoveryError(t *testing.T) {
 
 	settings := &config.Settings{
 		ContentDir: contentDir,
+		Scheme:     "acdc",
 		Search:     config.SearchSettings{InMemory: true},
 	}
 

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -13,6 +13,7 @@ func TestLoadSettings_Defaults(t *testing.T) {
 	// Note: Can't use t.Setenv to clear, so we still need os.Unsetenv here
 	_ = os.Unsetenv("ACDC_MCP_PORT")
 	_ = os.Unsetenv("ACDC_MCP_AUTH_TYPE")
+	_ = os.Unsetenv("ACDC_MCP_URI_SCHEME")
 
 	settings, err := LoadSettings()
 	if err != nil {
@@ -21,6 +22,9 @@ func TestLoadSettings_Defaults(t *testing.T) {
 
 	if settings.Port != 8080 {
 		t.Errorf("Expected default port 8080, got %d", settings.Port)
+	}
+	if settings.Scheme != "acdc" {
+		t.Errorf("Expected default scheme 'acdc', got '%s'", settings.Scheme)
 	}
 	if settings.Auth.Type != AuthTypeNone {
 		t.Errorf("Expected default auth type '%s', got '%s'", AuthTypeNone, settings.Auth.Type)
@@ -264,14 +268,14 @@ func TestLoadSettingsWithFlags_AllFlagTypes(t *testing.T) {
 // --- ValidateSettings Tests ---
 
 func TestValidateSettings_ValidNone(t *testing.T) {
-	s := &Settings{Transport: "stdio", Auth: AuthSettings{Type: AuthTypeNone}}
+	s := &Settings{Transport: "stdio", Scheme: "acdc", Auth: AuthSettings{Type: AuthTypeNone}}
 	if err := ValidateSettings(s); err != nil {
 		t.Errorf("Expected no error for valid none auth, got: %v", err)
 	}
 }
 
 func TestValidateSettings_ValidNone_EmptyType(t *testing.T) {
-	s := &Settings{Transport: "stdio", Auth: AuthSettings{Type: ""}}
+	s := &Settings{Transport: "stdio", Scheme: "acdc", Auth: AuthSettings{Type: ""}}
 	if err := ValidateSettings(s); err != nil {
 		t.Errorf("Expected no error for empty auth type, got: %v", err)
 	}
@@ -280,6 +284,7 @@ func TestValidateSettings_ValidNone_EmptyType(t *testing.T) {
 func TestValidateSettings_ValidBasic(t *testing.T) {
 	s := &Settings{
 		Transport: "stdio",
+		Scheme:    "acdc",
 		Auth: AuthSettings{
 			Type: AuthTypeBasic,
 			Basic: BasicAuthSettings{
@@ -296,6 +301,7 @@ func TestValidateSettings_ValidBasic(t *testing.T) {
 func TestValidateSettings_ValidAPIKey(t *testing.T) {
 	s := &Settings{
 		Transport: "stdio",
+		Scheme:    "acdc",
 		Auth: AuthSettings{
 			Type:    AuthTypeAPIKey,
 			APIKeys: []string{"key1", "key2"},
@@ -315,6 +321,7 @@ func TestValidateSettings_NoneWithCredentials(t *testing.T) {
 			name: "none with username",
 			settings: Settings{
 				Transport: "stdio",
+				Scheme:    "acdc",
 				Auth: AuthSettings{
 					Type:  AuthTypeNone,
 					Basic: BasicAuthSettings{Username: "admin"},
@@ -325,6 +332,7 @@ func TestValidateSettings_NoneWithCredentials(t *testing.T) {
 			name: "none with password",
 			settings: Settings{
 				Transport: "stdio",
+				Scheme:    "acdc",
 				Auth: AuthSettings{
 					Type:  AuthTypeNone,
 					Basic: BasicAuthSettings{Password: "secret"},
@@ -335,6 +343,7 @@ func TestValidateSettings_NoneWithCredentials(t *testing.T) {
 			name: "none with api keys",
 			settings: Settings{
 				Transport: "stdio",
+				Scheme:    "acdc",
 				Auth: AuthSettings{
 					Type:    AuthTypeNone,
 					APIKeys: []string{"key1"},
@@ -359,6 +368,7 @@ func TestValidateSettings_NoneWithCredentials(t *testing.T) {
 func TestValidateSettings_BasicAuthMissingUsername(t *testing.T) {
 	s := &Settings{
 		Transport: "stdio",
+		Scheme:    "acdc",
 		Auth: AuthSettings{
 			Type: AuthTypeBasic,
 			Basic: BasicAuthSettings{
@@ -378,6 +388,7 @@ func TestValidateSettings_BasicAuthMissingUsername(t *testing.T) {
 func TestValidateSettings_BasicAuthMissingPassword(t *testing.T) {
 	s := &Settings{
 		Transport: "stdio",
+		Scheme:    "acdc",
 		Auth: AuthSettings{
 			Type: AuthTypeBasic,
 			Basic: BasicAuthSettings{
@@ -394,6 +405,7 @@ func TestValidateSettings_BasicAuthMissingPassword(t *testing.T) {
 func TestValidateSettings_BasicAuthWithAPIKeys(t *testing.T) {
 	s := &Settings{
 		Transport: "stdio",
+		Scheme:    "acdc",
 		Auth: AuthSettings{
 			Type: AuthTypeBasic,
 			Basic: BasicAuthSettings{
@@ -415,6 +427,7 @@ func TestValidateSettings_BasicAuthWithAPIKeys(t *testing.T) {
 func TestValidateSettings_APIKeyMissingKeys(t *testing.T) {
 	s := &Settings{
 		Transport: "stdio",
+		Scheme:    "acdc",
 		Auth: AuthSettings{
 			Type: AuthTypeAPIKey,
 		},
@@ -431,6 +444,7 @@ func TestValidateSettings_APIKeyMissingKeys(t *testing.T) {
 func TestValidateSettings_APIKeyWithBasicCreds(t *testing.T) {
 	s := &Settings{
 		Transport: "stdio",
+		Scheme:    "acdc",
 		Auth: AuthSettings{
 			Type:    AuthTypeAPIKey,
 			APIKeys: []string{"key1"},
@@ -451,6 +465,7 @@ func TestValidateSettings_APIKeyWithBasicCreds(t *testing.T) {
 func TestValidateSettings_UnknownAuthType(t *testing.T) {
 	s := &Settings{
 		Transport: "stdio",
+		Scheme:    "acdc",
 		Auth: AuthSettings{
 			Type: "oauth",
 		},
@@ -467,14 +482,14 @@ func TestValidateSettings_UnknownAuthType(t *testing.T) {
 // --- Transport Validation Tests ---
 
 func TestValidateSettings_ValidTransportStdio(t *testing.T) {
-	s := &Settings{Transport: "stdio", Auth: AuthSettings{Type: AuthTypeNone}}
+	s := &Settings{Transport: "stdio", Scheme: "acdc", Auth: AuthSettings{Type: AuthTypeNone}}
 	if err := ValidateSettings(s); err != nil {
 		t.Errorf("Expected no error for valid stdio transport, got: %v", err)
 	}
 }
 
 func TestValidateSettings_ValidTransportSSE(t *testing.T) {
-	s := &Settings{Transport: "sse", Auth: AuthSettings{Type: AuthTypeNone}}
+	s := &Settings{Transport: "sse", Scheme: "acdc", Auth: AuthSettings{Type: AuthTypeNone}}
 	if err := ValidateSettings(s); err != nil {
 		t.Errorf("Expected no error for valid sse transport, got: %v", err)
 	}
@@ -495,6 +510,7 @@ func TestValidateSettings_InvalidTransport(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &Settings{
 				Transport: tt.transport,
+				Scheme:    "acdc",
 				Auth:      AuthSettings{Type: AuthTypeNone},
 			}
 			err := ValidateSettings(s)
@@ -503,6 +519,87 @@ func TestValidateSettings_InvalidTransport(t *testing.T) {
 			}
 			if !strings.Contains(err.Error(), "transport must be") {
 				t.Errorf("Expected 'transport must be' in error, got: %v", err)
+			}
+		})
+	}
+}
+
+// --- Scheme Tests ---
+
+func TestLoadSettings_SchemeEnvVar(t *testing.T) {
+	t.Setenv("ACDC_MCP_URI_SCHEME", "custom")
+
+	settings, err := LoadSettings()
+	if err != nil {
+		t.Fatalf("Failed to load settings: %v", err)
+	}
+
+	if settings.Scheme != "custom" {
+		t.Errorf("Expected scheme 'custom', got '%s'", settings.Scheme)
+	}
+}
+
+func TestLoadSettingsWithFlags_SchemeCLIOverridesEnv(t *testing.T) {
+	t.Setenv("ACDC_MCP_URI_SCHEME", "from-env")
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.String("uri-scheme", "", "")
+	_ = flags.Set("uri-scheme", "from-cli")
+
+	settings, err := LoadSettingsWithFlags(flags)
+	if err != nil {
+		t.Fatalf("Failed to load settings: %v", err)
+	}
+
+	if settings.Scheme != "from-cli" {
+		t.Errorf("Expected scheme 'from-cli', got '%s'", settings.Scheme)
+	}
+}
+
+func TestValidateSettings_ValidSchemes(t *testing.T) {
+	tests := []struct {
+		name   string
+		scheme string
+	}{
+		{"default acdc", "acdc"},
+		{"with hyphen", "my-scheme"},
+		{"with dot and plus", "x.y+z"},
+		{"uppercase start", "A1"},
+		{"single letter", "x"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Settings{Transport: "stdio", Scheme: tt.scheme, Auth: AuthSettings{Type: AuthTypeNone}}
+			if err := ValidateSettings(s); err != nil {
+				t.Errorf("Expected no error for scheme %q, got: %v", tt.scheme, err)
+			}
+		})
+	}
+}
+
+func TestValidateSettings_InvalidSchemes(t *testing.T) {
+	tests := []struct {
+		name   string
+		scheme string
+	}{
+		{"empty", ""},
+		{"starts with digit", "123"},
+		{"contains space", "a b"},
+		{"colon-slash-slash", "://"},
+		{"contains colon-slash", "a://b"},
+		{"contains bang", "a!b"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Settings{Transport: "stdio", Scheme: tt.scheme, Auth: AuthSettings{Type: AuthTypeNone}}
+			err := ValidateSettings(s)
+			if err == nil {
+				t.Fatalf("Expected error for scheme %q", tt.scheme)
+			}
+			if !strings.Contains(err.Error(), "scheme must match") {
+				t.Errorf("Expected 'scheme must match' in error, got: %v", err)
 			}
 		})
 	}

--- a/internal/resources/provider.go
+++ b/internal/resources/provider.go
@@ -90,8 +90,9 @@ func (p *ResourceProvider) StreamResources(ctx context.Context, ch chan<- domain
 	return nil
 }
 
-// DiscoverResources discovers resources from markdown files
-func DiscoverResources(cp *content.ContentProvider) ([]ResourceDefinition, error) {
+// DiscoverResources discovers resources from markdown files.
+// The scheme parameter specifies the URI scheme (e.g. "acdc" produces "acdc://...").
+func DiscoverResources(cp *content.ContentProvider, scheme string) ([]ResourceDefinition, error) {
 	var definitions []ResourceDefinition
 	resourcesDir := cp.ResourcesDir
 
@@ -141,7 +142,7 @@ func DiscoverResources(cp *content.ContentProvider) ([]ResourceDefinition, error
 		relPathNoExt := strings.TrimSuffix(relPath, filepath.Ext(relPath))
 		// normalized for URI (slashes)
 		uriPath := filepath.ToSlash(relPathNoExt)
-		uri := fmt.Sprintf("acdc://%s", uriPath)
+		uri := fmt.Sprintf("%s://%s", scheme, uriPath)
 
 		definitions = append(definitions, ResourceDefinition{
 			URI:         uri,

--- a/internal/resources/provider_test.go
+++ b/internal/resources/provider_test.go
@@ -225,7 +225,7 @@ func TestDiscoverResources(t *testing.T) {
 
 	cp := content.NewContentProvider(tmp)
 
-	defs, err := DiscoverResources(cp)
+	defs, err := DiscoverResources(cp, "acdc")
 	if err != nil {
 		t.Fatalf("DiscoverResources error = %v", err)
 	}
@@ -247,5 +247,33 @@ func TestDiscoverResources(t *testing.T) {
 	}
 	if !uris["acdc://sub/sub"] {
 		t.Error("Missing acdc://sub/sub")
+	}
+}
+
+func TestDiscoverResources_CustomScheme(t *testing.T) {
+	tmp := t.TempDir()
+	resDir := filepath.Join(tmp, "mcp-resources")
+	if err := os.MkdirAll(resDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	validRes := filepath.Join(resDir, "doc.md")
+	if err := os.WriteFile(validRes, []byte("---\nname: Doc\ndescription: D\n---\nContent"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cp := content.NewContentProvider(tmp)
+
+	defs, err := DiscoverResources(cp, "my-custom")
+	if err != nil {
+		t.Fatalf("DiscoverResources error = %v", err)
+	}
+
+	if len(defs) != 1 {
+		t.Fatalf("DiscoverResources found %d items, want 1", len(defs))
+	}
+
+	if defs[0].URI != "my-custom://doc" {
+		t.Errorf("Expected URI 'my-custom://doc', got '%s'", defs[0].URI)
 	}
 }

--- a/tests/integration/testkit/testkit.go
+++ b/tests/integration/testkit/testkit.go
@@ -186,6 +186,7 @@ type FlagOptions struct {
 	Transport string // Defaults to "sse"
 	AuthType  string // Defaults to "none"
 	Host      string // Defaults to "localhost"
+	Scheme    string // Defaults to "" (uses config default "acdc")
 }
 
 // NewTestFlags creates a configured pflag.FlagSet for testing
@@ -215,6 +216,11 @@ func NewTestFlags(t testing.TB, contentDir string, opts *FlagOptions) *pflag.Fla
 		}
 	}
 
+	scheme := ""
+	if opts != nil && opts.Scheme != "" {
+		scheme = opts.Scheme
+	}
+
 	if port == 0 {
 		port = MustGetFreePort(t)
 	}
@@ -224,6 +230,9 @@ func NewTestFlags(t testing.TB, contentDir string, opts *FlagOptions) *pflag.Fla
 	_ = flags.Set("transport", transport)
 	_ = flags.Set("auth-type", authType)
 	_ = flags.Set("host", host)
+	if scheme != "" {
+		_ = flags.Set("uri-scheme", scheme)
+	}
 
 	return flags
 }

--- a/tests/integration/testkit/testkit_test.go
+++ b/tests/integration/testkit/testkit_test.go
@@ -363,6 +363,29 @@ func TestNewTestFlags_WithOptions(t *testing.T) {
 	}
 }
 
+func TestNewTestFlags_WithScheme(t *testing.T) {
+	contentDir := CreateTestContentDir(t, nil)
+	opts := &FlagOptions{
+		Scheme: "myorg",
+	}
+	flags := NewTestFlags(t, contentDir, opts)
+
+	scheme, _ := flags.GetString("uri-scheme")
+	if scheme != "myorg" {
+		t.Errorf("Expected scheme 'myorg', got '%s'", scheme)
+	}
+}
+
+func TestNewTestFlags_WithoutScheme(t *testing.T) {
+	contentDir := CreateTestContentDir(t, nil)
+	flags := NewTestFlags(t, contentDir, nil)
+
+	scheme, _ := flags.GetString("uri-scheme")
+	if scheme != "" {
+		t.Errorf("Expected empty scheme (use config default), got '%s'", scheme)
+	}
+}
+
 type mockTB struct {
 	*testing.T
 	failed  bool

--- a/tests/integration/uri_scheme_test.go
+++ b/tests/integration/uri_scheme_test.go
@@ -1,0 +1,179 @@
+package integration
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/sha1n/mcp-acdc-server/tests/integration/testkit"
+)
+
+// TestURISchemeIntegration verifies that the server uses the configured URI scheme in resource URIs,
+// and that resources can be read back using those URIs.
+func TestURISchemeIntegration(t *testing.T) {
+	resourceContent := "---\nname: Scheme Test Resource\ndescription: A resource for URI scheme testing\n---\nScheme test content."
+
+	tests := []struct {
+		name           string
+		scheme         string
+		expectedScheme string
+	}{
+		{
+			name:           "default scheme",
+			scheme:         "",
+			expectedScheme: "acdc",
+		},
+		{
+			name:           "custom scheme",
+			scheme:         "myorg",
+			expectedScheme: "myorg",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			contentDir := testkit.CreateTestContentDir(t, &testkit.ContentDirOptions{
+				Resources: map[string]string{
+					"tools/test-tool.md": resourceContent,
+				},
+			})
+
+			flagOpts := &testkit.FlagOptions{
+				Transport: "stdio",
+			}
+			if tc.scheme != "" {
+				flagOpts.Scheme = tc.scheme
+			}
+
+			flags := testkit.NewTestFlags(t, contentDir, flagOpts)
+			service := testkit.NewACDCService("acdc-scheme-test", flags)
+			env := testkit.NewTestEnv(service)
+
+			props, err := env.Start()
+			if err != nil {
+				t.Fatalf("Failed to start env: %v", err)
+			}
+			defer func() { _ = env.Stop() }()
+
+			stdin := props["acdc.stdin"].(io.Writer)
+			stdout := props["acdc.stdout"].(io.Reader)
+			scanner := bufio.NewScanner(stdout)
+
+			sendRequest := func(req interface{}) {
+				reqBytes, _ := json.Marshal(req)
+				if _, err := fmt.Fprintf(stdin, "%s\n", reqBytes); err != nil {
+					t.Fatalf("Failed to write to stdin: %v", err)
+				}
+			}
+
+			readResponse := func(expectedID int) map[string]interface{} {
+				for scanner.Scan() {
+					line := scanner.Text()
+					var resp map[string]interface{}
+					if err := json.Unmarshal([]byte(line), &resp); err == nil {
+						if id, ok := resp["id"].(float64); ok && int(id) == expectedID {
+							return resp
+						}
+					}
+				}
+				return nil
+			}
+
+			// Initialize
+			sendRequest(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"method":  "initialize",
+				"params": map[string]interface{}{
+					"protocolVersion": "2024-11-05",
+					"capabilities":    map[string]interface{}{},
+					"clientInfo": map[string]string{
+						"name":    "test-client",
+						"version": "1.0",
+					},
+				},
+			})
+
+			initResp := readResponse(1)
+			if initResp == nil {
+				t.Fatal("Failed to get initialize response")
+			}
+
+			sendRequest(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"method":  "notifications/initialized",
+			})
+
+			// List resources and verify URI scheme
+			expectedURI := fmt.Sprintf("%s://tools/test-tool", tc.expectedScheme)
+
+			sendRequest(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      2,
+				"method":  "resources/list",
+			})
+
+			listResp := readResponse(2)
+			if listResp == nil {
+				t.Fatal("Failed to get resources/list response")
+			}
+
+			listResult, ok := listResp["result"].(map[string]interface{})
+			if !ok {
+				t.Fatalf("resources/list result is not a map: %v", listResp)
+			}
+
+			resourcesList, ok := listResult["resources"].([]interface{})
+			if !ok {
+				t.Fatalf("resources list is invalid: %v", listResult)
+			}
+
+			found := false
+			for _, r := range resourcesList {
+				resMap := r.(map[string]interface{})
+				uri := resMap["uri"].(string)
+				t.Logf("Resource URI: %s", uri)
+				if uri == expectedURI {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("Expected URI %s not found in resources/list", expectedURI)
+			}
+
+			// Read resource using the scheme-prefixed URI
+			sendRequest(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      3,
+				"method":  "resources/read",
+				"params": map[string]string{
+					"uri": expectedURI,
+				},
+			})
+
+			readResp := readResponse(3)
+			if readResp == nil {
+				t.Fatal("Failed to get resources/read response")
+			}
+
+			result, ok := readResp["result"].(map[string]interface{})
+			if !ok {
+				t.Fatalf("Response result is not a map: %v", readResp)
+			}
+
+			contents, ok := result["contents"].([]interface{})
+			if !ok || len(contents) == 0 {
+				t.Fatalf("Failed to get contents. Response: %v", readResp)
+			}
+
+			firstContent := contents[0].(map[string]interface{})
+			text := firstContent["text"].(string)
+
+			if text != "Scheme test content." {
+				t.Errorf("Unexpected content: %s", text)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add --uri-scheme/-s flag and ACDC_MCP_URI_SCHEME env var to allow custom URI
schemes for resources (default: "acdc"). The scheme is validated against
RFC 3986 at startup. Update documentation and specs accordingly.
