### PR TITLE
fix: bump Go base image to 1.26 to match go.mod requirement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
## Problem

The Docker build in CI was failing at the `go mod download` step with:

```
go: go.mod requires go >= 1.26 (running go 1.25.8; GOTOOLCHAIN=local)
```

`go.mod` declares `go 1.26` as the minimum version, but the `Dockerfile` was using `golang:1.25-alpine`. Go's toolchain enforcement rejects running under an older version.

## Fix

Bump the builder base image from `golang:1.25-alpine` to `golang:1.26-alpine`.