### PR TITLE
chore: remove pull_request trigger from release drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    types: [opened, reopened, synchronize, edited, labeled]
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
Only trigger release draft updates on push to master, not on every PR event (opened, reopened, synchronize, edited, labeled).