### PR TITLE
docs: sync TASKS.md status with current implementation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,54 @@
+# ACDC MCP Server (mcp-acdc-server)
+
+## Project Overview
+
+The **Agent Content Discovery Companion (ACDC) MCP Server** is a high-performance Model Context Protocol (MCP) server designed to help AI agents discover and search local content. It bridges the gap between content repositories and AI agents, enabling team-specific knowledge management at scale.
+
+- **Main Technologies:** Go 1.26, [Bleve](https://github.com/blevesearch/bleve) (Full-Text Search), [MCP Go SDK](https://github.com/modelcontextprotocol/go-sdk), [Cobra](https://github.com/spf13/cobra) (CLI), [Viper](https://github.com/spf13/viper) (Configuration).
+- **Key Features:** Full-text search, dynamic resource and prompt discovery, dual transport (stdio/SSE), authentication (basic auth/API keys).
+- **Architecture:** Follows a standard Go project layout:
+  - `cmd/acdc-mcp/`: Entry point for the CLI application.
+  - `internal/`: Core logic, including:
+    - `app/`: Application runner and CLI coordination.
+    - `mcp/`: MCP protocol implementation (tools, resources, prompts).
+    - `search/`: Search service using Bleve.
+    - `content/`, `resources/`, `prompts/`: Content management and providers.
+    - `auth/`: Authentication middleware.
+    - `config/`: Configuration management.
+  - `docs/`: Comprehensive documentation on authoring, configuration, and development.
+  - `examples/`: Deployment patterns (Docker, local content).
+
+## Building and Running
+
+The project uses a `Makefile` for common tasks.
+
+### Key Commands
+
+- **Build:**
+  - `make build`: Builds binaries for all supported platforms (Linux, macOS, Windows).
+  - `make build-current`: Builds for the current OS/Arch (output in `bin/`).
+  - `make build-docker`: Builds the Docker image.
+- **Run:**
+  - `bin/acdc-mcp --content-dir ./content`: Runs the server with `stdio` transport (default).
+  - `bin/acdc-mcp --transport sse --content-dir ./content`: Runs the server with `sse` transport.
+- **Test:**
+  - `make test`: Runs all Go tests.
+  - `make coverage`: Runs tests and generates a coverage report.
+- **Lint & Format:**
+  - `make lint`: Runs `go vet`, `golangci-lint`, and format checks.
+  - `make format`: Formats Go source files using `gofmt`.
+
+### Development Setup
+
+To add the local development server to your MCP clients:
+- **Gemini CLI:** `make mcp-add-gemini-dev`
+- **Claude Code:** `make mcp-add-claude-dev`
+
+## Development Conventions
+
+- **Code Style:** Strictly follow standard Go formatting (`gofmt`). This is enforced by CI and the `make lint` command.
+- **Linters:** Use `make lint` to run all project linters. It includes `go vet` and `golangci-lint`.
+- **Testing:** New features should include unit tests in the same directory (e.g., `*_test.go`) and, if applicable, integration tests in `tests/integration/`.
+- **Dependencies:** Use `go mod tidy` to manage dependencies. `make install` is a shortcut for this.
+- **Configuration:** Configuration is handled via flags, environment variables (prefixed with `ACDC_MCP_`), or configuration files via Viper.
+- **Logging:** Use `log/slog` for structured logging. Logs are always directed to `stderr` to avoid interfering with the `stdio` transport.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -19,7 +19,7 @@
 - [x] [CLI] Implement version flags (`--version` / `-v`)
 - [ ] [CONTENT] Support Git repositories as content sources
   - [ ] [CONTENT] Implement scheduled synchronization and re-indexing (Note: Server metadata updates require reconnection)
-- [ ] [SEARCH] Support keyword boosting in the search API, so that agents can improve search quality based on context
+- [x] [SEARCH] Support keyword boosting in the search API, so that agents can improve search quality based on context
 - [ ] [CONTENT] Support additional content file types (e.g. PDF, DOCX, etc.) as MD resource attachments. MD provides context and metadata, attachments provide content.
 - [ ] [AUTH] Add Okta/OAuth2 authentication support
 - [ ] [API] Generate OpenAPI Spec: Auto-generate OpenAPI/Swagger documentation for the SSE HTTP endpoints.
@@ -30,14 +30,14 @@
 
 - [x] Stream Search Indexing: Refactor search indexing to use streaming and batching to prevent OOM on large content repositories.
 - [ ] Stream File Processing: Refactor ContentProvider to stream files instead of reading them entirely into memory (os.ReadFile), improving large file handling.
-- [ ] Define a hard limit on the number of resources that can return from a search query
+- [x] Define a hard limit on the number of resources that can return from a search query
 
 ### Observability
 
 - [ ] [LOGGING] Add more detailed logging
 - [ ] [LOGGING] Research stdio MCPs logging best practices
 - [ ] [LOGGING] Add log level configuration
-- [x] [HEALTH] Consider adding a health check endpoint
+- [x] [HEALTH] Add a health check endpoint (`/health`)
 - [ ] [METRICS] Consider adding a metrics endpoint
   - [ ] [METRICS] Consider OTel based metrics
 


### PR DESCRIPTION
Mark tasks that are already implemented as done:

- **[SEARCH] Keyword boosting** — `KeywordsBoost`, `NameBoost`, `ContentBoost` are fully implemented in `search/service.go` using `DisjunctionQuery` at query time.
- **Hard search result limit** — `MaxResults` (default: 10) is enforced in `Search()` via config, with a per-call override.
- **[HEALTH] Health check endpoint** — `/health` endpoint is live in `app/server.go`, excluded from auth middleware, and covered by integration tests.

Also updated the health check task wording from "Consider adding" to "Add" and noted the actual path (`/health`).

Additionally adds `GEMINI.md` and `CLAUDE.md` agent instruction files.