### PR TITLE
feat(config): add indexing and result mode contracts

### DIFF
--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -12,6 +12,7 @@ func RegisterFlags(flags *pflag.FlagSet) {
 	flags.Float64("search-keywords-boost", 0, "Boost for keywords matches (default: 3.0)")
 	flags.Float64("search-name-boost", 0, "Boost for name matches (default: 2.0)")
 	flags.Float64("search-content-boost", 0, "Boost for content matches (default: 1.0)")
+	flags.String("search-result-mode", "", "Search output mode: references or content (default: references)")
 	flags.StringP("uri-scheme", "s", "", "URI scheme for resources (default: acdc)")
 	flags.Bool("cross-ref", false, "Transform relative markdown links to resource URIs (default: false)")
 	flags.StringP("auth-type", "a", "", "Authentication type: none, basic, or apikey (default: none)")

--- a/internal/app/cli_test.go
+++ b/internal/app/cli_test.go
@@ -3,7 +3,9 @@ package app
 import (
 	"testing"
 
+	"github.com/sha1n/mcp-acdc-server/internal/config"
 	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRegisterFlags_AllFlagsExist(t *testing.T) {
@@ -19,6 +21,7 @@ func TestRegisterFlags_AllFlagsExist(t *testing.T) {
 		{"host", "H"},
 		{"port", "p"},
 		{"search-max-results", "m"},
+		{"search-result-mode", ""},
 		{"auth-type", "a"},
 		{"auth-basic-username", "u"},
 		{"auth-basic-password", "P"},
@@ -35,6 +38,15 @@ func TestRegisterFlags_AllFlagsExist(t *testing.T) {
 			t.Errorf("Flag --%s has wrong shorthand: expected -%s, got -%s", ef.long, ef.short, f.Shorthand)
 		}
 	}
+}
+
+func TestCLI_FlagParsing_SearchResultMode(t *testing.T) {
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	RegisterFlags(flags)
+	require.NoError(t, flags.Set("search-result-mode", "content"))
+	settings, err := config.LoadSettingsWithFlags(flags)
+	require.NoError(t, err)
+	require.Equal(t, config.SearchResultModeContent, settings.Search.ResultMode)
 }
 
 func TestRegisterFlags_FlagDescriptions(t *testing.T) {

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -25,6 +25,7 @@ func LogWithLogger(s *Settings, logger *slog.Logger) {
 	logger.InfoContext(ctx, "Config: search.keywords_boost", "value", s.Search.KeywordsBoost)
 	logger.InfoContext(ctx, "Config: search.name_boost", "value", s.Search.NameBoost)
 	logger.InfoContext(ctx, "Config: search.content_boost", "value", s.Search.ContentBoost)
+	logger.InfoContext(ctx, "Config: search.result_mode", "value", s.Search.ResultMode)
 
 	logger.InfoContext(ctx, "Config: auth.type", "value", s.Auth.Type)
 	switch s.Auth.Type {
@@ -44,6 +45,7 @@ func SearchSettingsLogValue(s SearchSettings) slog.Value {
 		slog.Float64("keywords_boost", s.KeywordsBoost),
 		slog.Float64("name_boost", s.NameBoost),
 		slog.Float64("content_boost", s.ContentBoost),
+		slog.String("result_mode", string(s.ResultMode)),
 	)
 }
 

--- a/internal/config/logging_test.go
+++ b/internal/config/logging_test.go
@@ -25,6 +25,7 @@ func TestLog(t *testing.T) {
 					KeywordsBoost: 1.0,
 					NameBoost:     1.0,
 					ContentBoost:  1.0,
+					ResultMode:    SearchResultModeReferences,
 				},
 				Auth: AuthSettings{
 					Type: AuthTypeNone,
@@ -35,6 +36,7 @@ func TestLog(t *testing.T) {
 				"Config: transport",
 				"Config: search.max_results",
 				"Config: search.in_memory",
+				"Config: search.result_mode",
 				"Config: auth.type",
 			},
 		},
@@ -98,6 +100,7 @@ func TestLog(t *testing.T) {
 				assert.Contains(t, captured, "Config: content_dir")
 				assert.Contains(t, captured, "Config: transport")
 				assert.NotContains(t, captured, "Config: host")
+				assert.Equal(t, SearchResultModeReferences, captured["Config: search.result_mode"])
 			}
 			if tt.settings.Auth.Type == AuthTypeBasic {
 				assert.Contains(t, captured, "Config: auth.basic.username")
@@ -119,6 +122,7 @@ func TestLogValues(t *testing.T) {
 		Transport:  "stdio",
 		Search: SearchSettings{
 			MaxResults: 10,
+			ResultMode: SearchResultModeReferences,
 		},
 		Auth: AuthSettings{
 			Type: AuthTypeBasic,
@@ -151,6 +155,7 @@ func TestLogValues(t *testing.T) {
 			attrMap[a.Key] = a.Value
 		}
 		assert.Equal(t, int64(10), attrMap["max_results"].Int64())
+		assert.Equal(t, "references", attrMap["result_mode"].String())
 	})
 
 	t.Run("AuthSettingsLogValue", func(t *testing.T) {

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -14,13 +14,22 @@ import (
 // schemeRegexp validates URI schemes per RFC 3986: ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
 var schemeRegexp = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+\-.]*$`)
 
+// SearchResultMode controls the detail level in search results.
+type SearchResultMode string
+
+const (
+	SearchResultModeReferences SearchResultMode = "references"
+	SearchResultModeContent    SearchResultMode = "content"
+)
+
 // SearchSettings configuration for search service
 type SearchSettings struct {
-	MaxResults    int     `mapstructure:"max_results"`
-	InMemory      bool    `mapstructure:"in_memory"`
-	KeywordsBoost float64 `mapstructure:"keywords_boost"`
-	NameBoost     float64 `mapstructure:"name_boost"`
-	ContentBoost  float64 `mapstructure:"content_boost"`
+	MaxResults    int              `mapstructure:"max_results"`
+	InMemory      bool             `mapstructure:"in_memory"`
+	KeywordsBoost float64          `mapstructure:"keywords_boost"`
+	NameBoost     float64          `mapstructure:"name_boost"`
+	ContentBoost  float64          `mapstructure:"content_boost"`
+	ResultMode    SearchResultMode `mapstructure:"result_mode"`
 }
 
 // Auth type constants
@@ -79,6 +88,7 @@ func LoadSettingsWithFlags(flags *pflag.FlagSet) (*Settings, error) {
 	v.SetDefault("search.keywords_boost", 3.0)
 	v.SetDefault("search.name_boost", 2.0)
 	v.SetDefault("search.content_boost", 1.0)
+	v.SetDefault("search.result_mode", SearchResultModeReferences)
 	v.SetDefault("cross_ref", false)
 	v.SetDefault("auth.type", AuthTypeNone)
 
@@ -94,6 +104,7 @@ func LoadSettingsWithFlags(flags *pflag.FlagSet) (*Settings, error) {
 	_ = v.BindEnv("search.keywords_boost", "ACDC_MCP_SEARCH_KEYWORDS_BOOST")
 	_ = v.BindEnv("search.name_boost", "ACDC_MCP_SEARCH_NAME_BOOST")
 	_ = v.BindEnv("search.content_boost", "ACDC_MCP_SEARCH_CONTENT_BOOST")
+	_ = v.BindEnv("search.result_mode", "ACDC_MCP_SEARCH_RESULT_MODE")
 
 	_ = v.BindEnv("uri_scheme", "ACDC_MCP_URI_SCHEME")
 	_ = v.BindEnv("cross_ref", "ACDC_MCP_CROSS_REF")
@@ -115,6 +126,7 @@ func LoadSettingsWithFlags(flags *pflag.FlagSet) (*Settings, error) {
 		_ = v.BindPFlag("search.keywords_boost", flags.Lookup("search-keywords-boost"))
 		_ = v.BindPFlag("search.name_boost", flags.Lookup("search-name-boost"))
 		_ = v.BindPFlag("search.content_boost", flags.Lookup("search-content-boost"))
+		_ = v.BindPFlag("search.result_mode", flags.Lookup("search-result-mode"))
 		_ = v.BindPFlag("auth.type", flags.Lookup("auth-type"))
 		_ = v.BindPFlag("auth.basic.username", flags.Lookup("auth-basic-username"))
 		_ = v.BindPFlag("auth.basic.password", flags.Lookup("auth-basic-password"))
@@ -165,6 +177,12 @@ func ValidateSettings(s *Settings) error {
 	// Validate URI scheme (RFC 3986: ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ))
 	if !schemeRegexp.MatchString(s.Scheme) {
 		return errors.New("scheme must match RFC 3986 (start with a letter, contain only letters, digits, +, -, .), got: " + s.Scheme)
+	}
+
+	switch s.Search.ResultMode {
+	case SearchResultModeReferences, SearchResultModeContent:
+	default:
+		return errors.New("search result mode must be 'references' or 'content', got: " + string(s.Search.ResultMode))
 	}
 
 	hasBasicCreds := s.Auth.Basic.Username != "" || s.Auth.Basic.Password != ""

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLoadSettings_Defaults(t *testing.T) {
@@ -41,6 +42,13 @@ func TestLoadSettings_Defaults(t *testing.T) {
 	if settings.CrossRef != false {
 		t.Errorf("Expected default cross_ref false, got %v", settings.CrossRef)
 	}
+}
+
+func TestLoadSettings_SearchResultMode(t *testing.T) {
+	t.Setenv("ACDC_MCP_SEARCH_RESULT_MODE", "content")
+	settings, err := LoadSettings()
+	require.NoError(t, err)
+	require.Equal(t, SearchResultModeContent, settings.Search.ResultMode)
 }
 
 func TestLoadSettings_EnvVars(t *testing.T) {
@@ -271,14 +279,27 @@ func TestLoadSettingsWithFlags_AllFlagTypes(t *testing.T) {
 // --- ValidateSettings Tests ---
 
 func TestValidateSettings_ValidNone(t *testing.T) {
-	s := &Settings{Transport: "stdio", Scheme: "acdc", Auth: AuthSettings{Type: AuthTypeNone}}
+	s := &Settings{Transport: "stdio", Scheme: "acdc", Search: SearchSettings{ResultMode: SearchResultModeReferences}, Auth: AuthSettings{Type: AuthTypeNone}}
 	if err := ValidateSettings(s); err != nil {
 		t.Errorf("Expected no error for valid none auth, got: %v", err)
 	}
 }
 
+func TestValidateSettings_SearchResultMode(t *testing.T) {
+	settings := &Settings{
+		Transport: "stdio",
+		Scheme:    "acdc",
+		Search: SearchSettings{
+			ResultMode: SearchResultModeReferences,
+		},
+		Auth: AuthSettings{Type: AuthTypeNone},
+	}
+	settings.Search.ResultMode = "verbose"
+	require.EqualError(t, ValidateSettings(settings), "search result mode must be 'references' or 'content', got: verbose")
+}
+
 func TestValidateSettings_ValidNone_EmptyType(t *testing.T) {
-	s := &Settings{Transport: "stdio", Scheme: "acdc", Auth: AuthSettings{Type: ""}}
+	s := &Settings{Transport: "stdio", Scheme: "acdc", Search: SearchSettings{ResultMode: SearchResultModeReferences}, Auth: AuthSettings{Type: ""}}
 	if err := ValidateSettings(s); err != nil {
 		t.Errorf("Expected no error for empty auth type, got: %v", err)
 	}
@@ -288,6 +309,7 @@ func TestValidateSettings_ValidBasic(t *testing.T) {
 	s := &Settings{
 		Transport: "stdio",
 		Scheme:    "acdc",
+		Search:    SearchSettings{ResultMode: SearchResultModeReferences},
 		Auth: AuthSettings{
 			Type: AuthTypeBasic,
 			Basic: BasicAuthSettings{
@@ -305,6 +327,7 @@ func TestValidateSettings_ValidAPIKey(t *testing.T) {
 	s := &Settings{
 		Transport: "stdio",
 		Scheme:    "acdc",
+		Search:    SearchSettings{ResultMode: SearchResultModeReferences},
 		Auth: AuthSettings{
 			Type:    AuthTypeAPIKey,
 			APIKeys: []string{"key1", "key2"},
@@ -325,6 +348,7 @@ func TestValidateSettings_NoneWithCredentials(t *testing.T) {
 			settings: Settings{
 				Transport: "stdio",
 				Scheme:    "acdc",
+				Search:    SearchSettings{ResultMode: SearchResultModeReferences},
 				Auth: AuthSettings{
 					Type:  AuthTypeNone,
 					Basic: BasicAuthSettings{Username: "admin"},
@@ -336,6 +360,7 @@ func TestValidateSettings_NoneWithCredentials(t *testing.T) {
 			settings: Settings{
 				Transport: "stdio",
 				Scheme:    "acdc",
+				Search:    SearchSettings{ResultMode: SearchResultModeReferences},
 				Auth: AuthSettings{
 					Type:  AuthTypeNone,
 					Basic: BasicAuthSettings{Password: "secret"},
@@ -347,6 +372,7 @@ func TestValidateSettings_NoneWithCredentials(t *testing.T) {
 			settings: Settings{
 				Transport: "stdio",
 				Scheme:    "acdc",
+				Search:    SearchSettings{ResultMode: SearchResultModeReferences},
 				Auth: AuthSettings{
 					Type:    AuthTypeNone,
 					APIKeys: []string{"key1"},
@@ -372,6 +398,7 @@ func TestValidateSettings_BasicAuthMissingUsername(t *testing.T) {
 	s := &Settings{
 		Transport: "stdio",
 		Scheme:    "acdc",
+		Search:    SearchSettings{ResultMode: SearchResultModeReferences},
 		Auth: AuthSettings{
 			Type: AuthTypeBasic,
 			Basic: BasicAuthSettings{
@@ -392,6 +419,7 @@ func TestValidateSettings_BasicAuthMissingPassword(t *testing.T) {
 	s := &Settings{
 		Transport: "stdio",
 		Scheme:    "acdc",
+		Search:    SearchSettings{ResultMode: SearchResultModeReferences},
 		Auth: AuthSettings{
 			Type: AuthTypeBasic,
 			Basic: BasicAuthSettings{
@@ -409,6 +437,7 @@ func TestValidateSettings_BasicAuthWithAPIKeys(t *testing.T) {
 	s := &Settings{
 		Transport: "stdio",
 		Scheme:    "acdc",
+		Search:    SearchSettings{ResultMode: SearchResultModeReferences},
 		Auth: AuthSettings{
 			Type: AuthTypeBasic,
 			Basic: BasicAuthSettings{
@@ -431,6 +460,7 @@ func TestValidateSettings_APIKeyMissingKeys(t *testing.T) {
 	s := &Settings{
 		Transport: "stdio",
 		Scheme:    "acdc",
+		Search:    SearchSettings{ResultMode: SearchResultModeReferences},
 		Auth: AuthSettings{
 			Type: AuthTypeAPIKey,
 		},
@@ -448,6 +478,7 @@ func TestValidateSettings_APIKeyWithBasicCreds(t *testing.T) {
 	s := &Settings{
 		Transport: "stdio",
 		Scheme:    "acdc",
+		Search:    SearchSettings{ResultMode: SearchResultModeReferences},
 		Auth: AuthSettings{
 			Type:    AuthTypeAPIKey,
 			APIKeys: []string{"key1"},
@@ -469,6 +500,7 @@ func TestValidateSettings_UnknownAuthType(t *testing.T) {
 	s := &Settings{
 		Transport: "stdio",
 		Scheme:    "acdc",
+		Search:    SearchSettings{ResultMode: SearchResultModeReferences},
 		Auth: AuthSettings{
 			Type: "oauth",
 		},
@@ -485,14 +517,14 @@ func TestValidateSettings_UnknownAuthType(t *testing.T) {
 // --- Transport Validation Tests ---
 
 func TestValidateSettings_ValidTransportStdio(t *testing.T) {
-	s := &Settings{Transport: "stdio", Scheme: "acdc", Auth: AuthSettings{Type: AuthTypeNone}}
+	s := &Settings{Transport: "stdio", Scheme: "acdc", Search: SearchSettings{ResultMode: SearchResultModeReferences}, Auth: AuthSettings{Type: AuthTypeNone}}
 	if err := ValidateSettings(s); err != nil {
 		t.Errorf("Expected no error for valid stdio transport, got: %v", err)
 	}
 }
 
 func TestValidateSettings_ValidTransportSSE(t *testing.T) {
-	s := &Settings{Transport: "sse", Scheme: "acdc", Auth: AuthSettings{Type: AuthTypeNone}}
+	s := &Settings{Transport: "sse", Scheme: "acdc", Search: SearchSettings{ResultMode: SearchResultModeReferences}, Auth: AuthSettings{Type: AuthTypeNone}}
 	if err := ValidateSettings(s); err != nil {
 		t.Errorf("Expected no error for valid sse transport, got: %v", err)
 	}
@@ -514,6 +546,7 @@ func TestValidateSettings_InvalidTransport(t *testing.T) {
 			s := &Settings{
 				Transport: tt.transport,
 				Scheme:    "acdc",
+				Search:    SearchSettings{ResultMode: SearchResultModeReferences},
 				Auth:      AuthSettings{Type: AuthTypeNone},
 			}
 			err := ValidateSettings(s)
@@ -605,7 +638,7 @@ func TestValidateSettings_ValidSchemes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := &Settings{Transport: "stdio", Scheme: tt.scheme, Auth: AuthSettings{Type: AuthTypeNone}}
+			s := &Settings{Transport: "stdio", Scheme: tt.scheme, Search: SearchSettings{ResultMode: SearchResultModeReferences}, Auth: AuthSettings{Type: AuthTypeNone}}
 			if err := ValidateSettings(s); err != nil {
 				t.Errorf("Expected no error for scheme %q, got: %v", tt.scheme, err)
 			}
@@ -628,7 +661,7 @@ func TestValidateSettings_InvalidSchemes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := &Settings{Transport: "stdio", Scheme: tt.scheme, Auth: AuthSettings{Type: AuthTypeNone}}
+			s := &Settings{Transport: "stdio", Scheme: tt.scheme, Search: SearchSettings{ResultMode: SearchResultModeReferences}, Auth: AuthSettings{Type: AuthTypeNone}}
 			err := ValidateSettings(s)
 			if err == nil {
 				t.Fatalf("Expected error for scheme %q", tt.scheme)

--- a/internal/domain/metadata.go
+++ b/internal/domain/metadata.go
@@ -17,10 +17,17 @@ type ToolMetadata struct {
 	Description string `yaml:"description"`
 }
 
+// IndexMetadata represents the index section of mcp-metadata.yaml.
+type IndexMetadata struct {
+	Include []string `yaml:"include"`
+	Exclude []string `yaml:"exclude,omitempty"`
+}
+
 // McpMetadata represents the root of mcp-metadata.yaml
 type McpMetadata struct {
 	Server ServerMetadata `yaml:"server"`
 	Tools  []ToolMetadata `yaml:"tools"`
+	Index  *IndexMetadata `yaml:"index,omitempty"`
 }
 
 // DefaultToolMetadata provides sensible defaults for known tools
@@ -76,6 +83,9 @@ func (m *McpMetadata) Validate() error {
 	}
 	if m.Server.Instructions == "" {
 		return fmt.Errorf("server instructions are required")
+	}
+	if m.Index != nil && len(m.Index.Include) == 0 {
+		return fmt.Errorf("index.include requires at least one pattern")
 	}
 
 	for i, t := range m.Tools {

--- a/internal/domain/metadata_test.go
+++ b/internal/domain/metadata_test.go
@@ -1,6 +1,10 @@
 package domain
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestMcpMetadata_Validate(t *testing.T) {
 	tests := []struct {
@@ -74,6 +78,33 @@ func TestMcpMetadata_Validate(t *testing.T) {
 			if err := tt.meta.Validate(); (err != nil) != tt.wantErr {
 				t.Errorf("McpMetadata.Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
+		})
+	}
+}
+
+func TestMcpMetadata_ValidateIndex(t *testing.T) {
+	tests := []struct {
+		name    string
+		index   *IndexMetadata
+		wantErr string
+	}{
+		{name: "absent", index: nil},
+		{name: "configured", index: &IndexMetadata{Include: []string{"docs/**/*.md"}}},
+		{name: "empty include", index: &IndexMetadata{}, wantErr: "index.include requires at least one pattern"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metadata := McpMetadata{
+				Server: ServerMetadata{Name: "test", Version: "1", Instructions: "test"},
+				Index:  tt.index,
+			}
+			err := metadata.Validate()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.EqualError(t, err, tt.wantErr)
 		})
 	}
 }


### PR DESCRIPTION
## Summary
Add the configuration contracts needed for repository indexing and process-wide search result presentation. Metadata can now declare optional include/exclude rules, while search output mode is configurable through defaults, environment variables, and the CLI.

## Changes
- Validate configured metadata so an explicit `index` block always has at least one include pattern.
- Add typed `references` and `content` result modes, keeping `references` as the default and exposing the selected mode in configuration logging.
- Reject invalid or zero-valued result modes when callers construct and validate settings directly; normal settings loading supplies the default.
