### PR TITLE
feat(content): [2/9] parse repository markdown metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
+	github.com/yuin/goldmark v1.8.5
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -663,6 +663,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/goldmark v1.8.5 h1:r6N5afV5qj/5S4UTch8agZHJ8UxNCMwX7WjkkJam2NA=
+github.com/yuin/goldmark v1.8.5/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 gitlab.com/bosi/decorder v0.4.2 h1:qbQaV3zgwnBZ4zPMhGLW4KZe7A7NwxEhJx39R3shffo=
 gitlab.com/bosi/decorder v0.4.2/go.mod h1:muuhHoaJkA9QLcYHq4Mj8FJUwDZ+EirSHRiaTcTf6T8=
 go-simpler.org/assert v0.9.0 h1:PfpmcSvL7yAnWyChSjOz6Sp6m9j5lyK8Ok9pEL31YkQ=

--- a/internal/content/markdown.go
+++ b/internal/content/markdown.go
@@ -1,0 +1,251 @@
+package content
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"path"
+	"strings"
+	"unicode"
+
+	"github.com/sha1n/mcp-acdc-server/internal/domain"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/extension"
+	"github.com/yuin/goldmark/text"
+	"gopkg.in/yaml.v3"
+)
+
+var markdownParser = goldmark.New(goldmark.WithExtensions(extension.GFM))
+
+type FrontmatterMode uint8
+
+const (
+	FrontmatterRequired FrontmatterMode = iota
+	FrontmatterOptional
+)
+
+type ParsedMarkdown struct {
+	Metadata      map[string]any
+	Body          []byte
+	BodyStartLine int
+	root          ast.Node
+}
+
+type SourceOptions struct {
+	URI          string
+	FilePath     string
+	RelativePath string
+	Raw          []byte
+}
+
+func ParseMarkdown(raw []byte, mode FrontmatterMode) (*ParsedMarkdown, error) {
+	normalized := bytes.ReplaceAll(raw, []byte("\r\n"), []byte("\n"))
+	metadata, body, bodyStartLine, err := parseFrontmatter(normalized, mode)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ParsedMarkdown{
+		Metadata:      metadata,
+		Body:          body,
+		BodyStartLine: bodyStartLine,
+		root:          markdownParser.Parser().Parse(text.NewReader(body)),
+	}, nil
+}
+
+func BuildSourceDocument(parsed *ParsedMarkdown, opts SourceOptions) (domain.SourceDocument, error) {
+	if parsed == nil {
+		return domain.SourceDocument{}, fmt.Errorf("parsed markdown is required")
+	}
+
+	name := metadataString(parsed.Metadata, "name")
+	if name == "" {
+		name = firstNodeText(parsed.root, parsed.Body, func(node ast.Node) bool {
+			heading, ok := node.(*ast.Heading)
+			return ok && heading.Level == 1
+		})
+	}
+
+	description := metadataString(parsed.Metadata, "description")
+	if description == "" {
+		description = firstNodeText(parsed.root, parsed.Body, func(node ast.Node) bool {
+			_, ok := node.(*ast.Paragraph)
+			return ok
+		})
+	}
+	description = truncateRunes(description, 200)
+
+	return domain.SourceDocument{
+		ID:            opts.URI,
+		URI:           opts.URI,
+		Name:          name,
+		Description:   description,
+		MIMEType:      "text/markdown",
+		FilePath:      opts.FilePath,
+		RelativePath:  opts.RelativePath,
+		Content:       string(parsed.Body),
+		Fingerprint:   fingerprint(opts.Raw),
+		BodyStartLine: parsed.BodyStartLine,
+		Keywords:      metadataStrings(parsed.Metadata, "keywords"),
+		PathLabels:    pathLabels(opts.RelativePath),
+	}, nil
+}
+
+func parseFrontmatter(raw []byte, mode FrontmatterMode) (map[string]any, []byte, int, error) {
+	if !bytes.HasPrefix(raw, []byte("---\n")) {
+		if mode == FrontmatterRequired {
+			return nil, nil, 0, fmt.Errorf("file must start with YAML frontmatter (---\\n)")
+		}
+		return map[string]any{}, raw, 1, nil
+	}
+
+	const delimiterLength = len("---\n")
+	remainder := raw[delimiterLength:]
+	if bytes.HasPrefix(remainder, []byte("---\n")) {
+		return map[string]any{}, remainder[delimiterLength:], 3, nil
+	}
+	if bytes.Equal(remainder, []byte("---")) {
+		return map[string]any{}, nil, 3, nil
+	}
+	endIndex := bytes.Index(remainder, []byte("\n---"))
+	if endIndex == -1 {
+		return nil, nil, 0, fmt.Errorf("invalid frontmatter format - missing closing ---")
+	}
+
+	afterDelimiter := endIndex + len("\n---")
+	if afterDelimiter < len(remainder) && remainder[afterDelimiter] != '\n' {
+		return nil, nil, 0, fmt.Errorf("closing --- must be on its own line")
+	}
+
+	metadata := map[string]any{}
+	if err := yaml.Unmarshal(remainder[:endIndex], &metadata); err != nil {
+		return nil, nil, 0, fmt.Errorf("invalid YAML in frontmatter: %w", err)
+	}
+	if metadata == nil {
+		metadata = map[string]any{}
+	}
+
+	if afterDelimiter == len(remainder) {
+		return metadata, nil, bytes.Count(raw, []byte("\n")) + 1, nil
+	}
+
+	body := remainder[afterDelimiter+1:]
+	bodyStartLine := bytes.Count(raw[:delimiterLength+afterDelimiter+1], []byte("\n")) + 1
+	return metadata, body, bodyStartLine, nil
+}
+
+func metadataString(metadata map[string]any, key string) string {
+	value, ok := metadata[key]
+	if !ok {
+		return ""
+	}
+	stringValue, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(stringValue)
+}
+
+func metadataStrings(metadata map[string]any, key string) []string {
+	values, ok := metadata[key].([]any)
+	if !ok {
+		return nil
+	}
+
+	keywords := make([]string, 0, len(values))
+	for _, value := range values {
+		keyword, ok := value.(string)
+		if ok {
+			keywords = append(keywords, keyword)
+		}
+	}
+	return keywords
+}
+
+func firstNodeText(root ast.Node, source []byte, matches func(ast.Node) bool) string {
+	if root == nil {
+		return ""
+	}
+
+	var result string
+	if err := ast.Walk(root, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering || !matches(node) {
+			return ast.WalkContinue, nil
+		}
+		result = strings.TrimSpace(nodeText(node, source))
+		return ast.WalkStop, nil
+	}); err != nil {
+		return ""
+	}
+	return result
+}
+
+func nodeText(node ast.Node, source []byte) string {
+	var content strings.Builder
+	if err := ast.Walk(node, func(descendant ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		if textNode, ok := descendant.(*ast.Text); ok {
+			content.Write(textNode.Segment.Value(source))
+		}
+		return ast.WalkContinue, nil
+	}); err != nil {
+		return ""
+	}
+	return content.String()
+}
+
+func truncateRunes(value string, limit int) string {
+	runes := []rune(value)
+	if len(runes) <= limit {
+		return value
+	}
+	return string(runes[:limit])
+}
+
+func pathLabels(relativePath string) []string {
+	withoutExtension := strings.TrimSuffix(relativePath, path.Ext(relativePath))
+	parts := strings.FieldsFunc(withoutExtension, func(r rune) bool {
+		return r == '/' || unicode.IsSpace(r) || r == '-' || r == '_'
+	})
+
+	labels := make([]string, 0, len(parts))
+	seen := make(map[string]struct{})
+	for _, part := range parts {
+		for _, label := range splitCamelCase(part) {
+			label = strings.ToLower(label)
+			if _, exists := seen[label]; exists || label == "" {
+				continue
+			}
+			seen[label] = struct{}{}
+			labels = append(labels, label)
+		}
+	}
+	return labels
+}
+
+func splitCamelCase(value string) []string {
+	if value == "" {
+		return nil
+	}
+
+	runes := []rune(value)
+	start := 0
+	parts := make([]string, 0, 1)
+	for index := 1; index < len(runes); index++ {
+		if unicode.IsLower(runes[index-1]) && unicode.IsUpper(runes[index]) {
+			parts = append(parts, string(runes[start:index]))
+			start = index
+		}
+	}
+	parts = append(parts, string(runes[start:]))
+	return parts
+}
+
+func fingerprint(raw []byte) string {
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/content/provider.go
+++ b/internal/content/provider.go
@@ -1,6 +1,7 @@
 package content
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -63,76 +64,21 @@ func (p *ContentProvider) LoadYAML(filePath string) (map[string]interface{}, err
 
 // LoadMarkdownWithFrontmatter loads a markdown file with YAML frontmatter
 func (p *ContentProvider) LoadMarkdownWithFrontmatter(filePath string) (*MarkdownWithFrontmatter, error) {
-	content, err := p.LoadText(filePath)
+	raw, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}
 
-	// Normalize CRLF to LF to simplify parsing
-	normalized := strings.ReplaceAll(content, "\r\n", "\n")
-
-	if !strings.HasPrefix(normalized, "---\n") {
-		return nil, fmt.Errorf("file must start with YAML frontmatter (---\\n) in %s", filePath)
-	}
-
-	const startDelimiterLen = 4
-	remainder := normalized[startDelimiterLen:]
-
-	// Check if we have an empty frontmatter (immediately closing)
-	if strings.HasPrefix(remainder, "---\n") {
-		// Empty metadata
-		markdownContent := remainder[4:]
-		return &MarkdownWithFrontmatter{
-			Metadata: map[string]interface{}{},
-			Content:  markdownContent,
-		}, nil
-	}
-
-	// Find the closing --- on its own line
-	// We search for "\n---"
-	endIndex := strings.Index(remainder, "\n---")
-	if endIndex == -1 {
-		return nil, fmt.Errorf("invalid frontmatter format - missing closing --- in %s", filePath)
-	}
-
-	// Verify it's a valid closing delimiter (followed by newline or EOF)
-	// endIndex points to the newline before ---
-	// So we check remainder[endIndex+4] (length of "\n---" is 4)
-
-	// Check if it is followed by newline or is end of file
-	afterDelimiter := endIndex + 4
-	if afterDelimiter < len(remainder) && remainder[afterDelimiter] != '\n' {
-		// This might be something like "\n---foo", which is not a delimiter
-		// In a real robust parser we would loop to find the next one, but for now let's assume valid markdown.
-		// Or we can try to find the next one.
-		// For simplicity, let's treat it as error or recurse.
-		// But given the scope, let's just fail if it's not a proper delimiter.
-		// Actually, standard says delimiter must be on its own line.
-		return nil, fmt.Errorf("closing --- must be on its own line in %s", filePath)
-	}
-
-	frontmatterText := remainder[:endIndex]
-
-	var contentStartIndex int
-	if afterDelimiter < len(remainder) {
-		// skip the following newline
-		contentStartIndex = afterDelimiter + 1
-	} else {
-		contentStartIndex = len(remainder)
-	}
-
-	markdownContent := ""
-	if contentStartIndex < len(remainder) {
-		markdownContent = remainder[contentStartIndex:]
-	}
-
-	var metadata map[string]interface{}
-	if err := yaml.Unmarshal([]byte(frontmatterText), &metadata); err != nil {
-		return nil, fmt.Errorf("invalid YAML in frontmatter of %s: %w", filePath, err)
+	parsed, err := ParseMarkdown(raw, FrontmatterRequired)
+	if err != nil {
+		if yamlErr := errors.Unwrap(err); yamlErr != nil && strings.HasPrefix(err.Error(), "invalid YAML in frontmatter: ") {
+			return nil, fmt.Errorf("invalid YAML in frontmatter of %s: %w", filePath, yamlErr)
+		}
+		return nil, fmt.Errorf("%w in %s", err, filePath)
 	}
 
 	return &MarkdownWithFrontmatter{
-		Metadata: metadata,
-		Content:  markdownContent,
+		Metadata: parsed.Metadata,
+		Content:  string(parsed.Body),
 	}, nil
 }

--- a/internal/content/provider_test.go
+++ b/internal/content/provider_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestContentProvider_LoadText(t *testing.T) {
@@ -40,6 +42,44 @@ func TestContentProvider_LoadYAML(t *testing.T) {
 	if data["key"] != "value" {
 		t.Errorf("Expected value 'value', got '%v'", data["key"])
 	}
+}
+
+func TestParseMarkdown_OptionalFrontmatterAndDerivedMetadata(t *testing.T) {
+	raw := []byte("# OAuth Setup\n\nUse client credentials securely.\n")
+	parsed, err := ParseMarkdown(raw, FrontmatterOptional)
+	require.NoError(t, err)
+
+	doc, err := BuildSourceDocument(parsed, SourceOptions{
+		URI:          "acdc://docs/platform/oauth",
+		FilePath:     "/repo/docs/platform/oauth.md",
+		RelativePath: "docs/platform/oauth.md",
+		Raw:          raw,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "OAuth Setup", doc.Name)
+	require.Equal(t, "Use client credentials securely.", doc.Description)
+	require.Equal(t, []string{"docs", "platform", "oauth"}, doc.PathLabels)
+	require.Equal(t, 1, doc.BodyStartLine)
+	require.Len(t, doc.Fingerprint, 64)
+}
+
+func TestParseMarkdown_AuthoredMetadataPrecedence(t *testing.T) {
+	raw := []byte("---\nname: Auth Guide\ntitle: Ignored\ndescription: Auth details\nkeywords: [oauth, tokens]\n---\n# Other Heading\nBody\n")
+	parsed, err := ParseMarkdown(raw, FrontmatterOptional)
+	require.NoError(t, err)
+	doc, err := BuildSourceDocument(parsed, SourceOptions{URI: "acdc://auth", RelativePath: "docs/auth.md", Raw: raw})
+	require.NoError(t, err)
+	require.Equal(t, "Auth Guide", doc.Name)
+	require.Equal(t, "Auth details", doc.Description)
+	require.Equal(t, []string{"oauth", "tokens"}, doc.Keywords)
+	require.Equal(t, 7, doc.BodyStartLine)
+}
+
+func TestParseMarkdown_FrontmatterModes(t *testing.T) {
+	_, err := ParseMarkdown([]byte("# Plain"), FrontmatterRequired)
+	require.ErrorContains(t, err, "file must start with YAML frontmatter")
+	_, err = ParseMarkdown([]byte("---\ninvalid: : yaml\n---\nBody"), FrontmatterOptional)
+	require.ErrorContains(t, err, "invalid YAML in frontmatter")
 }
 
 func TestContentProvider_LoadMarkdownWithFrontmatter(t *testing.T) {

--- a/internal/content/provider_test.go
+++ b/internal/content/provider_test.go
@@ -3,6 +3,7 @@ package content
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -80,6 +81,68 @@ func TestParseMarkdown_FrontmatterModes(t *testing.T) {
 	require.ErrorContains(t, err, "file must start with YAML frontmatter")
 	_, err = ParseMarkdown([]byte("---\ninvalid: : yaml\n---\nBody"), FrontmatterOptional)
 	require.ErrorContains(t, err, "invalid YAML in frontmatter")
+}
+
+func TestParseMarkdown_FrontmatterBoundaries(t *testing.T) {
+	tests := []struct {
+		name          string
+		raw           string
+		wantName      any
+		wantBody      string
+		wantStartLine int
+	}{
+		{name: "empty at EOF", raw: "---\n---", wantBody: "", wantStartLine: 3},
+		{name: "metadata at EOF", raw: "---\nname: Guide\n---", wantName: "Guide", wantBody: "", wantStartLine: 3},
+		{name: "null metadata", raw: "---\nnull\n---\nBody", wantBody: "Body", wantStartLine: 4},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed, err := ParseMarkdown([]byte(tt.raw), FrontmatterOptional)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantName, parsed.Metadata["name"])
+			require.Equal(t, tt.wantBody, string(parsed.Body))
+			require.Equal(t, tt.wantStartLine, parsed.BodyStartLine)
+		})
+	}
+}
+
+func TestBuildSourceDocument_NilParsedMarkdown(t *testing.T) {
+	_, err := BuildSourceDocument(nil, SourceOptions{})
+	require.EqualError(t, err, "parsed markdown is required")
+}
+
+func TestBuildSourceDocument_NonStringMetadataFallsBack(t *testing.T) {
+	raw := []byte("---\nname: 42\ndescription: [invalid]\n---\n# Derived Name\n\nDerived description.\n")
+	parsed, err := ParseMarkdown(raw, FrontmatterOptional)
+	require.NoError(t, err)
+
+	doc, err := BuildSourceDocument(parsed, SourceOptions{
+		URI:          "acdc://docs/client-credentials",
+		RelativePath: "Docs/clientCredentials/oauth_oauth.md",
+		Raw:          raw,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "Derived Name", doc.Name)
+	require.Equal(t, "Derived description.", doc.Description)
+	require.Equal(t, []string{"docs", "client", "credentials", "oauth"}, doc.PathLabels)
+}
+
+func TestBuildSourceDocument_DescriptionRuneLimit(t *testing.T) {
+	parsed := &ParsedMarkdown{Metadata: map[string]any{}}
+	longDescription := strings.Repeat("é", 201)
+	parsed.Metadata["description"] = longDescription
+	doc, err := BuildSourceDocument(parsed, SourceOptions{})
+	require.NoError(t, err)
+	require.Equal(t, strings.Repeat("é", 200), doc.Description)
+	require.Len(t, []rune(doc.Description), 200)
+}
+
+func TestBuildSourceDocument_MissingASTMetadataIsEmpty(t *testing.T) {
+	doc, err := BuildSourceDocument(&ParsedMarkdown{Metadata: map[string]any{}}, SourceOptions{})
+	require.NoError(t, err)
+	require.Empty(t, doc.Name)
+	require.Empty(t, doc.Description)
 }
 
 func TestContentProvider_LoadMarkdownWithFrontmatter(t *testing.T) {
@@ -203,6 +266,12 @@ func TestContentProvider_LoadMarkdownWithFrontmatter_Errors(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestContentProvider_LoadMarkdownWithFrontmatter_ReadError(t *testing.T) {
+	p := NewContentProvider(t.TempDir())
+	_, err := p.LoadMarkdownWithFrontmatter("missing.md")
+	require.Error(t, err)
 }
 
 func TestContentProvider_GetPath(t *testing.T) {

--- a/internal/domain/content.go
+++ b/internal/domain/content.go
@@ -1,0 +1,35 @@
+package domain
+
+type SourceDocument struct {
+	ID            string
+	URI           string
+	Name          string
+	Description   string
+	MIMEType      string
+	FilePath      string
+	RelativePath  string
+	Content       string
+	Fingerprint   string
+	BodyStartLine int
+	Keywords      []string
+	PathLabels    []string
+}
+
+type Chunk struct {
+	ID              string   `json:"chunk_id"`
+	SourceID        string   `json:"source_id"`
+	SourceURI       string   `json:"source_uri"`
+	ChunkURI        string   `json:"chunk_uri"`
+	SourceTitle     string   `json:"source_title"`
+	SourcePath      string   `json:"source_path"`
+	PathLabels      []string `json:"path_labels"`
+	HeadingPath     []string `json:"heading_path"`
+	SectionFragment string   `json:"section_fragment"`
+	Fragment        string   `json:"fragment"`
+	Part            int      `json:"part"`
+	PartCount       int      `json:"part_count"`
+	StartLine       int      `json:"start_line"`
+	EndLine         int      `json:"end_line"`
+	Content         string   `json:"content"`
+	Keywords        []string `json:"keywords,omitempty"`
+}


### PR DESCRIPTION
## Summary
Add shared repository Markdown parsing and source/chunk domain contracts while preserving the legacy frontmatter-loading interface used by resources and prompts.

## Changes
- Parse optional or required YAML frontmatter through a Goldmark GFM AST and derive source metadata deterministically.
- Add stable source-document and chunk contracts for later discovery, chunking, and search tasks.
- Preserve existing required-frontmatter behavior for legacy content-provider callers.