### PR TITLE
feat(content): [3/9] split markdown into stable chunks

### DIFF
--- a/internal/content/chunker.go
+++ b/internal/content/chunker.go
@@ -1,0 +1,302 @@
+package content
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/sha1n/mcp-acdc-server/internal/domain"
+	"github.com/yuin/goldmark/ast"
+)
+
+const maxChunkRunes = 4000
+
+type markdownBlock struct {
+	start int
+	stop  int
+	line  int
+	end   int
+	kind  ast.NodeKind
+}
+
+type markdownSection struct {
+	headings []string
+	base     string
+	blocks   []markdownBlock
+}
+
+// ChunkMarkdown divides parsed Markdown into stable, heading-aware chunks.
+func ChunkMarkdown(source domain.SourceDocument, parsed *ParsedMarkdown) ([]domain.Chunk, error) {
+	if parsed == nil {
+		return nil, fmt.Errorf("parsed markdown is required")
+	}
+	if parsed.root == nil {
+		return nil, fmt.Errorf("parsed markdown AST is required")
+	}
+
+	sections := []markdownSection{{base: "document"}}
+	current := 0
+	usedFragments := map[string]bool{"document": true}
+	fragmentCounts := map[string]int{"document": 1}
+	var headingStack [6]string
+
+	for node := parsed.root.FirstChild(); node != nil; node = node.NextSibling() {
+		heading, isHeading := node.(*ast.Heading)
+		if isHeading {
+			level := heading.Level
+			if level < 1 || level > len(headingStack) {
+				continue
+			}
+
+			headingStack[level-1] = strings.TrimSpace(nodeText(heading, parsed.Body))
+			for index := level; index < len(headingStack); index++ {
+				headingStack[index] = ""
+			}
+
+			if headingStack[level-1] == "" {
+				continue
+			}
+
+			path := headingPath(headingStack)
+			section := markdownSection{
+				headings: path,
+				base:     allocateFragment(slugifyHeading(headingStack[level-1]), usedFragments, fragmentCounts),
+			}
+			if block, ok := sourceBlock(node, parsed.Body, parsed.BodyStartLine); ok {
+				section.blocks = append(section.blocks, block)
+			}
+			sections = append(sections, section)
+			current = len(sections) - 1
+			continue
+		}
+
+		if block, ok := sourceBlock(node, parsed.Body, parsed.BodyStartLine); ok {
+			sections[current].blocks = append(sections[current].blocks, block)
+		}
+	}
+
+	var chunks []domain.Chunk
+	for _, section := range sections {
+		parts := splitSection(section, parsed.Body)
+		for part, blocks := range parts {
+			start := blocks[0].start
+			stop := blocks[len(blocks)-1].stop
+			fragment := section.base
+			partCount := len(parts)
+			if partCount > 1 {
+				fragment = fmt.Sprintf("%s~%d", section.base, part+1)
+			}
+
+			chunks = append(chunks, domain.Chunk{
+				ID:              source.ID + "#" + fragment,
+				SourceID:        source.ID,
+				SourceURI:       source.URI,
+				ChunkURI:        source.URI + "#" + fragment,
+				SourceTitle:     source.Name,
+				SourcePath:      source.RelativePath,
+				PathLabels:      append([]string(nil), source.PathLabels...),
+				HeadingPath:     append([]string(nil), section.headings...),
+				SectionFragment: section.base,
+				Fragment:        fragment,
+				Part:            part + 1,
+				PartCount:       partCount,
+				StartLine:       blocks[0].line,
+				EndLine:         blocks[len(blocks)-1].end,
+				Content:         string(parsed.Body[start:stop]),
+				Keywords:        append([]string(nil), source.Keywords...),
+			})
+		}
+	}
+
+	return chunks, nil
+}
+
+func headingPath(stack [6]string) []string {
+	path := make([]string, 0, len(stack))
+	for _, heading := range stack {
+		if heading != "" {
+			path = append(path, heading)
+		}
+	}
+	return path
+}
+
+func allocateFragment(base string, used map[string]bool, counts map[string]int) string {
+	if base == "" {
+		base = "section"
+	}
+	if !used[base] {
+		used[base] = true
+		counts[base] = 1
+		return base
+	}
+
+	for suffix := counts[base]; ; suffix++ {
+		candidate := fmt.Sprintf("%s-%d", base, suffix)
+		if !used[candidate] {
+			used[candidate] = true
+			counts[base] = suffix + 1
+			return candidate
+		}
+	}
+}
+
+func splitSection(section markdownSection, source []byte) [][]markdownBlock {
+	if len(section.blocks) == 0 {
+		return nil
+	}
+
+	parts := make([][]markdownBlock, 0, 1)
+	current := make([]markdownBlock, 0, len(section.blocks))
+	for _, block := range section.blocks {
+		start := block.start
+		if len(current) > 0 {
+			start = current[0].start
+		}
+		combinedRunes := utf8.RuneCount(source[start:block.stop])
+		blockRunes := utf8.RuneCount(source[block.start:block.stop])
+		if len(current) > 0 && blockRunes <= maxChunkRunes && combinedRunes > maxChunkRunes {
+			parts = append(parts, current)
+			current = nil
+		}
+		current = append(current, block)
+	}
+	if len(current) > 0 {
+		parts = append(parts, current)
+	}
+	return parts
+}
+
+func sourceBlock(node ast.Node, source []byte, bodyStartLine int) (markdownBlock, bool) {
+	start, stop, ok := nodeSourceRange(node)
+	if !ok {
+		return markdownBlock{}, false
+	}
+
+	start = lineStart(source, start)
+	stop = lineStop(source, stop)
+	if _, fenced := node.(*ast.FencedCodeBlock); fenced {
+		if !isFenceLine(source, start) {
+			start = previousLineStart(source, start)
+		}
+		if stop < len(source) && isFenceLine(source, stop) {
+			stop = lineStop(source, stop)
+		}
+	}
+
+	return markdownBlock{
+		start: start,
+		stop:  stop,
+		line:  sourceLine(source, start) + bodyStartLine - 1,
+		end:   sourceLine(source, stop-1) + bodyStartLine - 1,
+		kind:  node.Kind(),
+	}, true
+}
+
+func nodeSourceRange(node ast.Node) (int, int, bool) {
+	start, stop := 0, 0
+	found := false
+	visit := func(segmentStart, segmentStop int) {
+		if segmentStart >= segmentStop {
+			return
+		}
+		if !found || segmentStart < start {
+			start = segmentStart
+		}
+		if !found || segmentStop > stop {
+			stop = segmentStop
+		}
+		found = true
+	}
+
+	_ = ast.Walk(node, func(descendant ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		if descendant.Type() != ast.TypeInline {
+			for index := 0; index < descendant.Lines().Len(); index++ {
+				segment := descendant.Lines().At(index)
+				visit(segment.Start, segment.Stop)
+			}
+		}
+		if textNode, ok := descendant.(*ast.Text); ok {
+			visit(textNode.Segment.Start, textNode.Segment.Stop)
+		}
+		return ast.WalkContinue, nil
+	})
+	return start, stop, found
+}
+
+func lineStart(source []byte, offset int) int {
+	for offset > 0 && source[offset-1] != '\n' {
+		offset--
+	}
+	return offset
+}
+
+func previousLineStart(source []byte, offset int) int {
+	start := lineStart(source, offset)
+	if start == 0 {
+		return 0
+	}
+	return lineStart(source, start-1)
+}
+
+func lineStop(source []byte, offset int) int {
+	for offset < len(source) && source[offset] != '\n' {
+		offset++
+	}
+	if offset < len(source) {
+		offset++
+	}
+	return offset
+}
+
+func sourceLine(source []byte, offset int) int {
+	if offset < 0 {
+		return 1
+	}
+	if offset > len(source) {
+		offset = len(source)
+	}
+	return bytes.Count(source[:offset], []byte("\n")) + 1
+}
+
+func isFenceLine(source []byte, offset int) bool {
+	for offset < len(source) && source[offset] == ' ' {
+		offset++
+	}
+	if offset >= len(source) || (source[offset] != '`' && source[offset] != '~') {
+		return false
+	}
+	fence := source[offset]
+	count := 0
+	for offset < len(source) && source[offset] == fence {
+		count++
+		offset++
+	}
+	return count >= 3
+}
+
+func slugifyHeading(value string) string {
+	var slug strings.Builder
+	separator := false
+	for _, character := range strings.ToLower(strings.TrimSpace(value)) {
+		switch {
+		case unicode.IsLetter(character), unicode.IsNumber(character):
+			if separator && slug.Len() > 0 {
+				slug.WriteByte('-')
+			}
+			slug.WriteRune(character)
+			separator = false
+		case unicode.IsSpace(character), character == '-', character == '_':
+			separator = slug.Len() > 0
+		}
+	}
+	if slug.Len() == 0 {
+		return "section"
+	}
+	return slug.String()
+}

--- a/internal/content/chunker.go
+++ b/internal/content/chunker.go
@@ -157,9 +157,12 @@ func splitSection(section markdownSection, source []byte) [][]markdownBlock {
 		}
 		combinedRunes := utf8.RuneCount(source[start:block.stop])
 		blockRunes := utf8.RuneCount(source[block.start:block.stop])
-		if len(current) > 0 && blockRunes <= maxChunkRunes && combinedRunes > maxChunkRunes {
-			parts = append(parts, current)
-			current = nil
+		if len(current) > 0 && combinedRunes > maxChunkRunes {
+			keepHeadingWithOversizedBlock := blockRunes > maxChunkRunes && len(current) == 1 && current[0].kind == ast.KindHeading
+			if !keepHeadingWithOversizedBlock {
+				parts = append(parts, current)
+				current = nil
+			}
 		}
 		current = append(current, block)
 	}
@@ -172,7 +175,11 @@ func splitSection(section markdownSection, source []byte) [][]markdownBlock {
 func sourceBlock(node ast.Node, source []byte, bodyStartLine int) (markdownBlock, bool) {
 	start, stop, ok := nodeSourceRange(node)
 	if !ok {
-		return markdownBlock{}, false
+		start = node.Pos()
+		if start < 0 {
+			return markdownBlock{}, false
+		}
+		stop = start
 	}
 
 	start = lineStart(source, start)
@@ -184,6 +191,9 @@ func sourceBlock(node ast.Node, source []byte, bodyStartLine int) (markdownBlock
 		if stop < len(source) && isFenceLine(source, stop) {
 			stop = lineStop(source, stop)
 		}
+	}
+	if _, isHeading := node.(*ast.Heading); isHeading && !isATXHeadingLine(source, start) && isSetextUnderline(source, stop) {
+		stop = lineStop(source, stop)
 	}
 
 	return markdownBlock{
@@ -278,6 +288,27 @@ func isFenceLine(source []byte, offset int) bool {
 		offset++
 	}
 	return count >= 3
+}
+
+func isATXHeadingLine(source []byte, offset int) bool {
+	for offset < len(source) && source[offset] == ' ' {
+		offset++
+	}
+	return offset < len(source) && source[offset] == '#'
+}
+
+func isSetextUnderline(source []byte, offset int) bool {
+	lineEnd := lineStop(source, offset)
+	line := strings.TrimSpace(string(source[offset:lineEnd]))
+	if line == "" || (line[0] != '=' && line[0] != '-') {
+		return false
+	}
+	for index := 1; index < len(line); index++ {
+		if line[index] != line[0] {
+			return false
+		}
+	}
+	return true
 }
 
 func slugifyHeading(value string) string {

--- a/internal/content/chunker.go
+++ b/internal/content/chunker.go
@@ -46,10 +46,6 @@ func ChunkMarkdown(source domain.SourceDocument, parsed *ParsedMarkdown) ([]doma
 		heading, isHeading := node.(*ast.Heading)
 		if isHeading {
 			level := heading.Level
-			if level < 1 || level > len(headingStack) {
-				continue
-			}
-
 			headingStack[level-1] = strings.TrimSpace(nodeText(heading, parsed.Body))
 			for index := level; index < len(headingStack); index++ {
 				headingStack[index] = ""
@@ -64,17 +60,13 @@ func ChunkMarkdown(source domain.SourceDocument, parsed *ParsedMarkdown) ([]doma
 				headings: path,
 				base:     allocateFragment(slugifyHeading(headingStack[level-1]), usedFragments, fragmentCounts),
 			}
-			if block, ok := sourceBlock(node, parsed.Body, parsed.BodyStartLine); ok {
-				section.blocks = append(section.blocks, block)
-			}
+			section.blocks = append(section.blocks, sourceBlock(node, parsed.Body, parsed.BodyStartLine))
 			sections = append(sections, section)
 			current = len(sections) - 1
 			continue
 		}
 
-		if block, ok := sourceBlock(node, parsed.Body, parsed.BodyStartLine); ok {
-			sections[current].blocks = append(sections[current].blocks, block)
-		}
+		sections[current].blocks = append(sections[current].blocks, sourceBlock(node, parsed.Body, parsed.BodyStartLine))
 	}
 
 	var chunks []domain.Chunk
@@ -136,9 +128,6 @@ func headingPath(stack [6]string) []string {
 }
 
 func allocateFragment(base string, used map[string]bool, counts map[string]int) string {
-	if base == "" {
-		base = "section"
-	}
 	if !used[base] {
 		used[base] = true
 		counts[base] = 1
@@ -156,10 +145,6 @@ func allocateFragment(base string, used map[string]bool, counts map[string]int) 
 }
 
 func splitSection(section markdownSection, source []byte) [][]markdownBlock {
-	if len(section.blocks) == 0 {
-		return nil
-	}
-
 	parts := make([][]markdownBlock, 0, 1)
 	current := make([]markdownBlock, 0, len(section.blocks))
 	for _, block := range section.blocks {
@@ -184,13 +169,10 @@ func splitSection(section markdownSection, source []byte) [][]markdownBlock {
 	return parts
 }
 
-func sourceBlock(node ast.Node, source []byte, bodyStartLine int) (markdownBlock, bool) {
+func sourceBlock(node ast.Node, source []byte, bodyStartLine int) markdownBlock {
 	start, stop, ok := nodeSourceRange(node)
 	if !ok {
 		start = node.Pos()
-		if start < 0 {
-			return markdownBlock{}, false
-		}
 		stop = start
 	}
 
@@ -204,7 +186,7 @@ func sourceBlock(node ast.Node, source []byte, bodyStartLine int) (markdownBlock
 			stop = lineStop(source, stop)
 		}
 	}
-	if _, isHeading := node.(*ast.Heading); isHeading && !isATXHeadingLine(source, start) && isSetextUnderline(source, stop) {
+	if _, isHeading := node.(*ast.Heading); isHeading && !isATXHeadingLine(source, start) {
 		stop = lineStop(source, stop)
 	}
 
@@ -214,7 +196,7 @@ func sourceBlock(node ast.Node, source []byte, bodyStartLine int) (markdownBlock
 		line:  sourceLine(source, start) + bodyStartLine - 1,
 		end:   sourceLine(source, stop-1) + bodyStartLine - 1,
 		kind:  node.Kind(),
-	}, true
+	}
 }
 
 func nodeSourceRange(node ast.Node) (int, int, bool) {
@@ -260,9 +242,6 @@ func lineStart(source []byte, offset int) int {
 
 func previousLineStart(source []byte, offset int) int {
 	start := lineStart(source, offset)
-	if start == 0 {
-		return 0
-	}
 	return lineStart(source, start-1)
 }
 
@@ -277,12 +256,6 @@ func lineStop(source []byte, offset int) int {
 }
 
 func sourceLine(source []byte, offset int) int {
-	if offset < 0 {
-		return 1
-	}
-	if offset > len(source) {
-		offset = len(source)
-	}
 	return bytes.Count(source[:offset], []byte("\n")) + 1
 }
 
@@ -307,20 +280,6 @@ func isATXHeadingLine(source []byte, offset int) bool {
 		offset++
 	}
 	return offset < len(source) && source[offset] == '#'
-}
-
-func isSetextUnderline(source []byte, offset int) bool {
-	lineEnd := lineStop(source, offset)
-	line := strings.TrimSpace(string(source[offset:lineEnd]))
-	if line == "" || (line[0] != '=' && line[0] != '-') {
-		return false
-	}
-	for index := 1; index < len(line); index++ {
-		if line[index] != line[0] {
-			return false
-		}
-	}
-	return true
 }
 
 func slugifyHeading(value string) string {

--- a/internal/content/chunker.go
+++ b/internal/content/chunker.go
@@ -79,6 +79,9 @@ func ChunkMarkdown(source domain.SourceDocument, parsed *ParsedMarkdown) ([]doma
 
 	var chunks []domain.Chunk
 	for _, section := range sections {
+		if !sectionHasContent(section) {
+			continue
+		}
 		parts := splitSection(section, parsed.Body)
 		for part, blocks := range parts {
 			start := blocks[0].start
@@ -111,6 +114,15 @@ func ChunkMarkdown(source domain.SourceDocument, parsed *ParsedMarkdown) ([]doma
 	}
 
 	return chunks, nil
+}
+
+func sectionHasContent(section markdownSection) bool {
+	for _, block := range section.blocks {
+		if block.kind != ast.KindHeading {
+			return true
+		}
+	}
+	return false
 }
 
 func headingPath(stack [6]string) []string {
@@ -313,21 +325,28 @@ func isSetextUnderline(source []byte, offset int) bool {
 
 func slugifyHeading(value string) string {
 	var slug strings.Builder
-	separator := false
+	whitespace := false
 	for _, character := range strings.ToLower(strings.TrimSpace(value)) {
 		switch {
 		case unicode.IsLetter(character), unicode.IsNumber(character):
-			if separator && slug.Len() > 0 {
+			if whitespace && slug.Len() > 0 {
 				slug.WriteByte('-')
 			}
 			slug.WriteRune(character)
-			separator = false
-		case unicode.IsSpace(character), character == '-', character == '_':
-			separator = slug.Len() > 0
+			whitespace = false
+		case character == '-', character == '_':
+			if whitespace && slug.Len() > 0 {
+				slug.WriteByte('-')
+			}
+			slug.WriteRune(character)
+			whitespace = false
+		case unicode.IsSpace(character):
+			whitespace = slug.Len() > 0
 		}
 	}
-	if slug.Len() == 0 {
+	normalized := strings.Trim(slug.String(), "-_")
+	if normalized == "" {
 		return "section"
 	}
-	return slug.String()
+	return normalized
 }

--- a/internal/content/chunker_test.go
+++ b/internal/content/chunker_test.go
@@ -83,7 +83,7 @@ func TestChunkMarkdown_PreservesBlocksWithoutDescendantSegments(t *testing.T) {
 		},
 		{
 			name: "setext underline",
-			raw:  []byte("Heading\n=======\n"),
+			raw:  []byte("Heading\n=======\n\nBody.\n"),
 			want: "=======",
 		},
 	}
@@ -188,6 +188,182 @@ func TestChunkMarkdown_HeadingIDsDoNotDependOnBodyText(t *testing.T) {
 	require.Equal(t, chunkFragments(original), chunkFragments(changed))
 	require.Equal(t, chunkIDs(original), chunkIDs(changed))
 	require.Equal(t, chunkURIs(original), chunkURIs(changed))
+}
+
+func TestChunkMarkdown_PopulatesCompleteChunkContract(t *testing.T) {
+	raw := []byte("# Guide\n\nBody.\n")
+	parsed, err := ParseMarkdown(raw, FrontmatterOptional)
+	require.NoError(t, err)
+	source := domain.SourceDocument{
+		ID:           "source-1",
+		URI:          "acdc://guide",
+		Name:         "Guide title",
+		RelativePath: "docs/guide.md",
+		PathLabels:   []string{"docs", "guide"},
+		Keywords:     []string{"alpha", "beta"},
+	}
+
+	chunks, err := ChunkMarkdown(source, parsed)
+	require.NoError(t, err)
+	require.Equal(t, []domain.Chunk{{
+		ID:              "source-1#guide",
+		SourceID:        "source-1",
+		SourceURI:       "acdc://guide",
+		ChunkURI:        "acdc://guide#guide",
+		SourceTitle:     "Guide title",
+		SourcePath:      "docs/guide.md",
+		PathLabels:      []string{"docs", "guide"},
+		HeadingPath:     []string{"Guide"},
+		SectionFragment: "guide",
+		Fragment:        "guide",
+		Part:            1,
+		PartCount:       1,
+		StartLine:       1,
+		EndLine:         3,
+		Content:         "# Guide\n\nBody.\n",
+		Keywords:        []string{"alpha", "beta"},
+	}}, chunks)
+}
+
+func TestChunkMarkdown_OmitsEmptyLogicalSections(t *testing.T) {
+	raw := []byte("# Parent\n## Child\nBody.\n")
+	chunks := chunkMarkdownForTest(t, raw)
+
+	require.Equal(t, []string{"child"}, chunkFragments(chunks))
+	require.Equal(t, []string{"Parent", "Child"}, chunks[0].HeadingPath)
+	require.Equal(t, "## Child\nBody.\n", chunks[0].Content)
+}
+
+func TestChunkMarkdown_EmptyDocumentProducesNoChunks(t *testing.T) {
+	chunks := chunkMarkdownForTest(t, nil)
+
+	require.Empty(t, chunks)
+}
+
+func TestChunkMarkdown_GreedilySplitsExactSourceRanges(t *testing.T) {
+	first := strings.Repeat("a", 1500)
+	second := strings.Repeat("b", 1500)
+	third := strings.Repeat("c", 1500)
+	raw := []byte("# Large\n\n" + first + "\n\n" + second + "\n\n" + third + "\n")
+
+	chunks := chunkMarkdownForTest(t, raw)
+
+	require.Len(t, chunks, 2)
+	require.Equal(t, "# Large\n\n"+first+"\n\n"+second+"\n", chunks[0].Content)
+	require.Equal(t, third+"\n", chunks[1].Content)
+	require.Equal(t, []string{"large~1", "large~2"}, chunkFragments(chunks))
+	require.Equal(t, 1, chunks[0].Part)
+	require.Equal(t, 2, chunks[1].Part)
+	require.Equal(t, 2, chunks[0].PartCount)
+	require.Equal(t, 2, chunks[1].PartCount)
+	require.Equal(t, 1, chunks[0].StartLine)
+	require.Equal(t, 5, chunks[0].EndLine)
+	require.Equal(t, 7, chunks[1].StartLine)
+	require.Equal(t, 7, chunks[1].EndLine)
+}
+
+func TestChunkMarkdown_DocumentChunksUseSourceTitleOutsideHeadingPath(t *testing.T) {
+	raw := []byte("Body.\n")
+	parsed, err := ParseMarkdown(raw, FrontmatterOptional)
+	require.NoError(t, err)
+	source := domain.SourceDocument{ID: "source", URI: "acdc://guide", Name: "Guide"}
+
+	chunks, err := ChunkMarkdown(source, parsed)
+	require.NoError(t, err)
+	require.Len(t, chunks, 1)
+	require.Empty(t, chunks[0].HeadingPath)
+	require.Equal(t, "Guide", chunks[0].SourceTitle)
+}
+
+func TestChunkMarkdown_NormalizesStablePublicFragments(t *testing.T) {
+	raw := []byte("# API_Key\nOne.\n\n# *Résumé* Guide\nTwo.\n\n# API--Key\nThree.\n\n# API\nFour.\n\n# API-1\nFive.\n\n# API\nSix.\n")
+
+	chunks := chunkMarkdownForTest(t, raw)
+
+	wantFragments := []string{"api_key", "résumé-guide", "api--key", "api", "api-1", "api-2"}
+	require.Equal(t, wantFragments, chunkFragments(chunks))
+	for index, fragment := range wantFragments {
+		require.Equal(t, "acdc://stable#"+fragment, chunks[index].ID)
+		require.Equal(t, "acdc://stable#"+fragment, chunks[index].ChunkURI)
+	}
+}
+
+func TestChunkMarkdown_UsesUnicodeCodePointSoftLimit(t *testing.T) {
+	first := strings.Repeat("é", 1999)
+	exactSecond := strings.Repeat("界", 1998)
+	aboveSecond := strings.Repeat("界", 1999)
+	exactRaw := []byte(first + "\n\n" + exactSecond + "\n")
+	aboveRaw := []byte(first + "\n\n" + aboveSecond + "\n")
+
+	exact := chunkMarkdownForTest(t, exactRaw)
+	require.Len(t, exact, 1)
+	require.Equal(t, "document", exact[0].Fragment)
+	require.Equal(t, string(exactRaw), exact[0].Content)
+	require.Equal(t, 1, exact[0].PartCount)
+
+	above := chunkMarkdownForTest(t, aboveRaw)
+	require.Len(t, above, 2)
+	require.Equal(t, []string{"document~1", "document~2"}, chunkFragments(above))
+	require.Equal(t, first+"\n", above[0].Content)
+	require.Equal(t, aboveSecond+"\n", above[1].Content)
+	require.Equal(t, 2, above[0].PartCount)
+	require.Equal(t, 2, above[1].PartCount)
+}
+
+func TestChunkMarkdown_KeepsEveryOversizedStructuralBlockIntact(t *testing.T) {
+	long := strings.Repeat("x", 4100)
+	tests := []struct {
+		name string
+		raw  []byte
+	}{
+		{name: "GFM table", raw: []byte("# Table\n\n| value |\n| --- |\n| " + long + " |\n")},
+		{name: "list", raw: []byte("# List\n\n- " + long + "\n")},
+		{name: "tilde fence", raw: []byte("# Fence\n\n~~~text\n" + long + "\n~~~\n")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chunks := chunkMarkdownForTest(t, tt.raw)
+
+			require.Len(t, chunks, 1)
+			require.Equal(t, string(tt.raw), chunks[0].Content)
+			require.Equal(t, 1, chunks[0].Part)
+			require.Equal(t, 1, chunks[0].PartCount)
+			require.Equal(t, 1, chunks[0].StartLine)
+			require.Equal(t, strings.Count(string(tt.raw), "\n"), chunks[0].EndLine)
+		})
+	}
+}
+
+func TestChunkMarkdown_ResetsHeadingHierarchyAcrossLevelChanges(t *testing.T) {
+	raw := []byte("# A\nA body.\n\n### C\nC body.\n\n## B\nB body.\n\n# D\nD body.\n")
+
+	chunks := chunkMarkdownForTest(t, raw)
+
+	require.Equal(t, []string{"a", "c", "b", "d"}, chunkFragments(chunks))
+	require.Equal(t, []string{"A"}, chunks[0].HeadingPath)
+	require.Equal(t, []string{"A", "C"}, chunks[1].HeadingPath)
+	require.Equal(t, []string{"A", "B"}, chunks[2].HeadingPath)
+	require.Equal(t, []string{"D"}, chunks[3].HeadingPath)
+}
+
+func TestChunkMarkdown_InvalidParsedInputReturnsError(t *testing.T) {
+	tests := []struct {
+		name   string
+		parsed *ParsedMarkdown
+	}{
+		{name: "nil parsed markdown", parsed: nil},
+		{name: "missing AST", parsed: &ParsedMarkdown{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chunks, err := ChunkMarkdown(domain.SourceDocument{}, tt.parsed)
+
+			require.Nil(t, chunks)
+			require.Error(t, err)
+		})
+	}
 }
 
 func chunkMarkdownForTest(t *testing.T, raw []byte) []domain.Chunk {

--- a/internal/content/chunker_test.go
+++ b/internal/content/chunker_test.go
@@ -1,0 +1,163 @@
+package content
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sha1n/mcp-acdc-server/internal/domain"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChunkMarkdown_HeadingHierarchyAndStableFragments(t *testing.T) {
+	raw := []byte("Intro.\n\n# Configuration\nParent text.\n\n## Authentication\nAPI keys.\n\n## Authentication\nTokens.\n")
+	parsed, err := ParseMarkdown(raw, FrontmatterOptional)
+	require.NoError(t, err)
+	source, err := BuildSourceDocument(parsed, SourceOptions{URI: "acdc://docs/config", RelativePath: "docs/config.md", Raw: raw})
+	require.NoError(t, err)
+
+	chunks, err := ChunkMarkdown(source, parsed)
+	require.NoError(t, err)
+	require.Equal(t, []string{"document", "configuration", "authentication", "authentication-1"}, chunkFragments(chunks))
+	require.Equal(t, []string{"Configuration", "Authentication"}, chunks[2].HeadingPath)
+	require.Equal(t, "acdc://docs/config#authentication", chunks[2].ChunkURI)
+	require.Equal(t, 6, chunks[2].StartLine)
+}
+
+func TestChunkMarkdown_SplitsOversizedSectionsAtBlockBoundaries(t *testing.T) {
+	firstParagraph := strings.Repeat("a", 2100)
+	secondParagraph := strings.Repeat("b", 2100)
+	raw := []byte("# Large\n\n" + firstParagraph + "\n\n" + secondParagraph + "\n")
+	parsed, err := ParseMarkdown(raw, FrontmatterOptional)
+	require.NoError(t, err)
+	source, err := BuildSourceDocument(parsed, SourceOptions{URI: "acdc://large", RelativePath: "docs/large.md", Raw: raw})
+	require.NoError(t, err)
+
+	chunks, err := ChunkMarkdown(source, parsed)
+	require.NoError(t, err)
+	require.Len(t, chunks, 2)
+	require.Equal(t, []string{"large~1", "large~2"}, chunkFragments(chunks))
+	require.Equal(t, 2, chunks[0].PartCount)
+	require.NotContains(t, chunks[0].Content, chunks[1].Content)
+}
+
+func TestChunkMarkdown_KeepsIndivisibleBlocks(t *testing.T) {
+	code := "```text\n" + strings.Repeat("x", 5000) + "\n```"
+	raw := []byte("# Example\n\n" + code)
+	parsed, err := ParseMarkdown(raw, FrontmatterOptional)
+	require.NoError(t, err)
+	source, err := BuildSourceDocument(parsed, SourceOptions{URI: "acdc://example", RelativePath: "docs/example.md", Raw: raw})
+	require.NoError(t, err)
+	chunks, err := ChunkMarkdown(source, parsed)
+	require.NoError(t, err)
+	require.Len(t, chunks, 1)
+	require.Contains(t, chunks[0].Content, "```")
+}
+
+func TestChunkMarkdown_StructuralEdgeCases(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       []byte
+		fragments []string
+		assert    func(t *testing.T, chunks []domain.Chunk)
+	}{
+		{
+			name:      "headingless document",
+			raw:       []byte("First paragraph.\n\nSecond paragraph.\n"),
+			fragments: []string{"document"},
+			assert: func(t *testing.T, chunks []domain.Chunk) {
+				require.Empty(t, chunks[0].HeadingPath)
+				require.Equal(t, 1, chunks[0].StartLine)
+			},
+		},
+		{
+			name:      "empty heading with child",
+			raw:       []byte("#\n\n## Child\nBody.\n"),
+			fragments: []string{"child"},
+			assert: func(t *testing.T, chunks []domain.Chunk) {
+				require.Equal(t, []string{"Child"}, chunks[0].HeadingPath)
+			},
+		},
+		{
+			name:      "GFM table and list stay intact",
+			raw:       []byte("# GFM\n\n- first\n- second\n\n| name | value |\n| --- | --- |\n| one | two |\n"),
+			fragments: []string{"gfm"},
+			assert: func(t *testing.T, chunks []domain.Chunk) {
+				require.Contains(t, chunks[0].Content, "- first\n- second")
+				require.Contains(t, chunks[0].Content, "| name | value |")
+			},
+		},
+		{
+			name:      "CRLF frontmatter adjusts source lines",
+			raw:       []byte("---\r\nname: Example\r\n---\r\n# Title\r\n\r\nBody.\r\n"),
+			fragments: []string{"title"},
+			assert: func(t *testing.T, chunks []domain.Chunk) {
+				require.Equal(t, 4, chunks[0].StartLine)
+				require.Equal(t, 6, chunks[0].EndLine)
+			},
+		},
+		{
+			name:      "empty slug falls back to section",
+			raw:       []byte("# !!!\nBody.\n"),
+			fragments: []string{"section"},
+			assert:    func(*testing.T, []domain.Chunk) {},
+		},
+		{
+			name:      "document fragment is reserved",
+			raw:       []byte("# Document\nBody.\n"),
+			fragments: []string{"document-1"},
+			assert:    func(*testing.T, []domain.Chunk) {},
+		},
+		{
+			name:      "line ranges are inclusive",
+			raw:       []byte("# Title\n\nFirst.\n\nSecond.\n"),
+			fragments: []string{"title"},
+			assert: func(t *testing.T, chunks []domain.Chunk) {
+				require.Equal(t, 1, chunks[0].StartLine)
+				require.Equal(t, 5, chunks[0].EndLine)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed, err := ParseMarkdown(tt.raw, FrontmatterOptional)
+			require.NoError(t, err)
+			source, err := BuildSourceDocument(parsed, SourceOptions{URI: "acdc://test", RelativePath: "docs/test.md", Raw: tt.raw})
+			require.NoError(t, err)
+
+			chunks, err := ChunkMarkdown(source, parsed)
+			require.NoError(t, err)
+			require.Equal(t, tt.fragments, chunkFragments(chunks))
+			tt.assert(t, chunks)
+		})
+	}
+}
+
+func TestChunkMarkdown_HeadingIDsDoNotDependOnBodyText(t *testing.T) {
+	raw := []byte("# Stable\nOriginal body.\n\n## Child\nOriginal child body.\n")
+	edited := []byte("# Stable\nEdited body with different words.\n\n## Child\nAlso edited.\n")
+
+	original := chunkMarkdownForTest(t, raw)
+	changed := chunkMarkdownForTest(t, edited)
+
+	require.Equal(t, chunkFragments(original), chunkFragments(changed))
+}
+
+func chunkMarkdownForTest(t *testing.T, raw []byte) []domain.Chunk {
+	t.Helper()
+	parsed, err := ParseMarkdown(raw, FrontmatterOptional)
+	require.NoError(t, err)
+	source, err := BuildSourceDocument(parsed, SourceOptions{URI: "acdc://stable", RelativePath: "docs/stable.md", Raw: raw})
+	require.NoError(t, err)
+	chunks, err := ChunkMarkdown(source, parsed)
+	require.NoError(t, err)
+	return chunks
+}
+
+func chunkFragments(chunks []domain.Chunk) []string {
+	fragments := make([]string, len(chunks))
+	for index, chunk := range chunks {
+		fragments[index] = chunk.Fragment
+	}
+	return fragments
+}

--- a/internal/content/chunker_test.go
+++ b/internal/content/chunker_test.go
@@ -276,16 +276,28 @@ func TestChunkMarkdown_DocumentChunksUseSourceTitleOutsideHeadingPath(t *testing
 }
 
 func TestChunkMarkdown_NormalizesStablePublicFragments(t *testing.T) {
-	raw := []byte("# API_Key\nOne.\n\n# *Résumé* Guide\nTwo.\n\n# API--Key\nThree.\n\n# API\nFour.\n\n# API-1\nFive.\n\n# API\nSix.\n")
+	raw := []byte("# API_Key\nOne.\n\n# *Résumé* Guide\nTwo.\n\n# API--Key\nThree.\n\n# API - Key\nFour.\n\n# API\nFive.\n\n# API-1\nSix.\n\n# API\nSeven.\n")
 
 	chunks := chunkMarkdownForTest(t, raw)
 
-	wantFragments := []string{"api_key", "résumé-guide", "api--key", "api", "api-1", "api-2"}
+	wantFragments := []string{"api_key", "résumé-guide", "api--key", "api---key", "api", "api-1", "api-2"}
 	require.Equal(t, wantFragments, chunkFragments(chunks))
 	for index, fragment := range wantFragments {
 		require.Equal(t, "acdc://stable#"+fragment, chunks[index].ID)
 		require.Equal(t, "acdc://stable#"+fragment, chunks[index].ChunkURI)
 	}
+}
+
+func TestChunkMarkdown_PreservesIndentedCommonMarkSyntax(t *testing.T) {
+	raw := []byte("  # Heading\n\n  ~~~text\ncontent\n  ~~~\n")
+
+	chunks := chunkMarkdownForTest(t, raw)
+
+	require.Len(t, chunks, 1)
+	require.Equal(t, "heading", chunks[0].Fragment)
+	require.Equal(t, string(raw), chunks[0].Content)
+	require.Equal(t, 1, chunks[0].StartLine)
+	require.Equal(t, 5, chunks[0].EndLine)
 }
 
 func TestChunkMarkdown_UsesUnicodeCodePointSoftLimit(t *testing.T) {

--- a/internal/content/chunker_test.go
+++ b/internal/content/chunker_test.go
@@ -53,6 +53,51 @@ func TestChunkMarkdown_KeepsIndivisibleBlocks(t *testing.T) {
 	require.Contains(t, chunks[0].Content, "```")
 }
 
+func TestChunkMarkdown_SplitsBeforeOversizedBlockAfterPriorBody(t *testing.T) {
+	raw := []byte("# Example\n\nShort paragraph.\n\n```text\n" + strings.Repeat("x", 5000) + "\n```\n")
+
+	chunks := chunkMarkdownForTest(t, raw)
+
+	require.Len(t, chunks, 2)
+	require.Equal(t, []string{"example~1", "example~2"}, chunkFragments(chunks))
+	require.Contains(t, chunks[0].Content, "Short paragraph.")
+	require.NotContains(t, chunks[0].Content, "```")
+	require.Contains(t, chunks[1].Content, "```")
+}
+
+func TestChunkMarkdown_PreservesBlocksWithoutDescendantSegments(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  []byte
+		want string
+	}{
+		{
+			name: "trailing thematic break",
+			raw:  []byte("# Heading\n\n---\n"),
+			want: "---",
+		},
+		{
+			name: "empty fenced block",
+			raw:  []byte("# Heading\n\n```\n```\n"),
+			want: "```\n```",
+		},
+		{
+			name: "setext underline",
+			raw:  []byte("Heading\n=======\n"),
+			want: "=======",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chunks := chunkMarkdownForTest(t, tt.raw)
+
+			require.Len(t, chunks, 1)
+			require.Contains(t, chunks[0].Content, tt.want)
+		})
+	}
+}
+
 func TestChunkMarkdown_StructuralEdgeCases(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -141,6 +186,8 @@ func TestChunkMarkdown_HeadingIDsDoNotDependOnBodyText(t *testing.T) {
 	changed := chunkMarkdownForTest(t, edited)
 
 	require.Equal(t, chunkFragments(original), chunkFragments(changed))
+	require.Equal(t, chunkIDs(original), chunkIDs(changed))
+	require.Equal(t, chunkURIs(original), chunkURIs(changed))
 }
 
 func chunkMarkdownForTest(t *testing.T, raw []byte) []domain.Chunk {
@@ -160,4 +207,20 @@ func chunkFragments(chunks []domain.Chunk) []string {
 		fragments[index] = chunk.Fragment
 	}
 	return fragments
+}
+
+func chunkIDs(chunks []domain.Chunk) []string {
+	ids := make([]string, len(chunks))
+	for index, chunk := range chunks {
+		ids[index] = chunk.ID
+	}
+	return ids
+}
+
+func chunkURIs(chunks []domain.Chunk) []string {
+	uris := make([]string, len(chunks))
+	for index, chunk := range chunks {
+		uris[index] = chunk.ChunkURI
+	}
+	return uris
 }


### PR DESCRIPTION
## Summary

Add deterministic heading-aware Markdown chunking for chunk-level search while preserving source content and stable identities.

## Changes
- Allocate stable section fragments from visible heading text, preserving Unicode letters and numbers, underscores, and hyphens while resolving collisions in source order.
- Keep heading paths limited to authored Markdown structure and omit empty logical sections without losing ancestor context on descendant chunks.
- Split at Markdown block boundaries with a soft 4,000-code-point limit while keeping fences, tables, and lists indivisible.
- Preserve original content, inclusive source line ranges, source provenance, and part metadata.