### PR TITLE
feat(resources): [4/9] discover and retrieve configured chunks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26
 
 require (
 	github.com/blevesearch/bleve/v2 v2.6.0
+	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -148,6 +148,8 @@ github.com/blevesearch/zapx/v17 v17.1.2 h1:avbOk2igaASNoiy0BE/jPgcxAnRI2PGeydeP4
 github.com/blevesearch/zapx/v17 v17.1.2/go.mod h1:WQObxKrqUX7cd0G1GMvDfc/bmZzQvoy7APOPimx7DiI=
 github.com/blizzy78/varnamelen v0.8.0 h1:oqSblyuQvFsW1hbBHh1zfwrKe3kcSj0rnXkKzsQ089M=
 github.com/blizzy78/varnamelen v0.8.0/go.mod h1:V9TzQZ4fLJ1DSrjVDfl89H7aMnTvKkApdHeyESmyR7k=
+github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
+github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bombsimon/wsl/v4 v4.7.0 h1:1Ilm9JBPRczjyUs6hvOPKvd7VL1Q++PL8M0SXBDf+jQ=
 github.com/bombsimon/wsl/v4 v4.7.0/go.mod h1:uV/+6BkffuzSAVYD+yGyld1AChO7/EuLrCF/8xTiapg=
 github.com/bombsimon/wsl/v5 v5.6.0 h1:4z+/sBqC5vUmSp1O0mS+czxwH9+LKXtCWtHH9rZGQL8=

--- a/internal/app/factory.go
+++ b/internal/app/factory.go
@@ -39,7 +39,7 @@ func CreateMCPServer(settings *config.Settings) (*mcpsdk.Server, func(), error) 
 	}
 
 	// Discover resources
-	resourceDefinitions, err := resources.DiscoverResources(cp, settings.Scheme)
+	discovery, err := resources.Discover(context.Background(), cp, metadata.Index, settings.Scheme)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to discover resources: %w", err)
 	}
@@ -47,10 +47,13 @@ func CreateMCPServer(settings *config.Settings) (*mcpsdk.Server, func(), error) 
 	var resourceOpts []resources.Option
 	if settings.CrossRef {
 		resourceOpts = append(resourceOpts, resources.WithTransformer(
-			resources.NewCrossRefTransformer(resourceDefinitions, settings.Scheme),
+			resources.NewCrossRefTransformer(discovery.Sources, settings.Scheme),
 		))
 	}
-	resourceProvider := resources.NewResourceProvider(resourceDefinitions, resourceOpts...)
+	resourceProvider, err := resources.NewResourceProvider(discovery.Sources, discovery.Chunks, resourceOpts...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create resource provider: %w", err)
+	}
 
 	// Discover prompts
 	promptDefinitions, err := prompts.DiscoverPrompts(cp)

--- a/internal/app/factory_test.go
+++ b/internal/app/factory_test.go
@@ -389,7 +389,10 @@ func TestCreateMCPServer_CrossRefTransformation_ContentVerification(t *testing.T
 	}
 
 	transformer := resources.NewCrossRefTransformer(defs, "acdc")
-	provider := resources.NewResourceProvider(defs, resources.WithTransformer(transformer))
+	provider, err := resources.NewResourceProvider(defs, nil, resources.WithTransformer(transformer))
+	if err != nil {
+		t.Fatalf("NewResourceProvider error: %v", err)
+	}
 
 	// Read Doc A - should have transformed link to Doc B
 	contentA, err := provider.ReadResource("acdc://doc-a")
@@ -437,7 +440,10 @@ func TestCreateMCPServer_CrossRefDisabledByDefault(t *testing.T) {
 		t.Fatalf("DiscoverResources error: %v", err)
 	}
 
-	provider := resources.NewResourceProvider(defs)
+	provider, err := resources.NewResourceProvider(defs, nil)
+	if err != nil {
+		t.Fatalf("NewResourceProvider error: %v", err)
+	}
 
 	contentA, err := provider.ReadResource("acdc://doc-a")
 	if err != nil {
@@ -475,7 +481,10 @@ func TestCreateMCPServer_CrossRefTransformation_CustomScheme(t *testing.T) {
 	}
 
 	transformer := resources.NewCrossRefTransformer(defs, "myco")
-	provider := resources.NewResourceProvider(defs, resources.WithTransformer(transformer))
+	provider, err := resources.NewResourceProvider(defs, nil, resources.WithTransformer(transformer))
+	if err != nil {
+		t.Fatalf("NewResourceProvider error: %v", err)
+	}
 
 	contentA, err := provider.ReadResource("myco://a")
 	if err != nil {

--- a/internal/app/factory_test.go
+++ b/internal/app/factory_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sha1n/mcp-acdc-server/internal/config"
 	"github.com/sha1n/mcp-acdc-server/internal/content"
 	"github.com/sha1n/mcp-acdc-server/internal/resources"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateMCPServer_Success(t *testing.T) {
@@ -237,6 +238,41 @@ tools: []
 	if server == nil {
 		t.Fatal("Server is nil")
 	}
+}
+
+func TestCreateMCPServer_FailsWhenConfiguredDiscoveryFails(t *testing.T) {
+	contentDir := t.TempDir()
+	metadata := `
+server: { name: test, version: 1.0, instructions: inst }
+tools: []
+index:
+  include: ["docs/**"]
+`
+	require.NoError(t, os.WriteFile(filepath.Join(contentDir, "mcp-metadata.yaml"), []byte(metadata), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(contentDir, "docs"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(contentDir, "docs", "data.txt"), []byte("not markdown"), 0o644))
+
+	_, _, err := CreateMCPServer(&config.Settings{ContentDir: contentDir, Scheme: "acdc", Search: config.SearchSettings{InMemory: true}})
+	require.ErrorContains(t, err, "failed to discover resources")
+	require.ErrorContains(t, err, "configured index selected non-Markdown file")
+}
+
+func TestCreateMCPServer_FailsWhenDiscoveredSourcesShareURI(t *testing.T) {
+	contentDir := t.TempDir()
+	metadata := `
+server: { name: test, version: 1.0, instructions: inst }
+tools: []
+index:
+  include: ["docs/*"]
+`
+	require.NoError(t, os.WriteFile(filepath.Join(contentDir, "mcp-metadata.yaml"), []byte(metadata), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(contentDir, "docs"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(contentDir, "docs", "guide.md"), []byte("# Guide"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(contentDir, "docs", "guide.markdown"), []byte("# Guide duplicate"), 0o644))
+
+	_, _, err := CreateMCPServer(&config.Settings{ContentDir: contentDir, Scheme: "acdc", Search: config.SearchSettings{InMemory: true}})
+	require.ErrorContains(t, err, "failed to create resource provider")
+	require.ErrorContains(t, err, "duplicate source URI: acdc://docs/guide")
 }
 
 func TestCreateMCPServer_InvalidToolMetadata_MissingName(t *testing.T) {

--- a/internal/mcp/server_helpers_test.go
+++ b/internal/mcp/server_helpers_test.go
@@ -23,15 +23,17 @@ func TestMakeResourceHandler_Success(t *testing.T) {
 	err := os.WriteFile(filePath, []byte(resourceContent), 0644)
 	require.NoError(t, err)
 
-	resourceProvider := resources.NewResourceProvider([]resources.ResourceDefinition{
+	resourceProvider, err := resources.NewResourceProvider([]resources.ResourceDefinition{
 		{
 			Name:        "Test Resource",
 			URI:         "acdc://test-resource",
 			Description: "A test resource",
 			MIMEType:    "text/markdown",
 			FilePath:    filePath,
+			Content:     "# Test Content\n\nThis is test content.",
 		},
-	})
+	}, nil)
+	require.NoError(t, err)
 
 	handler := makeResourceHandler(resourceProvider, "acdc://test-resource")
 	require.NotNil(t, handler)
@@ -54,7 +56,8 @@ func TestMakeResourceHandler_Success(t *testing.T) {
 }
 
 func TestMakeResourceHandler_Error_NotFound(t *testing.T) {
-	resourceProvider := resources.NewResourceProvider([]resources.ResourceDefinition{})
+	resourceProvider, err := resources.NewResourceProvider([]resources.ResourceDefinition{}, nil)
+	require.NoError(t, err)
 
 	handler := makeResourceHandler(resourceProvider, "acdc://nonexistent")
 	require.NotNil(t, handler)

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -25,7 +25,10 @@ func TestCreateServer(t *testing.T) {
 		},
 	}
 
-	resourceProvider := resources.NewResourceProvider([]resources.ResourceDefinition{})
+	resourceProvider, err := resources.NewResourceProvider([]resources.ResourceDefinition{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	promptProvider := prompts.NewPromptProvider([]prompts.PromptDefinition{}, nil)
 	searchService := &mockSearcher{}
 

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -44,7 +44,8 @@ func TestToolRegistration(t *testing.T) {
 		t.Error("Search handler should not be nil")
 	}
 
-	resourceProvider := resources.NewResourceProvider([]resources.ResourceDefinition{})
+	resourceProvider, err := resources.NewResourceProvider([]resources.ResourceDefinition{}, nil)
+	require.NoError(t, err)
 	readHandler := NewReadToolHandler(resourceProvider)
 	if readHandler == nil {
 		t.Error("Read handler should not be nil")
@@ -146,15 +147,17 @@ func TestReadToolHandler_Success(t *testing.T) {
 	err := os.WriteFile(filePath, []byte(resourceContent), 0644)
 	require.NoError(t, err)
 
-	resourceProvider := resources.NewResourceProvider([]resources.ResourceDefinition{
+	resourceProvider, err := resources.NewResourceProvider([]resources.ResourceDefinition{
 		{
 			Name:        "Test Resource",
 			URI:         "acdc://test-resource",
 			Description: "A test resource",
 			MIMEType:    "text/markdown",
 			FilePath:    filePath,
+			Content:     "# Test Content\n\nThis is test content.",
 		},
-	})
+	}, nil)
+	require.NoError(t, err)
 
 	handler := NewReadToolHandler(resourceProvider)
 	require.NotNil(t, handler)
@@ -176,7 +179,8 @@ func TestReadToolHandler_Success(t *testing.T) {
 }
 
 func TestReadToolHandler_Error_ResourceNotFound(t *testing.T) {
-	resourceProvider := resources.NewResourceProvider([]resources.ResourceDefinition{})
+	resourceProvider, err := resources.NewResourceProvider([]resources.ResourceDefinition{}, nil)
+	require.NoError(t, err)
 
 	handler := NewReadToolHandler(resourceProvider)
 	ctx := context.Background()

--- a/internal/resources/crossref.go
+++ b/internal/resources/crossref.go
@@ -4,6 +4,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/sha1n/mcp-acdc-server/internal/domain"
 )
 
 // markdownLinkRe matches markdown links including images: ![text](target) and [text](target "title")
@@ -17,10 +19,10 @@ var markdownLinkRe = regexp.MustCompile(`!?\[([^\]]*)\]\(([^)\s]+)(\s+"[^"]*")?\
 // NewCrossRefTransformer creates a ContentTransformer that rewrites relative
 // markdown links to MCP resource URIs. The scheme parameter is used to
 // recognize and skip links that already use the configured URI scheme.
-func NewCrossRefTransformer(definitions []ResourceDefinition, scheme string) ContentTransformer {
-	filePathToURI := make(map[string]string, len(definitions))
-	for _, d := range definitions {
-		filePathToURI[d.FilePath] = d.URI
+func NewCrossRefTransformer(sources []domain.SourceDocument, scheme string) ContentTransformer {
+	filePathToURI := make(map[string]string, len(sources))
+	for _, source := range sources {
+		filePathToURI[source.FilePath] = source.URI
 	}
 
 	schemePrefix := scheme + "://"

--- a/internal/resources/definitions.go
+++ b/internal/resources/definitions.go
@@ -1,5 +1,7 @@
 package resources
 
+import "github.com/sha1n/mcp-acdc-server/internal/domain"
+
 // Field name constants for resource metadata
 const (
 	FieldURI      = "uri"
@@ -8,12 +10,5 @@ const (
 	FieldKeywords = "keywords"
 )
 
-// ResourceDefinition definition of an MCP resource
-type ResourceDefinition struct {
-	URI         string
-	Name        string
-	Description string
-	MIMEType    string
-	FilePath    string
-	Keywords    []string // Optional keywords for search boosting
-}
+// ResourceDefinition is retained as the legacy name for a source document.
+type ResourceDefinition = domain.SourceDocument

--- a/internal/resources/discovery.go
+++ b/internal/resources/discovery.go
@@ -1,0 +1,282 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
+	"github.com/sha1n/mcp-acdc-server/internal/content"
+	"github.com/sha1n/mcp-acdc-server/internal/domain"
+)
+
+// DiscoveryResult is the immutable source and chunk catalog input.
+type DiscoveryResult struct {
+	Sources []domain.SourceDocument
+	Chunks  []domain.Chunk
+}
+
+// Discover loads configured Markdown sources, or legacy mcp-resources when
+// index is nil.
+func Discover(ctx context.Context, cp *content.ContentProvider, index *domain.IndexMetadata, scheme string) (DiscoveryResult, error) {
+	if index == nil {
+		return discoverLegacy(ctx, cp, scheme)
+	}
+
+	patterns, err := validatePatterns(index.Include)
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
+	excludes, err := validatePatterns(index.Exclude)
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
+
+	root, err := canonicalPath(cp.ContentDir)
+	if err != nil {
+		return DiscoveryResult{}, fmt.Errorf("resolve content root: %w", err)
+	}
+
+	var selected []string
+	err = filepath.WalkDir(root, func(filePath string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if entry.Type()&fs.ModeSymlink != 0 || entry.IsDir() {
+			return nil
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+
+		canonicalFile, err := canonicalPath(filePath)
+		if err != nil {
+			return err
+		}
+		if !withinRoot(root, canonicalFile) {
+			return fmt.Errorf("selected file escapes content root: %s", filePath)
+		}
+
+		relativePath, err := filepath.Rel(root, canonicalFile)
+		if err != nil {
+			return err
+		}
+		relativePath = filepath.ToSlash(relativePath)
+		if !matchesAny(patterns, relativePath) || matchesAny(excludes, relativePath) {
+			return nil
+		}
+		selected = append(selected, canonicalFile)
+		return nil
+	})
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
+	if len(selected) == 0 {
+		return DiscoveryResult{}, fmt.Errorf("configured index matched no files")
+	}
+
+	sort.Strings(selected)
+	return buildCatalog(ctx, root, selected, scheme, false)
+}
+
+// DiscoverResources returns legacy mcp-resources definitions for callers that
+// only need source metadata.
+func DiscoverResources(cp *content.ContentProvider, scheme string) ([]ResourceDefinition, error) {
+	result, err := Discover(context.Background(), cp, nil, scheme)
+	if err != nil {
+		return nil, err
+	}
+	return result.Sources, nil
+}
+
+func discoverLegacy(ctx context.Context, cp *content.ContentProvider, scheme string) (DiscoveryResult, error) {
+	root, err := canonicalPath(cp.ResourcesDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return DiscoveryResult{}, nil
+		}
+		return DiscoveryResult{}, fmt.Errorf("resolve resources root: %w", err)
+	}
+
+	var files []string
+	err = filepath.WalkDir(root, func(filePath string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if entry.IsDir() || entry.Type()&fs.ModeSymlink != 0 || !isMarkdown(filePath) {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		files = append(files, filePath)
+		return nil
+	})
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
+	sort.Strings(files)
+
+	result := DiscoveryResult{}
+	for _, filePath := range files {
+		if err := ctx.Err(); err != nil {
+			return DiscoveryResult{}, err
+		}
+		raw, err := os.ReadFile(filePath)
+		if err != nil {
+			slog.Warn("Skipping invalid resource file", "file", filepath.Base(filePath), "error", err)
+			continue
+		}
+		parsed, err := content.ParseMarkdown(raw, content.FrontmatterRequired)
+		if err != nil {
+			slog.Warn("Skipping invalid resource file", "file", filepath.Base(filePath), "error", err)
+			continue
+		}
+		name, _ := parsed.Metadata["name"].(string)
+		description, _ := parsed.Metadata["description"].(string)
+		if name == "" || description == "" {
+			slog.Warn("Skipping resource with missing metadata", "file", filepath.Base(filePath))
+			continue
+		}
+		relativePath, err := filepath.Rel(root, filePath)
+		if err != nil {
+			return DiscoveryResult{}, err
+		}
+		uri := sourceURI(scheme, relativePath)
+		source, err := content.BuildSourceDocument(parsed, content.SourceOptions{
+			URI: uri, FilePath: filePath, RelativePath: filepath.ToSlash(relativePath), Raw: raw,
+		})
+		if err != nil {
+			slog.Warn("Skipping invalid resource file", "file", filepath.Base(filePath), "error", err)
+			continue
+		}
+		chunks, err := content.ChunkMarkdown(source, parsed)
+		if err != nil {
+			slog.Warn("Skipping invalid resource file", "file", filepath.Base(filePath), "error", err)
+			continue
+		}
+		result.Sources = append(result.Sources, source)
+		result.Chunks = append(result.Chunks, chunks...)
+		slog.Info("Loaded resource", "uri", uri, "name", source.Name)
+	}
+	return result, nil
+}
+
+func buildCatalog(ctx context.Context, root string, files []string, scheme string, requiredFrontmatter bool) (DiscoveryResult, error) {
+	result := DiscoveryResult{}
+	mode := content.FrontmatterOptional
+	if requiredFrontmatter {
+		mode = content.FrontmatterRequired
+	}
+	for _, filePath := range files {
+		if err := ctx.Err(); err != nil {
+			return DiscoveryResult{}, err
+		}
+		if !isMarkdown(filePath) {
+			return DiscoveryResult{}, fmt.Errorf("configured index selected non-Markdown file: %s", filePath)
+		}
+		raw, err := os.ReadFile(filePath)
+		if err != nil {
+			return DiscoveryResult{}, fmt.Errorf("read configured file %s: %w", filePath, err)
+		}
+		parsed, err := content.ParseMarkdown(raw, mode)
+		if err != nil {
+			return DiscoveryResult{}, fmt.Errorf("parse configured file %s: %w", filePath, err)
+		}
+		relativePath, err := filepath.Rel(root, filePath)
+		if err != nil {
+			return DiscoveryResult{}, err
+		}
+		uri := sourceURI(scheme, relativePath)
+		source, err := content.BuildSourceDocument(parsed, content.SourceOptions{
+			URI: uri, FilePath: filePath, RelativePath: filepath.ToSlash(relativePath), Raw: raw,
+		})
+		if err != nil {
+			return DiscoveryResult{}, fmt.Errorf("build configured source %s: %w", filePath, err)
+		}
+		chunks, err := content.ChunkMarkdown(source, parsed)
+		if err != nil {
+			return DiscoveryResult{}, fmt.Errorf("chunk configured source %s: %w", filePath, err)
+		}
+		result.Sources = append(result.Sources, source)
+		result.Chunks = append(result.Chunks, chunks...)
+	}
+	return result, nil
+}
+
+func validatePatterns(patterns []string) ([]string, error) {
+	validated := make([]string, len(patterns))
+	for i, pattern := range patterns {
+		normalized := strings.ReplaceAll(pattern, "\\", "/")
+		if filepath.IsAbs(pattern) || path.IsAbs(normalized) || filepath.VolumeName(pattern) != "" || hasVolumePrefix(normalized) {
+			return nil, fmt.Errorf("index pattern must be relative: %s", pattern)
+		}
+		cleaned := path.Clean(normalized)
+		if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+			return nil, fmt.Errorf("index pattern escapes content root: %s", pattern)
+		}
+		if !doublestar.ValidatePattern(normalized) {
+			return nil, fmt.Errorf("invalid index pattern: %s", pattern)
+		}
+		validated[i] = normalized
+	}
+	return validated, nil
+}
+
+func hasVolumePrefix(pattern string) bool {
+	return len(pattern) >= 2 && pattern[1] == ':' && ((pattern[0] >= 'a' && pattern[0] <= 'z') || (pattern[0] >= 'A' && pattern[0] <= 'Z'))
+}
+
+func canonicalPath(filePath string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(filePath)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Abs(resolved)
+}
+
+func withinRoot(root, candidate string) bool {
+	relativePath, err := filepath.Rel(root, candidate)
+	return err == nil && relativePath != ".." && !strings.HasPrefix(relativePath, ".."+string(filepath.Separator)) && !filepath.IsAbs(relativePath)
+}
+
+func matchesAny(patterns []string, name string) bool {
+	for _, pattern := range patterns {
+		matched, err := doublestar.Match(pattern, name)
+		if err == nil && matched {
+			return true
+		}
+	}
+	return false
+}
+
+func isMarkdown(filePath string) bool {
+	extension := strings.ToLower(filepath.Ext(filePath))
+	return extension == ".md" || extension == ".markdown"
+}
+
+func sourceURI(scheme, relativePath string) string {
+	withoutExtension := strings.TrimSuffix(relativePath, filepath.Ext(relativePath))
+	return fmt.Sprintf("%s://%s", scheme, filepath.ToSlash(withoutExtension))
+}

--- a/internal/resources/discovery.go
+++ b/internal/resources/discovery.go
@@ -22,11 +22,33 @@ type DiscoveryResult struct {
 	Chunks  []domain.Chunk
 }
 
+// discoveryOps keeps filesystem operations explicit for deterministic error
+// handling tests. Each Discover call receives its own immutable value.
+type discoveryOps struct {
+	canonicalPath func(string) (string, error)
+	walkDir       func(string, fs.WalkDirFunc) error
+	readFile      func(string) ([]byte, error)
+	relativePath  func(string, string) (string, error)
+}
+
+func defaultDiscoveryOps() discoveryOps {
+	return discoveryOps{
+		canonicalPath: canonicalPath,
+		walkDir:       filepath.WalkDir,
+		readFile:      os.ReadFile,
+		relativePath:  filepath.Rel,
+	}
+}
+
 // Discover loads configured Markdown sources, or legacy mcp-resources when
 // index is nil.
 func Discover(ctx context.Context, cp *content.ContentProvider, index *domain.IndexMetadata, scheme string) (DiscoveryResult, error) {
+	return discoverWithOps(ctx, cp, index, scheme, defaultDiscoveryOps())
+}
+
+func discoverWithOps(ctx context.Context, cp *content.ContentProvider, index *domain.IndexMetadata, scheme string, ops discoveryOps) (DiscoveryResult, error) {
 	if index == nil {
-		return discoverLegacy(ctx, cp, scheme)
+		return discoverLegacy(ctx, cp, scheme, ops)
 	}
 
 	patterns, err := validatePatterns(index.Include)
@@ -38,13 +60,13 @@ func Discover(ctx context.Context, cp *content.ContentProvider, index *domain.In
 		return DiscoveryResult{}, err
 	}
 
-	root, err := canonicalPath(cp.ContentDir)
+	root, err := ops.canonicalPath(cp.ContentDir)
 	if err != nil {
 		return DiscoveryResult{}, fmt.Errorf("resolve content root: %w", err)
 	}
 
 	var selected []string
-	err = filepath.WalkDir(root, func(filePath string, entry fs.DirEntry, walkErr error) error {
+	err = ops.walkDir(root, func(filePath string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
@@ -63,7 +85,7 @@ func Discover(ctx context.Context, cp *content.ContentProvider, index *domain.In
 			return nil
 		}
 
-		canonicalFile, err := canonicalPath(filePath)
+		canonicalFile, err := ops.canonicalPath(filePath)
 		if err != nil {
 			return err
 		}
@@ -71,7 +93,7 @@ func Discover(ctx context.Context, cp *content.ContentProvider, index *domain.In
 			return fmt.Errorf("selected file escapes content root: %s", filePath)
 		}
 
-		relativePath, err := filepath.Rel(root, canonicalFile)
+		relativePath, err := ops.relativePath(root, canonicalFile)
 		if err != nil {
 			return err
 		}
@@ -90,7 +112,7 @@ func Discover(ctx context.Context, cp *content.ContentProvider, index *domain.In
 	}
 
 	sort.Strings(selected)
-	return buildCatalog(ctx, root, selected, scheme, false)
+	return buildCatalog(ctx, root, selected, scheme, ops)
 }
 
 // DiscoverResources returns legacy mcp-resources definitions for callers that
@@ -103,8 +125,8 @@ func DiscoverResources(cp *content.ContentProvider, scheme string) ([]ResourceDe
 	return result.Sources, nil
 }
 
-func discoverLegacy(ctx context.Context, cp *content.ContentProvider, scheme string) (DiscoveryResult, error) {
-	root, err := canonicalPath(cp.ResourcesDir)
+func discoverLegacy(ctx context.Context, cp *content.ContentProvider, scheme string, ops discoveryOps) (DiscoveryResult, error) {
+	root, err := ops.canonicalPath(cp.ResourcesDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return DiscoveryResult{}, nil
@@ -113,7 +135,7 @@ func discoverLegacy(ctx context.Context, cp *content.ContentProvider, scheme str
 	}
 
 	var files []string
-	err = filepath.WalkDir(root, func(filePath string, entry fs.DirEntry, walkErr error) error {
+	err = ops.walkDir(root, func(filePath string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
@@ -143,7 +165,7 @@ func discoverLegacy(ctx context.Context, cp *content.ContentProvider, scheme str
 		if err := ctx.Err(); err != nil {
 			return DiscoveryResult{}, err
 		}
-		raw, err := os.ReadFile(filePath)
+		raw, err := ops.readFile(filePath)
 		if err != nil {
 			slog.Warn("Skipping invalid resource file", "file", filepath.Base(filePath), "error", err)
 			continue
@@ -159,23 +181,15 @@ func discoverLegacy(ctx context.Context, cp *content.ContentProvider, scheme str
 			slog.Warn("Skipping resource with missing metadata", "file", filepath.Base(filePath))
 			continue
 		}
-		relativePath, err := filepath.Rel(root, filePath)
+		relativePath, err := ops.relativePath(root, filePath)
 		if err != nil {
 			return DiscoveryResult{}, err
 		}
 		uri := sourceURI(scheme, relativePath)
-		source, err := content.BuildSourceDocument(parsed, content.SourceOptions{
+		source := buildParsedSource(parsed, content.SourceOptions{
 			URI: uri, FilePath: filePath, RelativePath: filepath.ToSlash(relativePath), Raw: raw,
 		})
-		if err != nil {
-			slog.Warn("Skipping invalid resource file", "file", filepath.Base(filePath), "error", err)
-			continue
-		}
-		chunks, err := content.ChunkMarkdown(source, parsed)
-		if err != nil {
-			slog.Warn("Skipping invalid resource file", "file", filepath.Base(filePath), "error", err)
-			continue
-		}
+		chunks := chunkParsedSource(source, parsed)
 		result.Sources = append(result.Sources, source)
 		result.Chunks = append(result.Chunks, chunks...)
 		slog.Info("Loaded resource", "uri", uri, "name", source.Name)
@@ -183,12 +197,8 @@ func discoverLegacy(ctx context.Context, cp *content.ContentProvider, scheme str
 	return result, nil
 }
 
-func buildCatalog(ctx context.Context, root string, files []string, scheme string, requiredFrontmatter bool) (DiscoveryResult, error) {
+func buildCatalog(ctx context.Context, root string, files []string, scheme string, ops discoveryOps) (DiscoveryResult, error) {
 	result := DiscoveryResult{}
-	mode := content.FrontmatterOptional
-	if requiredFrontmatter {
-		mode = content.FrontmatterRequired
-	}
 	for _, filePath := range files {
 		if err := ctx.Err(); err != nil {
 			return DiscoveryResult{}, err
@@ -196,33 +206,40 @@ func buildCatalog(ctx context.Context, root string, files []string, scheme strin
 		if !isMarkdown(filePath) {
 			return DiscoveryResult{}, fmt.Errorf("configured index selected non-Markdown file: %s", filePath)
 		}
-		raw, err := os.ReadFile(filePath)
+		raw, err := ops.readFile(filePath)
 		if err != nil {
 			return DiscoveryResult{}, fmt.Errorf("read configured file %s: %w", filePath, err)
 		}
-		parsed, err := content.ParseMarkdown(raw, mode)
+		parsed, err := content.ParseMarkdown(raw, content.FrontmatterOptional)
 		if err != nil {
 			return DiscoveryResult{}, fmt.Errorf("parse configured file %s: %w", filePath, err)
 		}
-		relativePath, err := filepath.Rel(root, filePath)
+		relativePath, err := ops.relativePath(root, filePath)
 		if err != nil {
 			return DiscoveryResult{}, err
 		}
 		uri := sourceURI(scheme, relativePath)
-		source, err := content.BuildSourceDocument(parsed, content.SourceOptions{
+		source := buildParsedSource(parsed, content.SourceOptions{
 			URI: uri, FilePath: filePath, RelativePath: filepath.ToSlash(relativePath), Raw: raw,
 		})
-		if err != nil {
-			return DiscoveryResult{}, fmt.Errorf("build configured source %s: %w", filePath, err)
-		}
-		chunks, err := content.ChunkMarkdown(source, parsed)
-		if err != nil {
-			return DiscoveryResult{}, fmt.Errorf("chunk configured source %s: %w", filePath, err)
-		}
+		chunks := chunkParsedSource(source, parsed)
 		result.Sources = append(result.Sources, source)
 		result.Chunks = append(result.Chunks, chunks...)
 	}
 	return result, nil
+}
+
+// ParseMarkdown returns a non-nil ParsedMarkdown with an AST on success.
+// The two construction helpers reject only that invalid input state, so their
+// errors are unreachable after a successful parse.
+func buildParsedSource(parsed *content.ParsedMarkdown, opts content.SourceOptions) domain.SourceDocument {
+	source, _ := content.BuildSourceDocument(parsed, opts)
+	return source
+}
+
+func chunkParsedSource(source domain.SourceDocument, parsed *content.ParsedMarkdown) []domain.Chunk {
+	chunks, _ := content.ChunkMarkdown(source, parsed)
+	return chunks
 }
 
 func validatePatterns(patterns []string) ([]string, error) {

--- a/internal/resources/discovery_ops_test.go
+++ b/internal/resources/discovery_ops_test.go
@@ -1,0 +1,262 @@
+package resources
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"testing"
+	"time"
+
+	"github.com/sha1n/mcp-acdc-server/internal/content"
+	"github.com/sha1n/mcp-acdc-server/internal/domain"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscoverWithOps_ConfiguredFilesystemFailures(t *testing.T) {
+	root := "/catalog"
+	file := root + "/docs/guide.md"
+	infoErr := errors.New("entry metadata unavailable")
+	canonicalErr := errors.New("file disappeared")
+	containmentErr := "selected file escapes content root"
+	relativeErr := errors.New("cannot make relative path")
+	readErr := errors.New("cannot read selected file")
+	walkErr := errors.New("directory traversal failed")
+
+	tests := []struct {
+		name      string
+		configure func(ops *discoveryOps)
+		wantErr   error
+		contains  string
+	}{
+		{
+			name: "walk error", wantErr: walkErr,
+			configure: func(ops *discoveryOps) {
+				ops.walkDir = func(path string, walk fs.WalkDirFunc) error {
+					return walk(path+"/docs", nil, walkErr)
+				}
+			},
+		},
+		{
+			name: "entry metadata error", wantErr: infoErr,
+			configure: func(ops *discoveryOps) {
+				ops.walkDir = walkOne(file, testDirEntry{name: "guide.md", infoErr: infoErr})
+			},
+		},
+		{
+			name: "canonicalization error", wantErr: canonicalErr,
+			configure: func(ops *discoveryOps) {
+				ops.walkDir = walkOne(file, regularEntry("guide.md"))
+				ops.canonicalPath = func(path string) (string, error) {
+					if path == root {
+						return root, nil
+					}
+					return "", canonicalErr
+				}
+			},
+		},
+		{
+			name: "containment error", contains: containmentErr,
+			configure: func(ops *discoveryOps) {
+				ops.walkDir = walkOne(file, regularEntry("guide.md"))
+				ops.canonicalPath = func(path string) (string, error) {
+					if path == root {
+						return root, nil
+					}
+					return "/outside/guide.md", nil
+				}
+			},
+		},
+		{
+			name: "relative path error", wantErr: relativeErr,
+			configure: func(ops *discoveryOps) {
+				ops.walkDir = walkOne(file, regularEntry("guide.md"))
+				ops.relativePath = func(_, _ string) (string, error) { return "", relativeErr }
+			},
+		},
+		{
+			name: "read error", wantErr: readErr,
+			configure: func(ops *discoveryOps) {
+				ops.walkDir = walkOne(file, regularEntry("guide.md"))
+				ops.readFile = func(string) ([]byte, error) { return nil, readErr }
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ops := successfulDiscoveryOps(root)
+			tt.configure(&ops)
+
+			_, err := discoverWithOps(context.Background(), content.NewContentProvider(root), &domain.IndexMetadata{Include: []string{"docs/*.md"}}, "acdc", ops)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+			}
+			if tt.contains != "" {
+				require.ErrorContains(t, err, tt.contains)
+			}
+		})
+	}
+}
+
+func TestDiscoverWithOps_LegacyTraversalAndCancellationFailures(t *testing.T) {
+	root := "/catalog"
+	resourcesRoot := root + "/mcp-resources"
+	file := resourcesRoot + "/guide.md"
+	walkErr := errors.New("legacy traversal failed")
+	infoErr := errors.New("legacy entry metadata unavailable")
+	relativeErr := errors.New("legacy relative path unavailable")
+
+	tests := []struct {
+		name      string
+		configure func(ops *discoveryOps, cancel context.CancelFunc)
+		wantErr   error
+	}{
+		{
+			name: "walk error", wantErr: walkErr,
+			configure: func(ops *discoveryOps, _ context.CancelFunc) {
+				ops.walkDir = func(path string, walk fs.WalkDirFunc) error {
+					return walk(path+"/nested", nil, walkErr)
+				}
+			},
+		},
+		{
+			name: "entry metadata error", wantErr: infoErr,
+			configure: func(ops *discoveryOps, _ context.CancelFunc) {
+				ops.walkDir = walkOne(file, testDirEntry{name: "guide.md", infoErr: infoErr})
+			},
+		},
+		{
+			name: "relative path error", wantErr: relativeErr,
+			configure: func(ops *discoveryOps, _ context.CancelFunc) {
+				ops.walkDir = walkOne(file, regularEntry("guide.md"))
+				ops.relativePath = func(_, _ string) (string, error) { return "", relativeErr }
+			},
+		},
+		{
+			name: "cancellation after scan", wantErr: context.Canceled,
+			configure: func(ops *discoveryOps, cancel context.CancelFunc) {
+				ops.walkDir = func(path string, walk fs.WalkDirFunc) error {
+					require.NoError(t, walk(file, regularEntry("guide.md"), nil))
+					cancel()
+					return nil
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			ops := successfulDiscoveryOps(root)
+			tt.configure(&ops, cancel)
+
+			_, err := discoverWithOps(ctx, content.NewContentProvider(root), nil, "acdc", ops)
+			require.ErrorIs(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestDiscoverWithOps_ConfiguredCancellationBeforeCatalogRead(t *testing.T) {
+	root := "/catalog"
+	file := root + "/docs/guide.md"
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ops := successfulDiscoveryOps(root)
+	ops.walkDir = func(path string, walk fs.WalkDirFunc) error {
+		require.NoError(t, walk(file, regularEntry("guide.md"), nil))
+		cancel()
+		return nil
+	}
+	ops.readFile = func(string) ([]byte, error) {
+		t.Fatal("a cancelled discovery must not read selected files")
+		return nil, nil
+	}
+
+	_, err := discoverWithOps(ctx, content.NewContentProvider(root), &domain.IndexMetadata{Include: []string{"docs/*.md"}}, "acdc", ops)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestDiscoverWithOps_LegacySkipsUnreadableAndNonregularEntries(t *testing.T) {
+	root := "/catalog"
+	resourcesRoot := root + "/mcp-resources"
+	file := resourcesRoot + "/guide.md"
+	readErr := errors.New("legacy file unreadable")
+
+	tests := []struct {
+		name      string
+		configure func(ops *discoveryOps)
+	}{
+		{
+			name: "unreadable file",
+			configure: func(ops *discoveryOps) {
+				ops.walkDir = walkOne(file, regularEntry("guide.md"))
+				ops.readFile = func(string) ([]byte, error) { return nil, readErr }
+			},
+		},
+		{
+			name: "nonregular file",
+			configure: func(ops *discoveryOps) {
+				ops.walkDir = walkOne(file, testDirEntry{name: "guide.md", mode: fs.ModeNamedPipe})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ops := successfulDiscoveryOps(root)
+			tt.configure(&ops)
+
+			result, err := discoverWithOps(context.Background(), content.NewContentProvider(root), nil, "acdc", ops)
+			require.NoError(t, err)
+			require.Empty(t, result.Sources)
+			require.Empty(t, result.Chunks)
+		})
+	}
+}
+
+func successfulDiscoveryOps(root string) discoveryOps {
+	return discoveryOps{
+		canonicalPath: func(path string) (string, error) { return path, nil },
+		walkDir:       walkOne(root+"/docs/guide.md", regularEntry("guide.md")),
+		readFile: func(string) ([]byte, error) {
+			return []byte("---\nname: Guide\ndescription: Guide description\n---\n# Guide\n"), nil
+		},
+		relativePath: func(root, path string) (string, error) {
+			if root == "/catalog/mcp-resources" {
+				return "guide.md", nil
+			}
+			return "docs/guide.md", nil
+		},
+	}
+}
+
+func walkOne(file string, entry fs.DirEntry) func(string, fs.WalkDirFunc) error {
+	return func(_ string, walk fs.WalkDirFunc) error { return walk(file, entry, nil) }
+}
+
+func regularEntry(name string) testDirEntry {
+	return testDirEntry{name: name}
+}
+
+type testDirEntry struct {
+	name    string
+	infoErr error
+	mode    fs.FileMode
+}
+
+func (entry testDirEntry) Name() string      { return entry.name }
+func (entry testDirEntry) IsDir() bool       { return entry.mode.IsDir() }
+func (entry testDirEntry) Type() fs.FileMode { return entry.mode }
+func (entry testDirEntry) Info() (fs.FileInfo, error) {
+	return testFileInfo{entry: entry}, entry.infoErr
+}
+
+type testFileInfo struct{ entry testDirEntry }
+
+func (info testFileInfo) Name() string       { return info.entry.name }
+func (info testFileInfo) Size() int64        { return 0 }
+func (info testFileInfo) Mode() fs.FileMode  { return info.entry.mode }
+func (info testFileInfo) ModTime() time.Time { return time.Time{} }
+func (info testFileInfo) IsDir() bool        { return info.entry.mode.IsDir() }
+func (info testFileInfo) Sys() any           { return nil }

--- a/internal/resources/discovery_test.go
+++ b/internal/resources/discovery_test.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"context"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -93,18 +92,6 @@ func TestDiscover_ConfiguredFailsForSelectedFileErrors(t *testing.T) {
 		require.ErrorContains(t, err, "invalid YAML in frontmatter")
 	})
 
-	t.Run("unreadable file", func(t *testing.T) {
-		if runtime.GOOS == "windows" {
-			t.Skip("file permissions are not portable on Windows")
-		}
-		root := t.TempDir()
-		path := writeFile(t, root, "docs/private.md", "# Private\n")
-		require.NoError(t, os.Chmod(path, 0o000))
-		t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
-
-		_, err := Discover(context.Background(), content.NewContentProvider(root), &domain.IndexMetadata{Include: []string{"docs/*.md"}}, "acdc")
-		require.Error(t, err)
-	})
 }
 
 func TestDiscover_ConfiguredCancellation(t *testing.T) {
@@ -160,21 +147,6 @@ func TestDiscover_LegacyMissingDirectoryAndCancellation(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
-func TestDiscover_LegacySkipsUnreadableFile(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("file permissions are not portable on Windows")
-	}
-	root := t.TempDir()
-	writeFile(t, root, "mcp-resources/available.md", "---\nname: Available\ndescription: Readable\n---\n# Available\n")
-	private := writeFile(t, root, "mcp-resources/private.md", "---\nname: Private\ndescription: Unreadable\n---\n# Private\n")
-	require.NoError(t, os.Chmod(private, 0o000))
-	t.Cleanup(func() { _ = os.Chmod(private, 0o600) })
-
-	result, err := Discover(context.Background(), content.NewContentProvider(root), nil, "acdc")
-	require.NoError(t, err)
-	require.Equal(t, []string{"acdc://available"}, sourceURIs(result.Sources))
-}
-
 func TestDiscoverResources_FailsForUnresolvableLegacyRoot(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("creating symlinks requires additional permissions on Windows")
@@ -185,34 +157,6 @@ func TestDiscoverResources_FailsForUnresolvableLegacyRoot(t *testing.T) {
 
 	_, err := DiscoverResources(content.NewContentProvider(root), "acdc")
 	require.ErrorContains(t, err, "resolve resources root")
-}
-
-func TestDiscover_IgnoresNonRegularFiles(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("mkfifo is not available on Windows")
-	}
-	root := t.TempDir()
-	docs := filepath.Join(root, "docs")
-	require.NoError(t, os.MkdirAll(docs, 0o755))
-	fifo := filepath.Join(docs, "stream.md")
-	require.NoError(t, exec.Command("mkfifo", fifo).Run())
-
-	_, err := Discover(context.Background(), content.NewContentProvider(root), &domain.IndexMetadata{Include: []string{"docs/*.md"}}, "acdc")
-	require.ErrorContains(t, err, "configured index matched no files")
-}
-
-func TestDiscover_ReportsUnreadableDirectory(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("directory permissions are not portable on Windows")
-	}
-	root := t.TempDir()
-	restricted := filepath.Join(root, "docs", "restricted")
-	require.NoError(t, os.MkdirAll(restricted, 0o755))
-	require.NoError(t, os.Chmod(restricted, 0o000))
-	t.Cleanup(func() { _ = os.Chmod(restricted, 0o700) })
-
-	_, err := Discover(context.Background(), content.NewContentProvider(root), &domain.IndexMetadata{Include: []string{"docs/**/*.md"}}, "acdc")
-	require.Error(t, err)
 }
 
 func writeFile(t *testing.T, root, name, body string) string {

--- a/internal/resources/discovery_test.go
+++ b/internal/resources/discovery_test.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -44,6 +45,21 @@ func TestDiscover_ConfiguredValidation(t *testing.T) {
 			require.ErrorContains(t, err, tt.wantErr)
 		})
 	}
+}
+
+func TestDiscover_ConfiguredRejectsInvalidExcludeAndMissingRoot(t *testing.T) {
+	root := t.TempDir()
+
+	_, err := Discover(context.Background(), content.NewContentProvider(root), &domain.IndexMetadata{
+		Include: []string{"docs/**/*.md"},
+		Exclude: []string{"/private/*.md"},
+	}, "acdc")
+	require.ErrorContains(t, err, "index pattern must be relative")
+
+	_, err = Discover(context.Background(), content.NewContentProvider(filepath.Join(root, "missing")), &domain.IndexMetadata{
+		Include: []string{"docs/**/*.md"},
+	}, "acdc")
+	require.ErrorContains(t, err, "resolve content root")
 }
 
 func TestDiscover_ConfiguredMatching(t *testing.T) {
@@ -113,6 +129,90 @@ func TestDiscover_ConfiguredSkipsSymlinksAndPreservesContainment(t *testing.T) {
 	result, err := Discover(context.Background(), content.NewContentProvider(root), &domain.IndexMetadata{Include: []string{"docs/**/*.md"}}, "acdc")
 	require.NoError(t, err)
 	require.Equal(t, []string{"acdc://docs/inside"}, sourceURIs(result.Sources))
+}
+
+func TestDiscover_LegacySkipsInvalidFilesAndBuildsChunks(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "mcp-resources/valid.md", "---\nname: Valid\ndescription: Valid description\n---\n# Valid\n\nBody.\n")
+	writeFile(t, root, "mcp-resources/broken.md", "---\nname: [\n---\n# Broken\n")
+	writeFile(t, root, "mcp-resources/missing.md", "---\nname: Missing description\n---\n# Missing\n")
+	writeFile(t, root, "mcp-resources/ignore.txt", "not a resource")
+
+	result, err := Discover(context.Background(), content.NewContentProvider(root), nil, "acdc")
+	require.NoError(t, err)
+	require.Equal(t, []string{"acdc://valid"}, sourceURIs(result.Sources))
+	require.NotEmpty(t, result.Chunks)
+	require.Equal(t, "# Valid\n\nBody.\n", result.Sources[0].Content)
+}
+
+func TestDiscover_LegacyMissingDirectoryAndCancellation(t *testing.T) {
+	root := t.TempDir()
+
+	definitions, err := DiscoverResources(content.NewContentProvider(root), "acdc")
+	require.NoError(t, err)
+	require.Empty(t, definitions)
+
+	resourcesDir := filepath.Join(root, "mcp-resources")
+	require.NoError(t, os.MkdirAll(resourcesDir, 0o755))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = Discover(ctx, content.NewContentProvider(root), nil, "acdc")
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestDiscover_LegacySkipsUnreadableFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file permissions are not portable on Windows")
+	}
+	root := t.TempDir()
+	writeFile(t, root, "mcp-resources/available.md", "---\nname: Available\ndescription: Readable\n---\n# Available\n")
+	private := writeFile(t, root, "mcp-resources/private.md", "---\nname: Private\ndescription: Unreadable\n---\n# Private\n")
+	require.NoError(t, os.Chmod(private, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(private, 0o600) })
+
+	result, err := Discover(context.Background(), content.NewContentProvider(root), nil, "acdc")
+	require.NoError(t, err)
+	require.Equal(t, []string{"acdc://available"}, sourceURIs(result.Sources))
+}
+
+func TestDiscoverResources_FailsForUnresolvableLegacyRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks requires additional permissions on Windows")
+	}
+	root := t.TempDir()
+	resourcesDir := filepath.Join(root, "mcp-resources")
+	require.NoError(t, os.Symlink(resourcesDir, resourcesDir))
+
+	_, err := DiscoverResources(content.NewContentProvider(root), "acdc")
+	require.ErrorContains(t, err, "resolve resources root")
+}
+
+func TestDiscover_IgnoresNonRegularFiles(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mkfifo is not available on Windows")
+	}
+	root := t.TempDir()
+	docs := filepath.Join(root, "docs")
+	require.NoError(t, os.MkdirAll(docs, 0o755))
+	fifo := filepath.Join(docs, "stream.md")
+	require.NoError(t, exec.Command("mkfifo", fifo).Run())
+
+	_, err := Discover(context.Background(), content.NewContentProvider(root), &domain.IndexMetadata{Include: []string{"docs/*.md"}}, "acdc")
+	require.ErrorContains(t, err, "configured index matched no files")
+}
+
+func TestDiscover_ReportsUnreadableDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permissions are not portable on Windows")
+	}
+	root := t.TempDir()
+	restricted := filepath.Join(root, "docs", "restricted")
+	require.NoError(t, os.MkdirAll(restricted, 0o755))
+	require.NoError(t, os.Chmod(restricted, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(restricted, 0o700) })
+
+	_, err := Discover(context.Background(), content.NewContentProvider(root), &domain.IndexMetadata{Include: []string{"docs/**/*.md"}}, "acdc")
+	require.Error(t, err)
 }
 
 func writeFile(t *testing.T, root, name, body string) string {

--- a/internal/resources/discovery_test.go
+++ b/internal/resources/discovery_test.go
@@ -1,0 +1,132 @@
+package resources
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/sha1n/mcp-acdc-server/internal/content"
+	"github.com/sha1n/mcp-acdc-server/internal/domain"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscover_ConfiguredSources(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "docs/guide.md", "# Guide\n\nUseful guide.\n")
+	writeFile(t, root, "docs/api/auth.md", "# Auth\n\nToken details.\n")
+	writeFile(t, root, "docs/generated/skip.md", "# Skip\n")
+
+	result, err := Discover(context.Background(), content.NewContentProvider(root), &domain.IndexMetadata{
+		Include: []string{"docs/**/*.md"},
+		Exclude: []string{"docs/generated/**"},
+	}, "acdc")
+	require.NoError(t, err)
+	require.Equal(t, []string{"acdc://docs/api/auth", "acdc://docs/guide"}, sourceURIs(result.Sources))
+	require.NotEmpty(t, result.Chunks)
+}
+
+func TestDiscover_ConfiguredValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		include []string
+		wantErr string
+	}{
+		{name: "absolute", include: []string{"/tmp/*.md"}, wantErr: "index pattern must be relative"},
+		{name: "escape", include: []string{"../docs/*.md"}, wantErr: "index pattern escapes content root"},
+		{name: "bad pattern", include: []string{"docs/[.md"}, wantErr: "invalid index pattern"},
+		{name: "zero matches", include: []string{"docs/**/*.md"}, wantErr: "configured index matched no files"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Discover(context.Background(), content.NewContentProvider(t.TempDir()), &domain.IndexMetadata{Include: tt.include}, "acdc")
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestDiscover_ConfiguredMatching(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "docs/top.md", "# Top\n")
+	writeFile(t, root, "docs/nested/guide.markdown", "# Nested\n")
+	writeFile(t, root, "docs/ignored.md", "# Ignored\n")
+
+	result, err := Discover(context.Background(), content.NewContentProvider(root), &domain.IndexMetadata{
+		Include: []string{"docs/**/*.md", "docs/**/*.*"},
+		Exclude: []string{"docs/ignored.md"},
+	}, "acdc")
+	require.NoError(t, err)
+	require.Equal(t, []string{"acdc://docs/nested/guide", "acdc://docs/top"}, sourceURIs(result.Sources))
+}
+
+func TestDiscover_ConfiguredRejectsSelectedNonMarkdown(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "docs/readme.txt", "not markdown")
+
+	_, err := Discover(context.Background(), content.NewContentProvider(root), &domain.IndexMetadata{Include: []string{"docs/**"}}, "acdc")
+	require.ErrorContains(t, err, "configured index selected non-Markdown file")
+}
+
+func TestDiscover_ConfiguredFailsForSelectedFileErrors(t *testing.T) {
+	t.Run("invalid explicit frontmatter", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, root, "docs/bad.md", "---\nname: [\n---\n# Bad\n")
+
+		_, err := Discover(context.Background(), content.NewContentProvider(root), &domain.IndexMetadata{Include: []string{"docs/*.md"}}, "acdc")
+		require.ErrorContains(t, err, "invalid YAML in frontmatter")
+	})
+
+	t.Run("unreadable file", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("file permissions are not portable on Windows")
+		}
+		root := t.TempDir()
+		path := writeFile(t, root, "docs/private.md", "# Private\n")
+		require.NoError(t, os.Chmod(path, 0o000))
+		t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+
+		_, err := Discover(context.Background(), content.NewContentProvider(root), &domain.IndexMetadata{Include: []string{"docs/*.md"}}, "acdc")
+		require.Error(t, err)
+	})
+}
+
+func TestDiscover_ConfiguredCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := Discover(ctx, content.NewContentProvider(t.TempDir()), &domain.IndexMetadata{Include: []string{"**/*.md"}}, "acdc")
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestDiscover_ConfiguredSkipsSymlinksAndPreservesContainment(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks requires additional permissions on Windows")
+	}
+	root := t.TempDir()
+	external := t.TempDir()
+	writeFile(t, root, "docs/inside.md", "# Inside\n")
+	outside := writeFile(t, external, "outside.md", "# Outside\n")
+	require.NoError(t, os.Symlink(outside, filepath.Join(root, "docs", "outside.md")))
+	require.NoError(t, os.Symlink(external, filepath.Join(root, "docs", "linked-dir")))
+
+	result, err := Discover(context.Background(), content.NewContentProvider(root), &domain.IndexMetadata{Include: []string{"docs/**/*.md"}}, "acdc")
+	require.NoError(t, err)
+	require.Equal(t, []string{"acdc://docs/inside"}, sourceURIs(result.Sources))
+}
+
+func writeFile(t *testing.T, root, name, body string) string {
+	t.Helper()
+	path := filepath.Join(root, name)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+	return path
+}
+
+func sourceURIs(sources []domain.SourceDocument) []string {
+	uris := make([]string, len(sources))
+	for i, source := range sources {
+		uris[i] = source.URI
+	}
+	return uris
+}

--- a/internal/resources/provider.go
+++ b/internal/resources/provider.go
@@ -2,19 +2,21 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"io/fs"
-	"log/slog"
-	"path/filepath"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/sha1n/mcp-acdc-server/internal/content"
 	"github.com/sha1n/mcp-acdc-server/internal/domain"
 )
 
+var (
+	ErrUnknownResource = errors.New("unknown resource")
+	ErrUnknownFragment = errors.New("unknown resource fragment")
+)
+
 // ContentTransformer transforms resource content before it is returned.
-// It receives the raw content and the definition of the resource being read.
+// It receives the raw content and the source containing the resource.
 type ContentTransformer func(content string, def ResourceDefinition) string
 
 // Option configures a ResourceProvider.
@@ -22,170 +24,162 @@ type Option func(*ResourceProvider)
 
 // WithTransformer adds a content transformer to the provider.
 // Multiple transformers are applied in the order they are added.
-func WithTransformer(t ContentTransformer) Option {
-	return func(p *ResourceProvider) {
-		p.transformers = append(p.transformers, t)
+func WithTransformer(transformer ContentTransformer) Option {
+	return func(provider *ResourceProvider) {
+		provider.transformers = append(provider.transformers, transformer)
 	}
 }
 
-// ResourceProvider provides access to resources
+// ResourceProvider is an immutable catalog of discovered sources and chunks.
 type ResourceProvider struct {
-	definitions  []ResourceDefinition
-	uriMap       map[string]ResourceDefinition
+	sources      []domain.SourceDocument
+	chunks       []domain.Chunk
+	sourceByURI  map[string]domain.SourceDocument
+	chunkByURI   map[string]domain.Chunk
+	sectionByURI map[string][]domain.Chunk
 	transformers []ContentTransformer
 }
 
-// NewResourceProvider creates a new resource provider
-func NewResourceProvider(definitions []ResourceDefinition, opts ...Option) *ResourceProvider {
-	uriMap := make(map[string]ResourceDefinition)
-	for _, d := range definitions {
-		uriMap[d.URI] = d
+// NewResourceProvider creates an immutable source and chunk catalog.
+func NewResourceProvider(sources []domain.SourceDocument, chunks []domain.Chunk, opts ...Option) (*ResourceProvider, error) {
+	provider := &ResourceProvider{
+		sources:      make([]domain.SourceDocument, 0, len(sources)),
+		chunks:       make([]domain.Chunk, 0, len(chunks)),
+		sourceByURI:  make(map[string]domain.SourceDocument, len(sources)),
+		chunkByURI:   make(map[string]domain.Chunk, len(chunks)),
+		sectionByURI: make(map[string][]domain.Chunk),
 	}
-	p := &ResourceProvider{
-		definitions: definitions,
-		uriMap:      uriMap,
+
+	for _, source := range sources {
+		if _, exists := provider.sourceByURI[source.URI]; exists {
+			return nil, fmt.Errorf("duplicate source URI: %s", source.URI)
+		}
+		copy := cloneSource(source)
+		provider.sources = append(provider.sources, copy)
+		provider.sourceByURI[copy.URI] = copy
 	}
-	for _, opt := range opts {
-		opt(p)
+
+	chunkIDs := make(map[string]struct{}, len(chunks))
+	for _, chunk := range chunks {
+		if _, exists := chunkIDs[chunk.ID]; exists {
+			return nil, fmt.Errorf("duplicate chunk ID: %s", chunk.ID)
+		}
+		if _, exists := provider.chunkByURI[chunk.ChunkURI]; exists {
+			return nil, fmt.Errorf("duplicate chunk URI: %s", chunk.ChunkURI)
+		}
+		chunkIDs[chunk.ID] = struct{}{}
+		copy := cloneChunk(chunk)
+		provider.chunks = append(provider.chunks, copy)
+		provider.chunkByURI[copy.ChunkURI] = copy
+		sectionURI := copy.SourceURI + "#" + copy.SectionFragment
+		provider.sectionByURI[sectionURI] = append(provider.sectionByURI[sectionURI], copy)
 	}
-	return p
+
+	for _, option := range opts {
+		option(provider)
+	}
+	return provider, nil
 }
 
-// ListResources lists all available resources
+// ListResources lists all available source resources.
 func (p *ResourceProvider) ListResources() []mcp.Resource {
-	resources := make([]mcp.Resource, len(p.definitions))
-	for i, d := range p.definitions {
+	resources := make([]mcp.Resource, len(p.sources))
+	for i, source := range p.sources {
 		resources[i] = mcp.Resource{
-			URI:         d.URI,
-			Name:        d.Name,
-			Description: d.Description,
-			MIMEType:    d.MIMEType,
+			URI:         source.URI,
+			Name:        source.Name,
+			Description: source.Description,
+			MIMEType:    source.MIMEType,
 		}
 	}
 	return resources
 }
 
-// ReadResource reads a resource by URI
+// ReadResource reads a source, exact chunk, or logical section URI.
 func (p *ResourceProvider) ReadResource(uri string) (string, error) {
-	defn, ok := p.uriMap[uri]
-	if !ok {
-		return "", fmt.Errorf("unknown resource: %s", uri)
+	if source, ok := p.sourceByURI[uri]; ok {
+		return p.transform(source.Content, source), nil
+	}
+	if chunk, ok := p.chunkByURI[uri]; ok {
+		return p.transform(chunk.Content, p.chunkSource(chunk)), nil
+	}
+	if chunks, ok := p.sectionByURI[uri]; ok {
+		parts := make([]string, len(chunks))
+		for i, chunk := range chunks {
+			parts[i] = chunk.Content
+		}
+		return p.transform(strings.Join(parts, "\n\n"), p.chunkSource(chunks[0])), nil
 	}
 
-	c, err := content.NewContentProvider("").LoadMarkdownWithFrontmatter(defn.FilePath)
-	if err != nil {
-		return "", err
+	base, _, hasFragment := strings.Cut(uri, "#")
+	if _, exists := p.sourceByURI[base]; hasFragment && exists {
+		return "", fmt.Errorf("%w: %s", ErrUnknownFragment, uri)
 	}
-
-	result := c.Content
-	for _, t := range p.transformers {
-		result = t(result, defn)
-	}
-	return result, nil
+	return "", fmt.Errorf("%w: %s", ErrUnknownResource, uri)
 }
 
-// StreamResources streams all resource contents to a channel
-func (p *ResourceProvider) StreamResources(ctx context.Context, ch chan<- domain.Document) error {
-	for _, defn := range p.definitions {
+// StreamChunks streams transformed copies in deterministic discovery order.
+func (p *ResourceProvider) StreamChunks(ctx context.Context, ch chan<- domain.Chunk) error {
+	for _, catalogChunk := range p.chunks {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		chunk := cloneChunk(catalogChunk)
+		chunk.Content = p.transform(chunk.Content, p.chunkSource(chunk))
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		default:
-		}
-
-		content, err := p.ReadResource(defn.URI)
-		if err != nil {
-			slog.Error("Error reading resource for indexing", "uri", defn.URI, "error", err)
-			continue
-		}
-
-		doc := domain.Document{
-			URI:      defn.URI,
-			Name:     defn.Name,
-			Content:  content,
-			Keywords: defn.Keywords,
-		}
-
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case ch <- doc:
+		case ch <- chunk:
 		}
 	}
 	return nil
 }
 
-// DiscoverResources discovers resources from markdown files.
-// The scheme parameter specifies the URI scheme (e.g. "acdc" produces "acdc://...").
-func DiscoverResources(cp *content.ContentProvider, scheme string) ([]ResourceDefinition, error) {
-	var definitions []ResourceDefinition
-	resourcesDir := cp.ResourcesDir
-
-	err := filepath.WalkDir(resourcesDir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
+// StreamResources preserves the legacy source-document stream until indexing
+// migrates to StreamChunks. New callers should use StreamChunks.
+func (p *ResourceProvider) StreamResources(ctx context.Context, ch chan<- domain.Document) error {
+	for _, source := range p.sources {
+		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if d.IsDir() {
-			return nil
+		document := domain.Document{
+			URI:      source.URI,
+			Name:     source.Name,
+			Content:  p.transform(source.Content, source),
+			Keywords: append([]string(nil), source.Keywords...),
 		}
-		if filepath.Ext(path) != ".md" {
-			return nil
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ch <- document:
 		}
-
-		// Parse frontmatter
-		md, err := cp.LoadMarkdownWithFrontmatter(path)
-		if err != nil {
-			slog.Warn("Skipping invalid resource file", "file", d.Name(), "error", err)
-			return nil
-		}
-
-		// Extract metadata
-		name, _ := md.Metadata["name"].(string)
-		description, _ := md.Metadata["description"].(string)
-
-		if name == "" || description == "" {
-			slog.Warn("Skipping resource with missing metadata", "file", d.Name())
-			return nil
-		}
-
-		// Extract optional keywords
-		var keywords []string
-		if kw, ok := md.Metadata["keywords"].([]interface{}); ok {
-			for _, k := range kw {
-				if s, ok := k.(string); ok {
-					keywords = append(keywords, s)
-				}
-			}
-		}
-
-		// Derive URI
-		relPath, err := filepath.Rel(resourcesDir, path)
-		if err != nil {
-			return err
-		}
-
-		relPathNoExt := strings.TrimSuffix(relPath, filepath.Ext(relPath))
-		// normalized for URI (slashes)
-		uriPath := filepath.ToSlash(relPathNoExt)
-		uri := fmt.Sprintf("%s://%s", scheme, uriPath)
-
-		definitions = append(definitions, ResourceDefinition{
-			URI:         uri,
-			Name:        name,
-			Description: description,
-			MIMEType:    "text/markdown",
-			FilePath:    path,
-			Keywords:    keywords,
-		})
-
-		slog.Info("Loaded resource", "uri", uri, "name", name)
-
-		return nil
-	})
-
-	if err != nil {
-		return nil, err
 	}
+	return nil
+}
 
-	return definitions, nil
+func (p *ResourceProvider) transform(body string, source domain.SourceDocument) string {
+	for _, transformer := range p.transformers {
+		body = transformer(body, source)
+	}
+	return body
+}
+
+func (p *ResourceProvider) chunkSource(chunk domain.Chunk) domain.SourceDocument {
+	if source, ok := p.sourceByURI[chunk.SourceURI]; ok {
+		return source
+	}
+	return domain.SourceDocument{ID: chunk.SourceID, URI: chunk.SourceURI}
+}
+
+func cloneSource(source domain.SourceDocument) domain.SourceDocument {
+	source.Keywords = append([]string(nil), source.Keywords...)
+	source.PathLabels = append([]string(nil), source.PathLabels...)
+	return source
+}
+
+func cloneChunk(chunk domain.Chunk) domain.Chunk {
+	chunk.PathLabels = append([]string(nil), chunk.PathLabels...)
+	chunk.HeadingPath = append([]string(nil), chunk.HeadingPath...)
+	chunk.Keywords = append([]string(nil), chunk.Keywords...)
+	return chunk
 }

--- a/internal/resources/provider_test.go
+++ b/internal/resources/provider_test.go
@@ -106,6 +106,66 @@ func TestResourceProvider_StreamChunks_StopsWhileBlocked(t *testing.T) {
 	require.ErrorIs(t, <-errs, context.Canceled)
 }
 
+func TestResourceProvider_ListsAndStreamsImmutableSources(t *testing.T) {
+	source := domain.SourceDocument{
+		ID: "acdc://guide", URI: "acdc://guide", Name: "Guide", Description: "Read this", MIMEType: "text/markdown",
+		Content: "body", Keywords: []string{"guide"},
+	}
+	provider, err := NewResourceProvider([]domain.SourceDocument{source}, nil, WithTransformer(func(body string, _ ResourceDefinition) string {
+		return strings.ToUpper(body)
+	}))
+	require.NoError(t, err)
+
+	// Mutating the caller-owned source must not change the catalog exposed to MCP or indexing.
+	source.Name = "Changed"
+	source.Keywords[0] = "changed"
+	listed := provider.ListResources()
+	require.Equal(t, []string{"acdc://guide"}, []string{listed[0].URI})
+	require.Equal(t, "Guide", listed[0].Name)
+	require.Equal(t, "Read this", listed[0].Description)
+	require.Equal(t, "text/markdown", listed[0].MIMEType)
+
+	stream := make(chan domain.Document, 1)
+	require.NoError(t, provider.StreamResources(context.Background(), stream))
+	document := <-stream
+	require.Equal(t, "acdc://guide", document.URI)
+	require.Equal(t, "Guide", document.Name)
+	require.Equal(t, "BODY", document.Content)
+	require.Equal(t, []string{"guide"}, document.Keywords)
+}
+
+func TestResourceProvider_StreamResourcesHonorsCancellation(t *testing.T) {
+	provider, err := NewResourceProvider([]domain.SourceDocument{{ID: "acdc://guide", URI: "acdc://guide"}}, nil)
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, provider.StreamResources(ctx, make(chan domain.Document)), context.Canceled)
+}
+
+func TestResourceProvider_StreamResourcesStopsWhileBlocked(t *testing.T) {
+	provider, err := NewResourceProvider([]domain.SourceDocument{{ID: "acdc://guide", URI: "acdc://guide", Content: "body"}}, nil)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errs := make(chan error, 1)
+	go func() { errs <- provider.StreamResources(ctx, make(chan domain.Document)) }()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	require.ErrorIs(t, <-errs, context.Canceled)
+}
+
+func TestResourceProvider_StreamsOrphanChunkWithSourceIdentity(t *testing.T) {
+	chunk := domain.Chunk{ID: "acdc://orphan#document", SourceID: "acdc://orphan", SourceURI: "acdc://orphan", ChunkURI: "acdc://orphan#document", Content: "body"}
+	provider, err := NewResourceProvider(nil, []domain.Chunk{chunk}, WithTransformer(func(body string, source ResourceDefinition) string {
+		return source.ID + ":" + body
+	}))
+	require.NoError(t, err)
+
+	stream := make(chan domain.Chunk, 1)
+	require.NoError(t, provider.StreamChunks(context.Background(), stream))
+	require.Equal(t, "acdc://orphan:body", (<-stream).Content)
+}
+
 func TestDiscoverResources_LegacyCompatibility(t *testing.T) {
 	root := t.TempDir()
 	writeFile(t, root, "mcp-resources/nested/guide.md", "---\nname: Guide\ndescription: Existing resource\n---\n# Guide\n")

--- a/internal/resources/provider_test.go
+++ b/internal/resources/provider_test.go
@@ -2,404 +2,117 @@ package resources
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/sha1n/mcp-acdc-server/internal/content"
 	"github.com/sha1n/mcp-acdc-server/internal/domain"
+	"github.com/stretchr/testify/require"
 )
 
-func TestResourceProvider_Methods(t *testing.T) {
-	tmp := t.TempDir()
-	f := filepath.Join(tmp, "test.md")
-	if err := os.WriteFile(f, []byte("---\nname: N\ndescription: D\n---\nBody"), 0644); err != nil {
-		t.Fatal(err)
+func TestResourceProvider_ReadSourceAndChunks(t *testing.T) {
+	source := domain.SourceDocument{ID: "acdc://guide", URI: "acdc://guide", Name: "Guide", Description: "Guide", MIMEType: "text/markdown", Content: "# Setup\n\nA.\n\nB.\n"}
+	chunks := []domain.Chunk{
+		{ID: "acdc://guide#setup~1", SourceID: source.ID, SourceURI: source.URI, ChunkURI: "acdc://guide#setup~1", SectionFragment: "setup", Fragment: "setup~1", Part: 1, PartCount: 2, Content: "# Setup\n\nA."},
+		{ID: "acdc://guide#setup~2", SourceID: source.ID, SourceURI: source.URI, ChunkURI: "acdc://guide#setup~2", SectionFragment: "setup", Fragment: "setup~2", Part: 2, PartCount: 2, Content: "B."},
 	}
+	provider, err := NewResourceProvider([]domain.SourceDocument{source}, chunks)
+	require.NoError(t, err)
 
-	defs := []ResourceDefinition{
-		{
-			URI:         "acdc://test",
-			Name:        "Test Resource",
-			Description: "Desc",
-			MIMEType:    "text/markdown",
-			FilePath:    f,
-		},
-	}
-
-	p := NewResourceProvider(defs)
-
-	// Test ListResources
-	t.Run("ListResources", func(t *testing.T) {
-		list := p.ListResources()
-		if len(list) != 1 {
-			t.Errorf("ListResources returned %d items, want 1", len(list))
-		}
-		if list[0].URI != defs[0].URI {
-			t.Errorf("ListResources URI = %s, want %s", list[0].URI, defs[0].URI)
-		}
-	})
-
-	// Test ReadResource
-	t.Run("ReadResource", func(t *testing.T) {
-		got, err := p.ReadResource(defs[0].URI)
-		if err != nil {
-			t.Errorf("ReadResource error = %v", err)
-		}
-		if got != "Body" {
-			t.Errorf("ReadResource content = %q, want %q", got, "Body")
-		}
-	})
-
-	// Test ReadResource Unknown
-	t.Run("ReadResource Unknown", func(t *testing.T) {
-		_, err := p.ReadResource("unknown")
-		if err == nil {
-			t.Error("ReadResource expected error for unknown URI")
-		}
-	})
-
-	// Test StreamResources
-	t.Run("StreamResources", func(t *testing.T) {
-		ch := make(chan domain.Document, 10)
-		go func() {
-			defer close(ch)
-			_ = p.StreamResources(context.Background(), ch)
-		}()
-
-		var docs []domain.Document
-		for d := range ch {
-			docs = append(docs, d)
-		}
-
-		if len(docs) != 1 {
-			t.Errorf("StreamResources returned %d items, want 1", len(docs))
-		}
-		if docs[0].Content != "Body" {
-			t.Errorf("StreamResources content = %q, want %q", docs[0].Content, "Body")
-		}
-	})
+	body, err := provider.ReadResource("acdc://guide")
+	require.NoError(t, err)
+	require.Equal(t, source.Content, body)
+	part, err := provider.ReadResource("acdc://guide#setup~2")
+	require.NoError(t, err)
+	require.Equal(t, "B.", part)
+	section, err := provider.ReadResource("acdc://guide#setup")
+	require.NoError(t, err)
+	require.Equal(t, "# Setup\n\nA.\n\nB.", section)
 }
 
-func TestResourceProvider_StreamResources_ErrorHandling(t *testing.T) {
-	defs := []ResourceDefinition{
-		{
-			URI:      "acdc://valid",
-			Name:     "Valid",
-			FilePath: "valid.md",
-		},
-		{
-			URI:      "acdc://invalid",
-			Name:     "Invalid",
-			FilePath: "invalid.md",
-		},
-	}
-
-	tempDir := t.TempDir()
-	validFile := filepath.Join(tempDir, "valid.md")
-	// content requires frontmatter to be parsed correctly by content provider if it uses LoadMarkdownWithFrontmatter?
-	// But ReadResource uses content.NewContentProvider("").LoadMarkdownWithFrontmatter(defn.FilePath)
-	// which expects frontmatter.
-	_ = os.WriteFile(validFile, []byte("---\nname: Valid\n---\nBody"), 0644)
-	defs[0].FilePath = validFile
-
-	p := NewResourceProvider(defs)
-
-	ch := make(chan domain.Document, 10)
-	go func() {
-		defer close(ch)
-		_ = p.StreamResources(context.Background(), ch)
-	}()
-
-	var got []domain.Document
-	for d := range ch {
-		got = append(got, d)
-	}
-
-	if len(got) != 1 {
-		t.Errorf("StreamResources returned %d items, want 1 (successful one)", len(got))
-		return
-	}
-
-	if got[0].URI != "acdc://valid" {
-		t.Errorf("Expected uri 'acdc://valid', got '%s'", got[0].URI)
-	}
+func TestResourceProvider_ReadErrors(t *testing.T) {
+	provider, err := NewResourceProvider([]domain.SourceDocument{{ID: "acdc://guide", URI: "acdc://guide"}}, nil)
+	require.NoError(t, err)
+	_, err = provider.ReadResource("acdc://missing")
+	require.ErrorIs(t, err, ErrUnknownResource)
+	_, err = provider.ReadResource("acdc://guide#missing")
+	require.ErrorIs(t, err, ErrUnknownFragment)
 }
 
-func TestResourceProvider_StreamResources_ContextCancellation(t *testing.T) {
-	defs := []ResourceDefinition{
-		{
-			URI:  "acdc://1",
-			Name: "1",
-		},
-	}
-	p := NewResourceProvider(defs)
+func TestResourceProvider_DuplicateIdentities(t *testing.T) {
+	source := domain.SourceDocument{ID: "acdc://guide", URI: "acdc://guide"}
+	chunk := domain.Chunk{ID: "acdc://guide#one", SourceURI: source.URI, ChunkURI: "acdc://guide#one"}
+
+	_, err := NewResourceProvider([]domain.SourceDocument{source, source}, nil)
+	require.ErrorContains(t, err, "duplicate source URI")
+	_, err = NewResourceProvider([]domain.SourceDocument{source}, []domain.Chunk{chunk, chunk})
+	require.ErrorContains(t, err, "duplicate chunk ID")
+	_, err = NewResourceProvider([]domain.SourceDocument{source}, []domain.Chunk{chunk, {ID: "other", ChunkURI: chunk.ChunkURI}})
+	require.ErrorContains(t, err, "duplicate chunk URI")
+}
+
+func TestResourceProvider_StreamChunks_TransformsAndCancels(t *testing.T) {
+	source := domain.SourceDocument{ID: "acdc://guide", URI: "acdc://guide", Name: "Guide"}
+	chunk := domain.Chunk{ID: "acdc://guide#document", SourceID: source.ID, SourceURI: source.URI, ChunkURI: "acdc://guide#document", Content: "body"}
+	provider, err := NewResourceProvider([]domain.SourceDocument{source}, []domain.Chunk{chunk}, WithTransformer(func(body string, _ ResourceDefinition) string {
+		return strings.ToUpper(body)
+	}))
+	require.NoError(t, err)
+
+	stream := make(chan domain.Chunk, 1)
+	require.NoError(t, provider.StreamChunks(context.Background(), stream))
+	require.Equal(t, "BODY", (<-stream).Content)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // Cancel immediately
-
-	ch := make(chan domain.Document)
-	err := p.StreamResources(ctx, ch)
-	if err == nil {
-		t.Error("Expected error on context cancellation, got nil")
-	}
-	if err != context.Canceled {
-		t.Errorf("Expected context.Canceled, got %v", err)
-	}
-}
-
-func TestResourceProvider_StreamResources_ContextCancellation_Blocked(t *testing.T) {
-	defs := []ResourceDefinition{
-		{
-			URI:  "acdc://1",
-			Name: "1",
-			// FilePath needs to exist for ReadResource to succeed and reach the send block
-			FilePath: "valid.md",
-		},
-	}
-	tempDir := t.TempDir()
-	defs[0].FilePath = filepath.Join(tempDir, "valid.md")
-	_ = os.WriteFile(defs[0].FilePath, []byte("---\nname: 1\n---\nBody"), 0644)
-
-	p := NewResourceProvider(defs)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	ch := make(chan domain.Document) // Unbuffered, so send will block
-
-	errChan := make(chan error)
-	go func() {
-		errChan <- p.StreamResources(ctx, ch)
-	}()
-
-	// Wait a bit to ensure ReadResource completes and we are blocked on sending
-	time.Sleep(50 * time.Millisecond)
 	cancel()
+	require.ErrorIs(t, provider.StreamChunks(ctx, make(chan domain.Chunk)), context.Canceled)
+}
 
-	select {
-	case err := <-errChan:
-		if err != context.Canceled {
-			t.Errorf("Expected context.Canceled, got %v", err)
-		}
-	case <-time.After(1 * time.Second):
-		t.Fatal("Timeout waiting for StreamResources to return")
+func TestResourceProvider_TransformerAppliesToEveryReadForm(t *testing.T) {
+	source := domain.SourceDocument{ID: "acdc://guide", URI: "acdc://guide", Name: "Guide", Content: "source"}
+	chunks := []domain.Chunk{
+		{ID: "acdc://guide#part~1", SourceURI: source.URI, ChunkURI: "acdc://guide#part~1", SectionFragment: "part", Content: "first"},
+		{ID: "acdc://guide#part~2", SourceURI: source.URI, ChunkURI: "acdc://guide#part~2", SectionFragment: "part", Content: "second"},
+	}
+	provider, err := NewResourceProvider([]domain.SourceDocument{source}, chunks, WithTransformer(func(body string, definition ResourceDefinition) string {
+		return definition.Name + ":" + strings.ToUpper(body)
+	}))
+	require.NoError(t, err)
+
+	for uri, want := range map[string]string{
+		"acdc://guide":        "Guide:SOURCE",
+		"acdc://guide#part~1": "Guide:FIRST",
+		"acdc://guide#part":   "Guide:FIRST\n\nSECOND",
+	} {
+		got, err := provider.ReadResource(uri)
+		require.NoError(t, err)
+		require.Equal(t, want, got)
 	}
 }
 
-func TestResourceProvider_NoTransformer(t *testing.T) {
-	tmp := t.TempDir()
-	f := filepath.Join(tmp, "test.md")
-	_ = os.WriteFile(f, []byte("---\nname: N\ndescription: D\n---\nOriginal content"), 0644)
+func TestResourceProvider_StreamChunks_StopsWhileBlocked(t *testing.T) {
+	source := domain.SourceDocument{ID: "acdc://guide", URI: "acdc://guide"}
+	chunk := domain.Chunk{ID: "acdc://guide#document", SourceURI: source.URI, ChunkURI: "acdc://guide#document"}
+	provider, err := NewResourceProvider([]domain.SourceDocument{source}, []domain.Chunk{chunk})
+	require.NoError(t, err)
 
-	defs := []ResourceDefinition{
-		{URI: "acdc://test", Name: "Test", FilePath: f},
-	}
-
-	p := NewResourceProvider(defs)
-	got, err := p.ReadResource("acdc://test")
-	if err != nil {
-		t.Fatalf("ReadResource error = %v", err)
-	}
-	if got != "Original content" {
-		t.Errorf("ReadResource = %q, want %q", got, "Original content")
-	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errs := make(chan error, 1)
+	go func() { errs <- provider.StreamChunks(ctx, make(chan domain.Chunk)) }()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	require.ErrorIs(t, <-errs, context.Canceled)
 }
 
-func TestResourceProvider_SingleTransformer(t *testing.T) {
-	tmp := t.TempDir()
-	f := filepath.Join(tmp, "test.md")
-	_ = os.WriteFile(f, []byte("---\nname: N\ndescription: D\n---\nhello"), 0644)
+func TestDiscoverResources_LegacyCompatibility(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "mcp-resources/nested/guide.md", "---\nname: Guide\ndescription: Existing resource\n---\n# Guide\n")
+	writeFile(t, root, "mcp-resources/invalid.md", "# No required frontmatter\n")
 
-	defs := []ResourceDefinition{
-		{URI: "acdc://test", Name: "Test", FilePath: f},
-	}
-
-	upper := func(content string, _ ResourceDefinition) string {
-		return strings.ToUpper(content)
-	}
-
-	p := NewResourceProvider(defs, WithTransformer(upper))
-	got, err := p.ReadResource("acdc://test")
-	if err != nil {
-		t.Fatalf("ReadResource error = %v", err)
-	}
-	if got != "HELLO" {
-		t.Errorf("ReadResource = %q, want %q", got, "HELLO")
-	}
-}
-
-func TestResourceProvider_MultipleTransformers(t *testing.T) {
-	tmp := t.TempDir()
-	f := filepath.Join(tmp, "test.md")
-	_ = os.WriteFile(f, []byte("---\nname: N\ndescription: D\n---\nhello"), 0644)
-
-	defs := []ResourceDefinition{
-		{URI: "acdc://test", Name: "Test", FilePath: f},
-	}
-
-	addPrefix := func(content string, _ ResourceDefinition) string {
-		return "prefix:" + content
-	}
-	addSuffix := func(content string, _ ResourceDefinition) string {
-		return content + ":suffix"
-	}
-
-	p := NewResourceProvider(defs, WithTransformer(addPrefix), WithTransformer(addSuffix))
-	got, err := p.ReadResource("acdc://test")
-	if err != nil {
-		t.Fatalf("ReadResource error = %v", err)
-	}
-	if got != "prefix:hello:suffix" {
-		t.Errorf("ReadResource = %q, want %q", got, "prefix:hello:suffix")
-	}
-}
-
-func TestResourceProvider_TransformerReceivesDefinition(t *testing.T) {
-	tmp := t.TempDir()
-	f := filepath.Join(tmp, "test.md")
-	_ = os.WriteFile(f, []byte("---\nname: N\ndescription: D\n---\ncontent"), 0644)
-
-	defs := []ResourceDefinition{
-		{URI: "acdc://test", Name: "TestName", FilePath: f},
-	}
-
-	echoName := func(content string, def ResourceDefinition) string {
-		return content + " from " + def.Name
-	}
-
-	p := NewResourceProvider(defs, WithTransformer(echoName))
-	got, err := p.ReadResource("acdc://test")
-	if err != nil {
-		t.Fatalf("ReadResource error = %v", err)
-	}
-	if got != "content from TestName" {
-		t.Errorf("ReadResource = %q, want %q", got, "content from TestName")
-	}
-}
-
-func TestResourceProvider_StreamResourcesWithTransformer(t *testing.T) {
-	tmp := t.TempDir()
-	f := filepath.Join(tmp, "test.md")
-	_ = os.WriteFile(f, []byte("---\nname: N\ndescription: D\n---\nhello"), 0644)
-
-	defs := []ResourceDefinition{
-		{URI: "acdc://test", Name: "Test", FilePath: f},
-	}
-
-	upper := func(content string, _ ResourceDefinition) string {
-		return strings.ToUpper(content)
-	}
-
-	p := NewResourceProvider(defs, WithTransformer(upper))
-
-	ch := make(chan domain.Document, 10)
-	go func() {
-		defer close(ch)
-		_ = p.StreamResources(context.Background(), ch)
-	}()
-
-	var docs []domain.Document
-	for d := range ch {
-		docs = append(docs, d)
-	}
-
-	if len(docs) != 1 {
-		t.Fatalf("StreamResources returned %d items, want 1", len(docs))
-	}
-	if docs[0].Content != "HELLO" {
-		t.Errorf("StreamResources content = %q, want %q", docs[0].Content, "HELLO")
-	}
-}
-
-func TestDiscoverResources(t *testing.T) {
-	// Setup directory structure
-	tmp := t.TempDir()
-	resDir := filepath.Join(tmp, "mcp-resources")
-	if err := os.MkdirAll(resDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	// Valid resource
-	validRes := filepath.Join(resDir, "valid.md")
-	if err := os.WriteFile(validRes, []byte("---\nname: Valid\ndescription: D\n---\nContent"), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	// Invalid resource (no name)
-	invalidRes := filepath.Join(resDir, "invalid.md")
-	if err := os.WriteFile(invalidRes, []byte("---\ndescription: D\n---\nContent"), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	// Not markdown
-	txtRes := filepath.Join(resDir, "files.txt")
-	if err := os.WriteFile(txtRes, []byte("text"), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	// Subdir (should be skipped by implementation if WalkDir doesn't recurse? WalkDir recurses. Implementation checks .md extension)
-	// But let's check if it handles subdirs correctly.
-	subDir := filepath.Join(resDir, "sub")
-	if err := os.Mkdir(subDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	subRes := filepath.Join(subDir, "sub.md")
-	if err := os.WriteFile(subRes, []byte("---\nname: Sub\ndescription: D\n---\nSubContent"), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	cp := content.NewContentProvider(tmp)
-
-	defs, err := DiscoverResources(cp, "acdc")
-	if err != nil {
-		t.Fatalf("DiscoverResources error = %v", err)
-	}
-
-	// Expect 2 resources: valid.md and sub.md
-	if len(defs) != 2 {
-		t.Errorf("DiscoverResources found %d items, want 2", len(defs))
-	}
-
-	// Check URIs (should use forward slashes)
-	// "valid" and "sub/sub"
-	uris := make(map[string]bool)
-	for _, d := range defs {
-		uris[d.URI] = true
-	}
-
-	if !uris["acdc://valid"] {
-		t.Error("Missing acdc://valid")
-	}
-	if !uris["acdc://sub/sub"] {
-		t.Error("Missing acdc://sub/sub")
-	}
-}
-
-func TestDiscoverResources_CustomScheme(t *testing.T) {
-	tmp := t.TempDir()
-	resDir := filepath.Join(tmp, "mcp-resources")
-	if err := os.MkdirAll(resDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	validRes := filepath.Join(resDir, "doc.md")
-	if err := os.WriteFile(validRes, []byte("---\nname: Doc\ndescription: D\n---\nContent"), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	cp := content.NewContentProvider(tmp)
-
-	defs, err := DiscoverResources(cp, "my-custom")
-	if err != nil {
-		t.Fatalf("DiscoverResources error = %v", err)
-	}
-
-	if len(defs) != 1 {
-		t.Fatalf("DiscoverResources found %d items, want 1", len(defs))
-	}
-
-	if defs[0].URI != "my-custom://doc" {
-		t.Errorf("Expected URI 'my-custom://doc', got '%s'", defs[0].URI)
-	}
+	definitions, err := DiscoverResources(content.NewContentProvider(root), "acdc")
+	require.NoError(t, err)
+	require.Len(t, definitions, 1)
+	require.Equal(t, "acdc://nested/guide", definitions[0].URI)
 }


### PR DESCRIPTION
## Summary
Add configuration-driven Markdown discovery and an immutable source/chunk catalog while preserving legacy resource behavior.

## Changes
- Validate and securely resolve configured include/exclude patterns with deterministic ordering and strict failures.
- Support base-source, exact-chunk, and logical-section reads with duplicate identity checks and immutable transformed streaming.
- Keep legacy discovery skip-and-warn behavior and existing MCP/CLI composition buildable until the later indexing migration.