### PR TITLE
feat(search): [5/9] index and rank document chunks

### DIFF
--- a/internal/app/indexing.go
+++ b/internal/app/indexing.go
@@ -8,27 +8,27 @@ import (
 	"github.com/sha1n/mcp-acdc-server/internal/search"
 )
 
-// ResourceStreamer interface for things that can stream resources
+// ResourceStreamer streams chunks for indexing.
 type ResourceStreamer interface {
-	StreamResources(ctx context.Context, ch chan<- domain.Document) error
+	StreamChunks(ctx context.Context, ch chan<- domain.Chunk) error
 }
 
 // IndexResources coordinates the streaming and indexing of resources
 func IndexResources(ctx context.Context, rs ResourceStreamer, indexer search.Searcher) {
-	docsChan := make(chan domain.Document, 100)
+	chunksChan := make(chan domain.Chunk, 100)
 
 	// Start producer
 	go func() {
-		defer close(docsChan)
-		if err := rs.StreamResources(ctx, docsChan); err != nil {
-			slog.Error("StreamResources failed", "error", err)
+		defer close(chunksChan)
+		if err := rs.StreamChunks(ctx, chunksChan); err != nil {
+			slog.Error("StreamChunks failed", "error", err)
 		}
 	}()
 
 	// Run consumer (blocking)
-	if err := indexer.Index(ctx, docsChan); err != nil {
-		slog.Error("Failed to index documents", "error", err)
+	if err := indexer.Index(ctx, chunksChan); err != nil {
+		slog.Error("Failed to index chunks", "error", err)
 	} else {
-		slog.Info("Indexed documents finished")
+		slog.Info("Indexed chunks finished")
 	}
 }

--- a/internal/app/indexing_test.go
+++ b/internal/app/indexing_test.go
@@ -13,12 +13,12 @@ type mockResourceStreamer struct {
 	err error
 }
 
-func (m *mockResourceStreamer) StreamResources(ctx context.Context, ch chan<- domain.Document) error {
+func (m *mockResourceStreamer) StreamChunks(ctx context.Context, ch chan<- domain.Chunk) error {
 	if m.err != nil {
 		return m.err
 	}
-	// Simulate one doc
-	ch <- domain.Document{URI: "1"}
+	// Simulate one chunk.
+	ch <- domain.Chunk{ID: "1", SourceID: "source"}
 	return nil
 }
 
@@ -26,20 +26,22 @@ type mockIndexer struct {
 	err error
 }
 
-func (m *mockIndexer) Index(ctx context.Context, documents <-chan domain.Document) error {
+func (m *mockIndexer) Index(ctx context.Context, chunks <-chan domain.Chunk) error {
 	if m.err != nil {
 		return m.err
 	}
-	for range documents {
+	for range chunks {
 		// drain
 	}
 	return nil
 }
 
-func (m *mockIndexer) Search(queryStr string, limit *int) ([]search.SearchResult, error) {
+func (m *mockIndexer) Search(queryStr string, candidateLimit int) ([]search.SearchResult, error) {
 	return nil, nil
 }
-func (m *mockIndexer) Close() {}
+func (m *mockIndexer) Close()                                                      {}
+func (m *mockIndexer) ReplaceSource(context.Context, string, []domain.Chunk) error { return nil }
+func (m *mockIndexer) DeleteSource(context.Context, string) error                  { return nil }
 
 func TestIndexResources_Success(t *testing.T) {
 	rs := &mockResourceStreamer{}

--- a/internal/domain/search.go
+++ b/internal/domain/search.go
@@ -1,14 +1,22 @@
 package domain
 
-// Field name constants for indexed documents
+// Field name constants for indexed chunks.
 const (
-	FieldURI      = "uri"
-	FieldName     = "name"
-	FieldContent  = "content"
-	FieldKeywords = "keywords"
+	FieldChunkID     = "chunk_id"
+	FieldSourceID    = "source_id"
+	FieldSourceURI   = "source_uri"
+	FieldChunkURI    = "chunk_uri"
+	FieldSourceTitle = "source_title"
+	FieldSourcePath  = "source_path"
+	FieldPathLabels  = "path_labels"
+	FieldHeadingPath = "heading_path"
+	FieldContent     = "content"
+	FieldKeywords    = "keywords"
+	FieldStartLine   = "start_line"
+	FieldEndLine     = "end_line"
 )
 
-// Document represents a document to index
+// Document is retained for the legacy resource stream. New search indexing uses Chunk.
 type Document struct {
 	URI      string   `json:"uri"`
 	Name     string   `json:"name"`

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -40,15 +40,18 @@ func TestCreateServer(t *testing.T) {
 
 type mockSearcher struct{}
 
-func (m *mockSearcher) Search(query string, options *int) ([]search.SearchResult, error) {
+func (m *mockSearcher) Search(query string, candidateLimit int) ([]search.SearchResult, error) {
 	return nil, nil
 }
 
 func (m *mockSearcher) Close() {}
 
-func (m *mockSearcher) Index(ctx context.Context, docs <-chan domain.Document) error {
-	for range docs {
+func (m *mockSearcher) Index(ctx context.Context, chunks <-chan domain.Chunk) error {
+	for range chunks {
 		// drain
 	}
 	return nil
 }
+
+func (m *mockSearcher) ReplaceSource(context.Context, string, []domain.Chunk) error { return nil }
+func (m *mockSearcher) DeleteSource(context.Context, string) error                  { return nil }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -52,7 +52,7 @@ func NewSearchToolHandler(searchService search.Searcher) mcp.ToolHandlerFor[Sear
 		// Args are already validated and unmarshaled by SDK via jsonschema tags
 		slog.Info("Search request", "query", args.Query)
 
-		results, err := searchService.Search(args.Query, nil)
+		results, err := searchService.Search(args.Query, 0)
 		if err != nil {
 			slog.Error("Search failed", "query", args.Query, "error", err)
 			return nil, nil, err
@@ -64,7 +64,7 @@ func NewSearchToolHandler(searchService search.Searcher) mcp.ToolHandlerFor[Sear
 		} else {
 			fmt.Fprintf(&sb, "Search results for '%s':\n\n", args.Query)
 			for _, r := range results {
-				fmt.Fprintf(&sb, "- [%s](%s): %s\n\n", r.Name, r.URI, r.Snippet)
+				fmt.Fprintf(&sb, "- [%s](%s): %s\n\n", r.SourceTitle, r.SourceURI, r.Snippet)
 			}
 		}
 

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -17,24 +17,27 @@ import (
 
 // Mock searcher for testing
 type TestMockSearcher struct {
-	MockSearch func(queryStr string, limit *int) ([]search.SearchResult, error)
+	MockSearch func(queryStr string, candidateLimit int) ([]search.SearchResult, error)
 }
 
-func (m *TestMockSearcher) Search(query string, options *int) ([]search.SearchResult, error) {
+func (m *TestMockSearcher) Search(query string, candidateLimit int) ([]search.SearchResult, error) {
 	if m.MockSearch != nil {
-		return m.MockSearch(query, options)
+		return m.MockSearch(query, candidateLimit)
 	}
 	return nil, nil
 }
 
 func (m *TestMockSearcher) Close() {}
 
-func (m *TestMockSearcher) Index(ctx context.Context, docs <-chan domain.Document) error {
-	for range docs {
+func (m *TestMockSearcher) Index(ctx context.Context, chunks <-chan domain.Chunk) error {
+	for range chunks {
 		// drain
 	}
 	return nil
 }
+
+func (m *TestMockSearcher) ReplaceSource(context.Context, string, []domain.Chunk) error { return nil }
+func (m *TestMockSearcher) DeleteSource(context.Context, string) error                  { return nil }
 
 func TestToolRegistration(t *testing.T) {
 	// Just verify tools can be created without panic
@@ -54,18 +57,19 @@ func TestToolRegistration(t *testing.T) {
 
 func TestSearchToolHandler_Success_WithResults(t *testing.T) {
 	mockSearcher := &TestMockSearcher{
-		MockSearch: func(query string, limit *int) ([]search.SearchResult, error) {
+		MockSearch: func(query string, candidateLimit int) ([]search.SearchResult, error) {
 			assert.Equal(t, "test query", query)
+			assert.Equal(t, 0, candidateLimit)
 			return []search.SearchResult{
 				{
-					Name:    "Result 1",
-					URI:     "acdc://result1",
-					Snippet: "This is result 1",
+					SourceTitle: "Result 1",
+					SourceURI:   "acdc://result1",
+					Snippet:     "This is result 1",
 				},
 				{
-					Name:    "Result 2",
-					URI:     "acdc://result2",
-					Snippet: "This is result 2",
+					SourceTitle: "Result 2",
+					SourceURI:   "acdc://result2",
+					Snippet:     "This is result 2",
 				},
 			}, nil
 		},
@@ -96,7 +100,7 @@ func TestSearchToolHandler_Success_WithResults(t *testing.T) {
 
 func TestSearchToolHandler_Success_NoResults(t *testing.T) {
 	mockSearcher := &TestMockSearcher{
-		MockSearch: func(query string, limit *int) ([]search.SearchResult, error) {
+		MockSearch: func(query string, candidateLimit int) ([]search.SearchResult, error) {
 			return []search.SearchResult{}, nil
 		},
 	}
@@ -121,7 +125,7 @@ func TestSearchToolHandler_Success_NoResults(t *testing.T) {
 func TestSearchToolHandler_Error(t *testing.T) {
 	expectedErr := errors.New("search service error")
 	mockSearcher := &TestMockSearcher{
-		MockSearch: func(query string, limit *int) ([]search.SearchResult, error) {
+		MockSearch: func(query string, candidateLimit int) ([]search.SearchResult, error) {
 			return nil, expectedErr
 		},
 	}

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 
 	"github.com/blevesearch/bleve/v2"
 	"github.com/blevesearch/bleve/v2/mapping"
@@ -50,6 +51,7 @@ type BatchIndexer interface {
 
 // Service search service using Bleve
 type Service struct {
+	mu           sync.RWMutex
 	settings     config.SearchSettings
 	index        bleve.Index
 	indexDir     string
@@ -69,49 +71,65 @@ func NewService(settings config.SearchSettings) *Service {
 
 // Index rebuilds the index from a stream of chunks.
 func (s *Service) Index(ctx context.Context, chunks <-chan domain.Chunk) error {
-	// Close existing index if any
-	if s.index != nil {
-		_ = s.index.Close()
-		s.index = nil
-	}
-	if s.indexDir != "" {
-		_ = os.RemoveAll(s.indexDir)
-	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
-	// Define mapping
-	indexMapping := buildMapping()
-
-	var index bleve.Index
-	var err error
-
-	if s.settings.InMemory {
-		index, err = bleve.NewMemOnly(indexMapping)
-	} else {
-		// Create temp dir
-		var mkErr error
-		tempDir, mkErr := os.MkdirTemp("", "acdc_search_")
-		if mkErr != nil {
-			return fmt.Errorf("failed to create temp dir: %w", mkErr)
-		}
-		// bleve.New requires the directory to not exist
-		if rmErr := os.RemoveAll(tempDir); rmErr != nil {
-			return fmt.Errorf("failed to remove temp dir: %w", rmErr)
-		}
-		s.indexDir = tempDir
-
-		index, err = bleve.New(s.indexDir, indexMapping)
-	}
-
+	index, indexDir, err := s.newIndex()
 	if err != nil {
-		return fmt.Errorf("failed to create index: %w", err)
+		return err
 	}
-	s.index = index
-	s.sourceChunks = make(map[string][]string)
+	newSourceChunks := make(map[string][]string)
+	if err := batchIndex(ctx, index, chunks, newSourceChunks); err != nil {
+		_ = index.Close()
+		if indexDir != "" {
+			_ = os.RemoveAll(indexDir)
+		}
+		return err
+	}
 
-	return s.batchIndex(ctx, s.index, chunks)
+	oldIndex, oldIndexDir := s.index, s.indexDir
+	s.index = index
+	s.indexDir = indexDir
+	s.sourceChunks = newSourceChunks
+	if oldIndex != nil {
+		_ = oldIndex.Close()
+	}
+	if oldIndexDir != "" && oldIndexDir != indexDir {
+		_ = os.RemoveAll(oldIndexDir)
+	}
+	return nil
+}
+
+func (s *Service) newIndex() (bleve.Index, string, error) {
+	indexMapping := buildMapping()
+	if s.settings.InMemory {
+		index, err := bleve.NewMemOnly(indexMapping)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to create index: %w", err)
+		}
+		return index, "", nil
+	}
+
+	indexDir, err := os.MkdirTemp("", "acdc_search_")
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create temp dir: %w", err)
+	}
+	if err := os.RemoveAll(indexDir); err != nil {
+		return nil, "", fmt.Errorf("failed to remove temp dir: %w", err)
+	}
+	index, err := bleve.New(indexDir, indexMapping)
+	if err != nil {
+		_ = os.RemoveAll(indexDir)
+		return nil, "", fmt.Errorf("failed to create index: %w", err)
+	}
+	return index, indexDir, nil
 }
 
 func (s *Service) batchIndex(ctx context.Context, index BatchIndexer, chunks <-chan domain.Chunk) error {
+	return batchIndex(ctx, index, chunks, s.sourceChunks)
+}
+
+func batchIndex(ctx context.Context, index BatchIndexer, chunks <-chan domain.Chunk, sourceChunks map[string][]string) error {
 	batch := index.NewBatch()
 	batchSize := 100
 	count := 0
@@ -127,7 +145,7 @@ func (s *Service) batchIndex(ctx context.Context, index BatchIndexer, chunks <-c
 					if err := index.Batch(batch); err != nil {
 						return fmt.Errorf("failed to execute final batch index: %w", err)
 					}
-					s.addSourceChunks(pendingSources)
+					addSourceChunks(sourceChunks, pendingSources)
 				}
 				return nil
 			}
@@ -142,7 +160,7 @@ func (s *Service) batchIndex(ctx context.Context, index BatchIndexer, chunks <-c
 				if err := index.Batch(batch); err != nil {
 					return fmt.Errorf("failed to execute batch index: %w", err)
 				}
-				s.addSourceChunks(pendingSources)
+				addSourceChunks(sourceChunks, pendingSources)
 				batch = index.NewBatch()
 				count = 0
 				pendingSources = make(map[string][]string)
@@ -151,9 +169,9 @@ func (s *Service) batchIndex(ctx context.Context, index BatchIndexer, chunks <-c
 	}
 }
 
-func (s *Service) addSourceChunks(sourceChunks map[string][]string) {
+func addSourceChunks(destination, sourceChunks map[string][]string) {
 	for sourceID, chunkIDs := range sourceChunks {
-		s.sourceChunks[sourceID] = append(s.sourceChunks[sourceID], chunkIDs...)
+		destination[sourceID] = append(destination[sourceID], chunkIDs...)
 	}
 }
 
@@ -200,6 +218,9 @@ func buildMapping() mapping.IndexMapping {
 
 // Search finds chunks matching query.
 func (s *Service) Search(queryStr string, candidateLimit int) ([]SearchResult, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	if s.index == nil {
 		return []SearchResult{}, nil
 	}
@@ -320,6 +341,9 @@ func fieldInt(fields map[string]interface{}, field string) int {
 
 // ReplaceSource atomically removes a source's known chunks and indexes its replacements.
 func (s *Service) ReplaceSource(ctx context.Context, sourceID string, chunks []domain.Chunk) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -350,6 +374,9 @@ func (s *Service) ReplaceSource(ctx context.Context, sourceID string, chunks []d
 
 // DeleteSource atomically removes all known chunks for sourceID.
 func (s *Service) DeleteSource(ctx context.Context, sourceID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -374,16 +401,24 @@ func (s *Service) DeleteSource(ctx context.Context, sourceID string) error {
 
 // Close cleans up resources
 func (s *Service) Close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	if s.index != nil {
 		_ = s.index.Close()
+		s.index = nil
 	}
 	if s.indexDir != "" {
 		_ = os.RemoveAll(s.indexDir)
+		s.indexDir = ""
 	}
 }
 
 // DocCount returns number of docs in index
 func (s *Service) DocCount() (uint64, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	if s.index == nil {
 		return 0, nil
 	}

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -3,7 +3,6 @@ package search
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"os"
 
 	"github.com/blevesearch/bleve/v2"
@@ -13,17 +12,33 @@ import (
 	"github.com/sha1n/mcp-acdc-server/internal/domain"
 )
 
-// SearchResult represents a search result
+const (
+	headingBoost = 2.5
+	pathBoost    = 1.25
+)
+
+// SearchResult is a chunk returned by a search.
 type SearchResult struct {
-	URI     string
-	Name    string
-	Snippet string
+	ChunkID     string
+	SourceID    string
+	SourceURI   string
+	ChunkURI    string
+	SourceTitle string
+	SourcePath  string
+	HeadingPath []string
+	StartLine   int
+	EndLine     int
+	Score       float64
+	Snippet     string
+	Content     string
 }
 
-// Searcher interface in search package
+// Searcher indexes and searches document chunks.
 type Searcher interface {
-	Search(queryStr string, limit *int) ([]SearchResult, error)
-	Index(ctx context.Context, documents <-chan domain.Document) error
+	Search(query string, candidateLimit int) ([]SearchResult, error)
+	Index(ctx context.Context, chunks <-chan domain.Chunk) error
+	ReplaceSource(ctx context.Context, sourceID string, chunks []domain.Chunk) error
+	DeleteSource(ctx context.Context, sourceID string) error
 	Close()
 }
 
@@ -35,9 +50,10 @@ type BatchIndexer interface {
 
 // Service search service using Bleve
 type Service struct {
-	settings config.SearchSettings
-	index    bleve.Index
-	indexDir string
+	settings     config.SearchSettings
+	index        bleve.Index
+	indexDir     string
+	sourceChunks map[string][]string
 }
 
 // Ensure Service implements Searcher
@@ -46,12 +62,13 @@ var _ Searcher = (*Service)(nil)
 // NewService creates a new search service
 func NewService(settings config.SearchSettings) *Service {
 	return &Service{
-		settings: settings,
+		settings:     settings,
+		sourceChunks: make(map[string][]string),
 	}
 }
 
-// Index indexes a stream of documents
-func (s *Service) Index(ctx context.Context, documents <-chan domain.Document) error {
+// Index rebuilds the index from a stream of chunks.
+func (s *Service) Index(ctx context.Context, chunks <-chan domain.Chunk) error {
 	// Close existing index if any
 	if s.index != nil {
 		_ = s.index.Close()
@@ -89,92 +106,107 @@ func (s *Service) Index(ctx context.Context, documents <-chan domain.Document) e
 		return fmt.Errorf("failed to create index: %w", err)
 	}
 	s.index = index
+	s.sourceChunks = make(map[string][]string)
 
-	return s.batchIndex(ctx, s.index, documents)
+	return s.batchIndex(ctx, s.index, chunks)
 }
 
-func (s *Service) batchIndex(ctx context.Context, index BatchIndexer, documents <-chan domain.Document) error {
-	// Batch index
+func (s *Service) batchIndex(ctx context.Context, index BatchIndexer, chunks <-chan domain.Chunk) error {
 	batch := index.NewBatch()
-	batchSize := 100 // configurable?
+	batchSize := 100
 	count := 0
+	pendingSources := make(map[string][]string)
 
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case doc, ok := <-documents:
+		case chunk, ok := <-chunks:
 			if !ok {
-				// Channel closed, flush remaining
 				if count > 0 {
 					if err := index.Batch(batch); err != nil {
 						return fmt.Errorf("failed to execute final batch index: %w", err)
 					}
+					s.addSourceChunks(pendingSources)
 				}
 				return nil
 			}
 
-			if err := batch.Index(doc.URI, doc); err != nil {
-				return fmt.Errorf("failed to add document to batch: %w", err)
+			if err := batch.Index(chunk.ID, chunk); err != nil {
+				return fmt.Errorf("failed to add chunk to batch: %w", err)
 			}
+			pendingSources[chunk.SourceID] = append(pendingSources[chunk.SourceID], chunk.ID)
 			count++
 
 			if count >= batchSize {
 				if err := index.Batch(batch); err != nil {
 					return fmt.Errorf("failed to execute batch index: %w", err)
 				}
+				s.addSourceChunks(pendingSources)
 				batch = index.NewBatch()
 				count = 0
+				pendingSources = make(map[string][]string)
 			}
 		}
 	}
 }
 
-func buildMapping() mapping.IndexMapping {
-	// URI field: Stored, Indexed
-	uriMapping := bleve.NewTextFieldMapping()
-	uriMapping.Store = true
-	uriMapping.IncludeInAll = false
-
-	// Name field: Stored, Indexed, Included in All (default)
-	nameMapping := bleve.NewTextFieldMapping()
-	nameMapping.Store = true
-	nameMapping.IncludeInAll = true
-	nameMapping.Analyzer = "en"
-
-	// Content field: Indexed, Not Stored, Included in All
-	contentMapping := bleve.NewTextFieldMapping()
-	contentMapping.Store = true // DEBUG: Store content to ensure we can see it
-	contentMapping.IncludeInAll = true
-	contentMapping.Analyzer = "en"
-
-	// Keywords field: Indexed, Not Stored, Included in All
-	// Boosting is done at query-time via DisjunctionQuery
-	keywordsMapping := bleve.NewTextFieldMapping()
-	keywordsMapping.Store = false
-	keywordsMapping.IncludeInAll = true
-	keywordsMapping.Analyzer = "en"
-
-	docMapping := bleve.NewDocumentMapping()
-	docMapping.AddFieldMappingsAt(domain.FieldURI, uriMapping)
-	docMapping.AddFieldMappingsAt(domain.FieldName, nameMapping)
-	docMapping.AddFieldMappingsAt(domain.FieldContent, contentMapping)
-	docMapping.AddFieldMappingsAt(domain.FieldKeywords, keywordsMapping)
-
-	mapping := bleve.NewIndexMapping()
-	mapping.DefaultMapping = docMapping
-	return mapping
+func (s *Service) addSourceChunks(sourceChunks map[string][]string) {
+	for sourceID, chunkIDs := range sourceChunks {
+		s.sourceChunks[sourceID] = append(s.sourceChunks[sourceID], chunkIDs...)
+	}
 }
 
-// Search searches for resources
-func (s *Service) Search(queryStr string, limit *int) ([]SearchResult, error) {
+func buildMapping() mapping.IndexMapping {
+	storedIdentifier := bleve.NewKeywordFieldMapping()
+	storedIdentifier.Store = true
+	storedIdentifier.IncludeInAll = false
+
+	searchableText := bleve.NewTextFieldMapping()
+	searchableText.Store = true
+	searchableText.IncludeInAll = true
+	searchableText.Analyzer = "en"
+
+	lineNumber := bleve.NewNumericFieldMapping()
+	lineNumber.Store = true
+	lineNumber.IncludeInAll = false
+
+	chunkMapping := bleve.NewDocumentMapping()
+	for _, field := range []string{
+		domain.FieldChunkID,
+		domain.FieldSourceID,
+		domain.FieldSourceURI,
+		domain.FieldChunkURI,
+		domain.FieldSourcePath,
+	} {
+		chunkMapping.AddFieldMappingsAt(field, storedIdentifier)
+	}
+	for _, field := range []string{
+		domain.FieldSourceTitle,
+		domain.FieldPathLabels,
+		domain.FieldHeadingPath,
+		domain.FieldContent,
+		domain.FieldKeywords,
+	} {
+		chunkMapping.AddFieldMappingsAt(field, searchableText)
+	}
+	chunkMapping.AddFieldMappingsAt(domain.FieldStartLine, lineNumber)
+	chunkMapping.AddFieldMappingsAt(domain.FieldEndLine, lineNumber)
+
+	indexMapping := bleve.NewIndexMapping()
+	indexMapping.DefaultMapping = chunkMapping
+	return indexMapping
+}
+
+// Search finds chunks matching query.
+func (s *Service) Search(queryStr string, candidateLimit int) ([]SearchResult, error) {
 	if s.index == nil {
 		return []SearchResult{}, nil
 	}
 
 	maxResults := s.settings.MaxResults
-	if limit != nil {
-		maxResults = *limit
+	if candidateLimit > 0 {
+		maxResults = candidateLimit
 	}
 
 	// Build query with keyword boosting
@@ -183,30 +215,20 @@ func (s *Service) Search(queryStr string, limit *int) ([]SearchResult, error) {
 	if queryStr == "*" {
 		q = bleve.NewMatchAllQuery()
 	} else {
-		// Create field-specific queries with boosting and fuzziness
-		nameQuery := bleve.NewMatchQuery(queryStr)
-		nameQuery.SetField(domain.FieldName)
-		nameQuery.SetFuzziness(1)
-		nameQuery.SetBoost(s.settings.NameBoost)
-
-		contentQuery := bleve.NewMatchQuery(queryStr)
-		contentQuery.SetField(domain.FieldContent)
-		contentQuery.SetFuzziness(1)
-		contentQuery.SetBoost(s.settings.ContentBoost)
-
-		keywordsQuery := bleve.NewMatchQuery(queryStr)
-		keywordsQuery.SetField(domain.FieldKeywords)
-		keywordsQuery.SetFuzziness(1)
-		keywordsQuery.SetBoost(s.settings.KeywordsBoost)
-
-		// DisjunctionQuery combines results, boosted fields will score higher
-		q = bleve.NewDisjunctionQuery(nameQuery, contentQuery, keywordsQuery)
+		q = bleve.NewDisjunctionQuery(
+			fieldQuery(queryStr, domain.FieldKeywords, s.settings.KeywordsBoost),
+			fieldQuery(queryStr, domain.FieldHeadingPath, headingBoost),
+			fieldQuery(queryStr, domain.FieldSourceTitle, s.settings.NameBoost),
+			fieldQuery(queryStr, domain.FieldPathLabels, pathBoost),
+			fieldQuery(queryStr, domain.FieldContent, s.settings.ContentBoost),
+		)
 	}
 
 	searchRequest := bleve.NewSearchRequest(q)
 	searchRequest.Size = maxResults
-	searchRequest.Fields = []string{domain.FieldURI, domain.FieldName, domain.FieldContent}
+	searchRequest.Fields = []string{"*"}
 	searchRequest.Highlight = bleve.NewHighlight()
+	searchRequest.SortBy([]string{"-_score", domain.FieldSourceURI, domain.FieldChunkID})
 
 	searchResult, err := s.index.Search(searchRequest)
 	if err != nil {
@@ -215,31 +237,139 @@ func (s *Service) Search(queryStr string, limit *int) ([]SearchResult, error) {
 
 	results := make([]SearchResult, 0, len(searchResult.Hits))
 	for _, hit := range searchResult.Hits {
-		uri, ok := hit.Fields[domain.FieldURI].(string)
-		if !ok {
-			slog.Warn("Search hit missing URI field", "id", hit.ID)
-			continue
-		}
-
-		name, ok := hit.Fields[domain.FieldName].(string)
-		if !ok || name == "" {
-			name = "Unknown" // Fallback
-		}
-
-		// Improved snippet generation with highlighting
-		snippet := fmt.Sprintf("%s (relevance: %.2f)", name, hit.Score)
+		snippet := fieldString(hit.Fields, domain.FieldContent)
 		if fragments, ok := hit.Fragments[domain.FieldContent]; ok && len(fragments) > 0 {
-			snippet = fmt.Sprintf("%s... (relevance: %.2f)", fragments[0], hit.Score)
+			snippet = fragments[0]
+		}
+		if snippet == "" {
+			snippet = fieldString(hit.Fields, domain.FieldSourceTitle)
 		}
 
 		results = append(results, SearchResult{
-			URI:     uri,
-			Name:    name,
-			Snippet: snippet,
+			ChunkID:     fieldStringOr(hit.Fields, domain.FieldChunkID, hit.ID),
+			SourceID:    fieldString(hit.Fields, domain.FieldSourceID),
+			SourceURI:   fieldString(hit.Fields, domain.FieldSourceURI),
+			ChunkURI:    fieldString(hit.Fields, domain.FieldChunkURI),
+			SourceTitle: fieldString(hit.Fields, domain.FieldSourceTitle),
+			SourcePath:  fieldString(hit.Fields, domain.FieldSourcePath),
+			HeadingPath: fieldStrings(hit.Fields, domain.FieldHeadingPath),
+			StartLine:   fieldInt(hit.Fields, domain.FieldStartLine),
+			EndLine:     fieldInt(hit.Fields, domain.FieldEndLine),
+			Score:       hit.Score,
+			Snippet:     snippet,
+			Content:     fieldString(hit.Fields, domain.FieldContent),
 		})
 	}
 
 	return results, nil
+}
+
+func fieldQuery(queryStr, field string, boost float64) *query.MatchQuery {
+	fieldQuery := bleve.NewMatchQuery(queryStr)
+	fieldQuery.SetField(field)
+	fieldQuery.SetFuzziness(1)
+	fieldQuery.SetBoost(boost)
+	return fieldQuery
+}
+
+func fieldString(fields map[string]interface{}, field string) string {
+	value, _ := fields[field].(string)
+	return value
+}
+
+func fieldStringOr(fields map[string]interface{}, field, fallback string) string {
+	if value := fieldString(fields, field); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func fieldStrings(fields map[string]interface{}, field string) []string {
+	switch value := fields[field].(type) {
+	case []string:
+		return append([]string(nil), value...)
+	case []interface{}:
+		values := make([]string, 0, len(value))
+		for _, item := range value {
+			if text, ok := item.(string); ok {
+				values = append(values, text)
+			}
+		}
+		return values
+	case string:
+		return []string{value}
+	default:
+		return nil
+	}
+}
+
+func fieldInt(fields map[string]interface{}, field string) int {
+	switch value := fields[field].(type) {
+	case float64:
+		return int(value)
+	case float32:
+		return int(value)
+	case int:
+		return value
+	case int64:
+		return int(value)
+	default:
+		return 0
+	}
+}
+
+// ReplaceSource atomically removes a source's known chunks and indexes its replacements.
+func (s *Service) ReplaceSource(ctx context.Context, sourceID string, chunks []domain.Chunk) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if s.index == nil {
+		return fmt.Errorf("search index is not initialized")
+	}
+
+	batch := s.index.NewBatch()
+	for _, chunkID := range s.sourceChunks[sourceID] {
+		batch.Delete(chunkID)
+	}
+	for _, chunk := range chunks {
+		if err := batch.Index(chunk.ID, chunk); err != nil {
+			return fmt.Errorf("failed to add replacement chunk to batch: %w", err)
+		}
+	}
+	if err := s.index.Batch(batch); err != nil {
+		return fmt.Errorf("failed to replace source chunks: %w", err)
+	}
+
+	chunkIDs := make([]string, len(chunks))
+	for i, chunk := range chunks {
+		chunkIDs[i] = chunk.ID
+	}
+	s.sourceChunks[sourceID] = chunkIDs
+	return nil
+}
+
+// DeleteSource atomically removes all known chunks for sourceID.
+func (s *Service) DeleteSource(ctx context.Context, sourceID string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if s.index == nil {
+		return nil
+	}
+	chunkIDs := s.sourceChunks[sourceID]
+	if len(chunkIDs) == 0 {
+		return nil
+	}
+
+	batch := s.index.NewBatch()
+	for _, chunkID := range chunkIDs {
+		batch.Delete(chunkID)
+	}
+	if err := s.index.Batch(batch); err != nil {
+		return fmt.Errorf("failed to delete source chunks: %w", err)
+	}
+	delete(s.sourceChunks, sourceID)
+	return nil
 }
 
 // Close cleans up resources

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -18,6 +18,13 @@ const (
 	pathBoost    = 1.25
 )
 
+var (
+	newMemoryIndex = bleve.NewMemOnly
+	makeTempDir    = os.MkdirTemp
+	removeAll      = os.RemoveAll
+	newDiskIndex   = bleve.New
+)
+
 // SearchResult is a chunk returned by a search.
 type SearchResult struct {
 	ChunkID     string
@@ -49,11 +56,18 @@ type BatchIndexer interface {
 	Batch(b *bleve.Batch) error
 }
 
+type searchIndex interface {
+	BatchIndexer
+	Search(request *bleve.SearchRequest) (*bleve.SearchResult, error)
+	Close() error
+	DocCount() (uint64, error)
+}
+
 // Service search service using Bleve
 type Service struct {
 	mu           sync.RWMutex
 	settings     config.SearchSettings
-	index        bleve.Index
+	index        searchIndex
 	indexDir     string
 	sourceChunks map[string][]string
 }
@@ -82,7 +96,7 @@ func (s *Service) Index(ctx context.Context, chunks <-chan domain.Chunk) error {
 	if err := batchIndex(ctx, index, chunks, newSourceChunks); err != nil {
 		_ = index.Close()
 		if indexDir != "" {
-			_ = os.RemoveAll(indexDir)
+			_ = removeAll(indexDir)
 		}
 		return err
 	}
@@ -95,31 +109,31 @@ func (s *Service) Index(ctx context.Context, chunks <-chan domain.Chunk) error {
 		_ = oldIndex.Close()
 	}
 	if oldIndexDir != "" && oldIndexDir != indexDir {
-		_ = os.RemoveAll(oldIndexDir)
+		_ = removeAll(oldIndexDir)
 	}
 	return nil
 }
 
-func (s *Service) newIndex() (bleve.Index, string, error) {
+func (s *Service) newIndex() (searchIndex, string, error) {
 	indexMapping := buildMapping()
 	if s.settings.InMemory {
-		index, err := bleve.NewMemOnly(indexMapping)
+		index, err := newMemoryIndex(indexMapping)
 		if err != nil {
 			return nil, "", fmt.Errorf("failed to create index: %w", err)
 		}
 		return index, "", nil
 	}
 
-	indexDir, err := os.MkdirTemp("", "acdc_search_")
+	indexDir, err := makeTempDir("", "acdc_search_")
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to create temp dir: %w", err)
 	}
-	if err := os.RemoveAll(indexDir); err != nil {
+	if err := removeAll(indexDir); err != nil {
 		return nil, "", fmt.Errorf("failed to remove temp dir: %w", err)
 	}
-	index, err := bleve.New(indexDir, indexMapping)
+	index, err := newDiskIndex(indexDir, indexMapping)
 	if err != nil {
-		_ = os.RemoveAll(indexDir)
+		_ = removeAll(indexDir)
 		return nil, "", fmt.Errorf("failed to create index: %w", err)
 	}
 	return index, indexDir, nil
@@ -409,7 +423,7 @@ func (s *Service) Close() {
 		s.index = nil
 	}
 	if s.indexDir != "" {
-		_ = os.RemoveAll(s.indexDir)
+		_ = removeAll(s.indexDir)
 		s.indexDir = ""
 	}
 }

--- a/internal/search/service_test.go
+++ b/internal/search/service_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/blevesearch/bleve/v2"
 	"github.com/sha1n/mcp-acdc-server/internal/config"
 	"github.com/sha1n/mcp-acdc-server/internal/domain"
+	"github.com/stretchr/testify/require"
 )
 
 type mockBatchIndexer struct {
@@ -17,673 +17,265 @@ type mockBatchIndexer struct {
 	batchErr  error
 }
 
-func (m *mockBatchIndexer) NewBatch() *bleve.Batch {
-	return m.realIndex.NewBatch()
-}
+func (m *mockBatchIndexer) NewBatch() *bleve.Batch { return m.realIndex.NewBatch() }
 
-func (m *mockBatchIndexer) Batch(b *bleve.Batch) error {
+func (m *mockBatchIndexer) Batch(batch *bleve.Batch) error {
 	if m.batchErr != nil {
 		return m.batchErr
 	}
-	return m.realIndex.Batch(b)
-}
-
-func TestService_BatchIndex_AddToBatchError(t *testing.T) {
-	s := NewService(testSettings())
-	defer s.Close()
-
-	// Create a real index to pass to batchIndex
-	index, _ := bleve.NewMemOnly(buildMapping())
-
-	// Document with empty URI should fail batch.Index
-	docs := []domain.Document{
-		{URI: "", Name: "Invalid", Content: "Content"},
-	}
-
-	ch := make(chan domain.Document, 1)
-	ch <- docs[0]
-	close(ch)
-
-	err := s.batchIndex(context.Background(), index, ch)
-	if err == nil {
-		t.Error("Expected error for empty URI, got nil")
-	}
-	if !contains(err.Error(), "failed to add document to batch") {
-		t.Errorf("Unexpected error: %v", err)
-	}
-}
-
-func TestService_BatchIndex_BatchExecutionError(t *testing.T) {
-	s := NewService(testSettings())
-	defer s.Close()
-
-	realIndex, _ := bleve.NewMemOnly(buildMapping())
-	mockIndex := &mockBatchIndexer{
-		realIndex: realIndex,
-		batchErr:  errors.New("simulated batch error"),
-	}
-
-	// Send enough docs to trigger batch flush (assuming batchSize=100 in service.go)
-	// Or just close channel to trigger final flush.
-	// We need > 0 docs to trigger final flush.
-	ch := make(chan domain.Document, 1)
-	ch <- domain.Document{URI: "1", Name: "1", Content: "C"}
-	close(ch)
-
-	err := s.batchIndex(context.Background(), mockIndex, ch)
-	if err == nil {
-		t.Error("Expected error for batch execution, got nil")
-	}
-	if !contains(err.Error(), "failed to execute final batch index") && !contains(err.Error(), "simulated batch error") {
-		t.Errorf("Unexpected error: %v", err)
-	}
-}
-
-func TestService_BatchIndex_FullBatchError(t *testing.T) {
-	s := NewService(testSettings())
-	defer s.Close()
-
-	realIndex, _ := bleve.NewMemOnly(buildMapping())
-	mockIndex := &mockBatchIndexer{
-		realIndex: realIndex,
-		batchErr:  errors.New("simulated batch error"),
-	}
-
-	// Send 100 docs to trigger intermediate flush
-	count := 100
-	ch := make(chan domain.Document, count)
-	for i := 0; i < count; i++ {
-		ch <- domain.Document{URI: fmt.Sprintf("%d", i), Name: "N", Content: "C"}
-	}
-	// Don't close yet, we want the flush to happen during loop
-	// Actually we can close, it buffers.
-	close(ch)
-
-	err := s.batchIndex(context.Background(), mockIndex, ch)
-	if err == nil {
-		t.Error("Expected error for full batch execution, got nil")
-	}
-	if !contains(err.Error(), "failed to execute batch index") {
-		t.Errorf("Unexpected error: %v", err)
-	}
+	return m.realIndex.Batch(batch)
 }
 
 func testSettings() config.SearchSettings {
 	return config.SearchSettings{
+		InMemory:      true,
 		MaxResults:    10,
-		KeywordsBoost: 3.0,
-		NameBoost:     2.0,
-		ContentBoost:  1.0,
+		KeywordsBoost: 3,
+		NameBoost:     2,
+		ContentBoost:  1,
 	}
 }
 
-func indexDocsHelper(s *Service, docs []domain.Document) error {
-	ch := make(chan domain.Document, len(docs))
-	for _, d := range docs {
-		ch <- d
+func indexChunks(t *testing.T, service *Service, chunks []domain.Chunk) {
+	t.Helper()
+	stream := make(chan domain.Chunk, len(chunks))
+	for _, chunk := range chunks {
+		stream <- chunk
 	}
-	close(ch)
-	return s.Index(context.Background(), ch)
+	close(stream)
+	require.NoError(t, service.Index(context.Background(), stream))
+}
+
+func TestSearch_ChunkFieldBoosts(t *testing.T) {
+	tests := []struct {
+		name     string
+		stronger domain.Chunk
+		weaker   domain.Chunk
+	}{
+		{name: "keyword over heading", stronger: domain.Chunk{Keywords: []string{"oauth"}}, weaker: domain.Chunk{HeadingPath: []string{"oauth"}}},
+		{name: "heading over title", stronger: domain.Chunk{HeadingPath: []string{"oauth"}}, weaker: domain.Chunk{SourceTitle: "oauth"}},
+		{name: "title over path label", stronger: domain.Chunk{SourceTitle: "oauth"}, weaker: domain.Chunk{PathLabels: []string{"oauth"}}},
+		{name: "path label over body", stronger: domain.Chunk{PathLabels: []string{"oauth"}}, weaker: domain.Chunk{Content: "oauth"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := NewService(testSettings())
+			defer service.Close()
+
+			stronger := tt.stronger
+			stronger.ID = "stronger"
+			stronger.SourceID = "stronger-source"
+			stronger.SourceURI = "acdc://stronger"
+			stronger.ChunkURI = "acdc://stronger#chunk"
+			if stronger.Content == "" {
+				stronger.Content = "unrelated"
+			}
+			weaker := tt.weaker
+			weaker.ID = "weaker"
+			weaker.SourceID = "weaker-source"
+			weaker.SourceURI = "acdc://weaker"
+			weaker.ChunkURI = "acdc://weaker#chunk"
+			if weaker.Content == "" {
+				weaker.Content = "unrelated"
+			}
+			indexChunks(t, service, []domain.Chunk{weaker, stronger})
+
+			results, err := service.Search("oauth", 10)
+			require.NoError(t, err)
+			require.Len(t, results, 2)
+			require.Equal(t, "stronger", results[0].ChunkID)
+		})
+	}
+}
+
+func TestSearch_StoresChunkProvenanceAndSnippet(t *testing.T) {
+	service := NewService(testSettings())
+	defer service.Close()
+	chunk := domain.Chunk{
+		ID: "guide#oauth", SourceID: "guide", SourceURI: "acdc://guide", ChunkURI: "acdc://guide#oauth",
+		SourceTitle: "OAuth guide", SourcePath: "guides/oauth.md", HeadingPath: []string{"Authentication", "OAuth"},
+		PathLabels: []string{"guides", "security"}, StartLine: 12, EndLine: 20,
+		Content: "Configure OAuth clients with a redirect URI.",
+	}
+	indexChunks(t, service, []domain.Chunk{chunk})
+
+	results, err := service.Search("redirect", 10)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Equal(t, SearchResult{
+		ChunkID: "guide#oauth", SourceID: "guide", SourceURI: "acdc://guide", ChunkURI: "acdc://guide#oauth",
+		SourceTitle: "OAuth guide", SourcePath: "guides/oauth.md", HeadingPath: []string{"Authentication", "OAuth"},
+		StartLine: 12, EndLine: 20, Content: chunk.Content,
+	}, withoutScoreAndSnippet(results[0]))
+	require.Contains(t, results[0].Snippet, "redirect")
+}
+
+func withoutScoreAndSnippet(result SearchResult) SearchResult {
+	result.Score = 0
+	result.Snippet = ""
+	return result
+}
+
+func TestSearch_AccuracyAndCandidateLimit(t *testing.T) {
+	settings := testSettings()
+	settings.MaxResults = 2
+	service := NewService(settings)
+	defer service.Close()
+	indexChunks(t, service, []domain.Chunk{
+		{ID: "one", SourceID: "source", SourceURI: "acdc://source", ChunkURI: "acdc://source#one", Content: "Searching configuration"},
+		{ID: "two", SourceID: "source", SourceURI: "acdc://source", ChunkURI: "acdc://source#two", Content: "Another configuration"},
+		{ID: "three", SourceID: "source", SourceURI: "acdc://source", ChunkURI: "acdc://source#three", Content: "Third configuration"},
+	})
+
+	for _, query := range []string{"search", "serch", "*"} {
+		results, err := service.Search(query, 0)
+		require.NoError(t, err)
+		if query == "*" {
+			require.Len(t, results, 2)
+		} else {
+			require.NotEmpty(t, results)
+		}
+	}
+	results, err := service.Search("configuration", 1)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	results, err = service.Search("*", -1)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+}
+
+func TestSearch_DeterministicTieOrdering(t *testing.T) {
+	service := NewService(testSettings())
+	defer service.Close()
+	indexChunks(t, service, []domain.Chunk{
+		{ID: "b", SourceID: "source-b", SourceURI: "acdc://b", ChunkURI: "acdc://b#b", Content: "identical"},
+		{ID: "c", SourceID: "source-a", SourceURI: "acdc://a", ChunkURI: "acdc://a#c", Content: "identical"},
+		{ID: "a", SourceID: "source-a", SourceURI: "acdc://a", ChunkURI: "acdc://a#a", Content: "identical"},
+	})
+
+	results, err := service.Search("identical", 10)
+	require.NoError(t, err)
+	require.Equal(t, []string{"a", "c", "b"}, chunkIDs(results))
+}
+
+func TestSearch_MissingStoredFieldsUsesStableDefaults(t *testing.T) {
+	service := NewService(testSettings())
+	defer service.Close()
+	index, err := bleve.NewMemOnly(buildMapping())
+	require.NoError(t, err)
+	require.NoError(t, index.Index("fallback-id", struct {
+		Content string `json:"content"`
+	}{Content: "visible"}))
+	service.index = index
+
+	results, err := service.Search("visible", 10)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Equal(t, "fallback-id", results[0].ChunkID)
+	require.Empty(t, results[0].SourceURI)
+}
+
+func TestSearch_EmptyIndex(t *testing.T) {
+	service := NewService(testSettings())
+	defer service.Close()
+
+	results, err := service.Search("anything", 10)
+	require.NoError(t, err)
+	require.Empty(t, results)
 }
 
 func TestService_Index_ContextCancellation(t *testing.T) {
-	s := NewService(testSettings())
-	defer s.Close()
-
+	service := NewService(testSettings())
+	defer service.Close()
 	ctx, cancel := context.WithCancel(context.Background())
-	ch := make(chan domain.Document)
-
-	// Cancel immediately
 	cancel()
-
-	err := s.Index(ctx, ch)
-	if err == nil {
-		t.Error("Expected error on context cancellation, got nil")
-	}
-	if err != context.Canceled {
-		t.Errorf("Expected context.Canceled, got %v", err)
-	}
+	require.ErrorIs(t, service.Index(ctx, make(chan domain.Chunk)), context.Canceled)
 }
 
-func TestService_Index_BatchingAndFlushing(t *testing.T) {
-	s := NewService(testSettings())
-	defer s.Close()
-
-	// 150 documents to test batching (100) and flushing (50)
-	count := 150
-	ch := make(chan domain.Document, count)
-	for i := 0; i < count; i++ {
-		ch <- domain.Document{
-			URI:     fmt.Sprintf("uri-%d", i),
-			Name:    fmt.Sprintf("Doc %d", i),
-			Content: "content",
-		}
-	}
-	close(ch)
-
-	if err := s.Index(context.Background(), ch); err != nil {
-		t.Fatalf("Index failed: %v", err)
-	}
-
-	docCount, err := s.DocCount()
-	if err != nil {
-		t.Fatalf("DocCount failed: %v", err)
-	}
-	if docCount != uint64(count) {
-		t.Errorf("Expected %d documents, got %d", count, docCount)
-	}
-}
-
-func TestService_Index_EmptyChannel(t *testing.T) {
-	s := NewService(testSettings())
-	defer s.Close()
-
-	ch := make(chan domain.Document)
-	close(ch)
-
-	if err := s.Index(context.Background(), ch); err != nil {
-		t.Fatalf("Index failed: %v", err)
-	}
-
-	docCount, err := s.DocCount()
-	if err != nil {
-		t.Fatalf("DocCount failed: %v", err)
-	}
-	if docCount != 0 {
-		t.Errorf("Expected 0 documents, got %d", docCount)
-	}
-}
-
-func TestSearchService(t *testing.T) {
-	settings := testSettings()
-	service := NewService(settings)
-	defer service.Close()
-
-	docs := []domain.Document{
-		{
-			URI:     "acdc://doc1",
-			Name:    "Document One",
-			Content: "This is the content of document one. It talks about testing.",
-		},
-		{
-			URI:     "acdc://doc2",
-			Name:    "Document Two",
-			Content: "This is the content of document two. It talks about development.",
-		},
-	}
-
-	if err := indexDocsHelper(service, docs); err != nil {
-		t.Fatalf("IndexDocuments failed: %v", err)
-	}
-
-	// Search for "testing"
-	results, err := service.Search("testing", nil)
-	if err != nil {
-		t.Fatalf("Search failed: %v", err)
-	}
-
-	if len(results) != 1 {
-		t.Fatalf("Expected 1 result, got %d", len(results))
-	}
-	if results[0].URI != "acdc://doc1" {
-		t.Errorf("Expected URI 'acdc://doc1', got '%s'", results[0].URI)
-	}
-
-	// Search for "document"
-	results, err = service.Search("document", nil)
-	if err != nil {
-		t.Fatalf("Search failed: %v", err)
-	}
-	if len(results) != 2 {
-		t.Fatalf("Expected 2 results, got %d", len(results))
-	}
-
-	// DocCount
-	count, err := service.DocCount()
-	if err != nil {
-		t.Fatalf("DocCount failed: %v", err)
-	}
-	if count != 2 {
-		t.Errorf("Expected 2 documents, got %d", count)
-	}
-}
-
-func TestSearchService_ReIndex(t *testing.T) {
-	settings := testSettings()
-	settings.InMemory = true
-	service := NewService(settings) // Use in-memory for speed
-	defer service.Close()
-
-	if err := indexDocsHelper(service, []domain.Document{{URI: "1", Name: "1"}}); err != nil {
-		t.Fatal(err)
-	}
-	if count, _ := service.DocCount(); count != 1 {
-		t.Errorf("Expected 1, got %d", count)
-	}
-
-	// Re-index
-	if err := indexDocsHelper(service, []domain.Document{{URI: "2", Name: "2"}}); err != nil {
-		t.Fatal(err)
-	}
-	if count, _ := service.DocCount(); count != 1 {
-		t.Errorf("Expected 1 (replaced), got %d", count)
-	}
-}
-
-func TestSearchService_Empty(t *testing.T) {
+func TestService_BatchIndexFailures(t *testing.T) {
 	service := NewService(testSettings())
-	// No index created yet
-	results, err := service.Search("test", nil)
-	if err != nil {
-		t.Errorf("Expected no error for empty search, got %v", err)
-	}
-	if len(results) != 0 {
-		t.Errorf("Expected 0 results, got %d", len(results))
-	}
+	defer service.Close()
+	index, err := bleve.NewMemOnly(buildMapping())
+	require.NoError(t, err)
 
-	count, err := service.DocCount()
-	if err != nil {
-		t.Errorf("Expected no error for empty doc count, got %v", err)
-	}
-	if count != 0 {
-		t.Errorf("Expected 0 count, got %d", count)
-	}
+	t.Run("rejects missing chunk id", func(t *testing.T) {
+		stream := make(chan domain.Chunk, 1)
+		stream <- domain.Chunk{Content: "invalid"}
+		close(stream)
+		require.ErrorContains(t, service.batchIndex(context.Background(), index, stream), "failed to add chunk to batch")
+	})
+	t.Run("reports final batch failure", func(t *testing.T) {
+		stream := make(chan domain.Chunk, 1)
+		stream <- domain.Chunk{ID: "chunk", Content: "valid"}
+		close(stream)
+		mock := &mockBatchIndexer{realIndex: index, batchErr: errors.New("batch failed")}
+		require.ErrorContains(t, service.batchIndex(context.Background(), mock, stream), "failed to execute final batch index")
+	})
+	t.Run("reports full batch failure", func(t *testing.T) {
+		stream := make(chan domain.Chunk, 100)
+		for i := 0; i < 100; i++ {
+			stream <- domain.Chunk{ID: fmt.Sprintf("chunk-%d", i), Content: "valid"}
+		}
+		close(stream)
+		mock := &mockBatchIndexer{realIndex: index, batchErr: errors.New("batch failed")}
+		require.ErrorContains(t, service.batchIndex(context.Background(), mock, stream), "failed to execute batch index")
+	})
 }
 
-func TestSearchService_DiskLifecycle(t *testing.T) {
-	// Test without InMemory=true, so it uses disk
+func TestService_IndexRebuildsAndBatchesChunks(t *testing.T) {
 	service := NewService(testSettings())
-
-	// Create index (this should trigger temp dir creation)
-	if err := indexDocsHelper(service, []domain.Document{{URI: "1", Name: "1"}}); err != nil {
-		t.Fatal(err)
-	}
-
-	// Verify indexDir is set and exists
-	if service.indexDir == "" {
-		t.Error("Expected indexDir to be set")
-	}
-	if _, err := os.Stat(service.indexDir); os.IsNotExist(err) {
-		t.Error("Expected indexDir to exist on disk")
-	}
-
-	// Close service
-	service.Close()
-
-	// Verify indexDir is removed
-	if _, err := os.Stat(service.indexDir); !os.IsNotExist(err) {
-		t.Error("Expected indexDir to be removed after Close()")
-	}
-}
-
-func TestSearchService_Extended(t *testing.T) {
-	settings := testSettings()
-	settings.InMemory = true
-	settings.MaxResults = 5
-	service := NewService(settings)
 	defer service.Close()
-
-	docs := []domain.Document{
-		{URI: "1", Name: "Alpha", Content: "Content Alpha"},
-		{URI: "2", Name: "Bravo", Content: "Content Bravo"},
-		{URI: "3", Name: "Charlie", Content: "Content Charlie"},
+	chunks := make([]domain.Chunk, 150)
+	for i := range chunks {
+		chunks[i] = domain.Chunk{ID: fmt.Sprintf("chunk-%d", i), SourceID: "source", SourceURI: "acdc://source", ChunkURI: fmt.Sprintf("acdc://source#%d", i), Content: "content"}
 	}
-	if err := indexDocsHelper(service, docs); err != nil {
-		t.Fatal(err)
-	}
-
-	// 1. Test MatchAll (search with "*")
-	results, err := service.Search("*", nil)
-	if err != nil {
-		t.Fatalf("Search failed: %v", err)
-	}
-	if len(results) != 3 {
-		t.Errorf("Expected 3 results for match all, got %d", len(results))
-	}
-
-	// 2. Test MaxResults and Limits
-	// Default from settings is 5, request explicit limit 1
-	limit := 1
-	results, err = service.Search("*", &limit)
-	if err != nil {
-		t.Fatalf("Search with limit failed: %v", err)
-	}
-	if len(results) != 1 {
-		t.Errorf("Expected 1 result with limit=1, got %d", len(results))
-	}
-
-	// Test nil limit uses MaxResults (all 3 should return because MaxResults=5)
-	results, err = service.Search("*", nil)
-	if err != nil {
-		t.Fatalf("Search with nil limit failed: %v", err)
-	}
-	if len(results) != 3 {
-		t.Errorf("Expected 3 results (within MaxResults=5), got %d", len(results))
-	}
-
-	// 3. Test Result fields (Snippet, URI, Name)
-	// Searching for "Alpha" should return doc 1
-	results, err = service.Search("Alpha", nil)
-	if err != nil {
-		t.Fatalf("Search failed: %v", err)
-	}
-	if len(results) != 1 {
-		t.Fatalf("Expected 1 result for 'Alpha', got %d", len(results))
-	}
-	r := results[0]
-	if r.URI != "1" {
-		t.Errorf("Expected URI '1', got %s", r.URI)
-	}
-	if r.Name != "Alpha" {
-		t.Errorf("Expected Name 'Alpha', got %s", r.Name)
-	}
-	// Snippet format check: should contain relevance score and match content or name
-	if !contains(r.Snippet, "relevance:") {
-		t.Errorf("Snippet '%s' missing 'relevance:'", r.Snippet)
-	}
-	if !contains(r.Snippet, "Alpha") {
-		t.Errorf("Snippet '%s' missing match term 'Alpha'", r.Snippet)
-	}
+	indexChunks(t, service, chunks)
+	count, err := service.DocCount()
+	require.NoError(t, err)
+	require.Equal(t, uint64(len(chunks)), count)
+	indexChunks(t, service, []domain.Chunk{{ID: "replacement", SourceID: "new", SourceURI: "acdc://new", ChunkURI: "acdc://new#replacement", Content: "new"}})
+	count, err = service.DocCount()
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), count)
 }
 
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || stringsContains(s, substr))
-}
-
-func stringsContains(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
-}
-
-// TestSearch_AccuracyFeatures verifies fuzzy matching and stemming
-func TestSearch_AccuracyFeatures(t *testing.T) {
-	settings := testSettings()
-	settings.InMemory = true
-	service := NewService(settings)
+func TestService_ReplaceAndDeleteSource(t *testing.T) {
+	service := NewService(testSettings())
 	defer service.Close()
+	indexChunks(t, service, []domain.Chunk{{ID: "old", SourceID: "source", SourceURI: "acdc://source", ChunkURI: "acdc://source#old", Content: "legacy"}})
 
-	if err := indexDocsHelper(service, []domain.Document{
-		{
-			URI:     "acdc://test",
-			Name:    "Search Service",
-			Content: "This is a document about searching capabilities.",
-		},
-	}); err != nil {
-		t.Fatalf("IndexDocuments failed: %v", err)
-	}
+	require.NoError(t, service.ReplaceSource(context.Background(), "source", []domain.Chunk{{ID: "new", SourceID: "source", SourceURI: "acdc://source", ChunkURI: "acdc://source#new", Content: "modern"}}))
+	oldResults, err := service.Search("legacy", 10)
+	require.NoError(t, err)
+	require.Empty(t, oldResults)
+	newResults, err := service.Search("modern", 10)
+	require.NoError(t, err)
+	require.Len(t, newResults, 1)
 
-	// 1. Test Stemming (search "search" matches "searching")
-	results, err := service.Search("search", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(results) != 1 {
-		t.Errorf("Expected 1 result for stemmed match 'search', got %d", len(results))
-	}
-
-	// 2. Test Fuzzy Match (search "serch" matches "Search")
-	results, err = service.Search("serch", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(results) != 1 {
-		t.Errorf("Expected 1 result for fuzzy match 'serch', got %d", len(results))
-	}
+	require.NoError(t, service.DeleteSource(context.Background(), "source"))
+	newResults, err = service.Search("modern", 10)
+	require.NoError(t, err)
+	require.Empty(t, newResults)
 }
 
-func TestSearch_MissingName(t *testing.T) {
-	settings := testSettings()
-	settings.InMemory = true
-	service := NewService(settings)
-	if err := indexDocsHelper(service, []domain.Document{
-		{
-			URI:     "acdc://test",
-			Name:    "", // empty name to trigger fallback
-			Content: "The quick brown fox jumps over the lazy dog",
-		},
-	}); err != nil {
-		t.Fatalf("IndexDocuments failed: %v", err)
-	}
+func TestService_ReplaceSource_InvalidChunkPreservesExistingSource(t *testing.T) {
+	service := NewService(testSettings())
 	defer service.Close()
+	indexChunks(t, service, []domain.Chunk{{ID: "old", SourceID: "source", SourceURI: "acdc://source", ChunkURI: "acdc://source#old", Content: "legacy"}})
 
-	results, err := service.Search("fox", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(results) != 1 {
-		t.Fatalf("Expected 1 result for 'fox', got %d", len(results))
-	}
-	if results[0].Name != "Unknown" {
-		t.Errorf("Expected name 'Unknown', got '%s'", results[0].Name)
-	}
+	err := service.ReplaceSource(context.Background(), "source", []domain.Chunk{{Content: "invalid"}})
+	require.ErrorContains(t, err, "failed to add replacement chunk to batch")
+	results, err := service.Search("legacy", 10)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Equal(t, "old", results[0].ChunkID)
 }
 
-func TestSearch_MissingURI(t *testing.T) {
-	settings := testSettings()
-	settings.InMemory = true
-	service := NewService(settings)
-
-	// Since we can't easily produce a hit without a URI using IndexDocuments,
-	// we use a real index and custom indexing logic just for this test.
-	index, _ := bleve.NewMemOnly(buildMapping())
-	_ = index.Index("1", struct {
-		Name    string `json:"name"`
-		Content string `json:"content"`
-	}{
-		Name:    "TestDoc",
-		Content: "Some test content",
-	})
-	service.index = index
-	defer service.Close()
-
-	results, err := service.Search("test", nil)
-	if err != nil {
-		t.Fatal(err)
+func chunkIDs(results []SearchResult) []string {
+	ids := make([]string, len(results))
+	for i, result := range results {
+		ids[i] = result.ChunkID
 	}
-	// Documents missing URI should be skipped
-	if len(results) != 0 {
-		t.Errorf("Expected 0 results because URI is missing, got %d", len(results))
-	}
-}
-
-func TestSearch_WrongTypeName(t *testing.T) {
-	settings := testSettings()
-	settings.InMemory = true
-	service := NewService(settings)
-	index, _ := bleve.NewMemOnly(buildMapping())
-	_ = index.Index("acdc://test", struct {
-		URI     string `json:"uri"`
-		Name    int    `json:"name"` // wrong type
-		Content string `json:"content"`
-	}{
-		URI:     "acdc://test",
-		Name:    123,
-		Content: "Some test content",
-	})
-	service.index = index
-	defer service.Close()
-
-	results, err := service.Search("test", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(results) != 1 {
-		t.Fatalf("Expected 1 result, got %d", len(results))
-	}
-	if results[0].Name != "Unknown" {
-		t.Errorf("Expected name 'Unknown', got '%s'", results[0].Name)
-	}
-}
-
-// TestSearch_KeywordsBoosting proves that documents with matching keywords
-// score higher than documents without keywords, even with identical content.
-// This test is strict: both documents match the search term in content,
-// but only one has it as a keyword. The keyword-boosted doc must rank first
-// AND have a measurably higher score.
-func TestSearch_KeywordsBoosting(t *testing.T) {
-	settings := testSettings()
-	settings.InMemory = true
-	service := NewService(settings)
-	defer service.Close()
-
-	// CRITICAL: Both documents contain "development" in their content
-	// Only doc2 has "development" as a keyword (which gets 2x boost)
-	docs := []domain.Document{
-		{
-			URI:      "acdc://doc1",
-			Name:     "Document One",
-			Content:  "Information about software development practices", // Has "development" in content
-			Keywords: nil,                                                // No keywords
-		},
-		{
-			URI:      "acdc://doc2",
-			Name:     "Document Two",
-			Content:  "Information about software development practices", // Same content with "development"
-			Keywords: []string{"development", "coding"},                  // Also has "development" as keyword
-		},
-	}
-
-	if err := indexDocsHelper(service, docs); err != nil {
-		t.Fatalf("IndexDocuments failed: %v", err)
-	}
-
-	// Search for "development" - both docs match in content, but doc2 also matches in keywords
-	results, err := service.Search("development", nil)
-	if err != nil {
-		t.Fatalf("Search failed: %v", err)
-	}
-
-	// Both documents should match (they both have "development" in content)
-	if len(results) != 2 {
-		t.Fatalf("Expected 2 results (both docs contain 'development'), got %d", len(results))
-	}
-
-	// doc2 MUST be first because it has "development" as a boosted keyword (2x boost)
-	if results[0].URI != "acdc://doc2" {
-		t.Errorf("Expected doc2 (with keyword boost) to rank first, got %s", results[0].URI)
-	}
-	if results[1].URI != "acdc://doc1" {
-		t.Errorf("Expected doc1 to rank second, got %s", results[1].URI)
-	}
-}
-
-// TestSearch_KeywordsEmpty verifies that empty/nil keywords don't affect search behavior
-func TestSearch_KeywordsEmpty(t *testing.T) {
-	settings := testSettings()
-	settings.InMemory = true
-	service := NewService(settings)
-	defer service.Close()
-
-	docs := []domain.Document{
-		{
-			URI:      "acdc://doc1",
-			Name:     "Alpha Doc",
-			Content:  "The quick brown fox jumps",
-			Keywords: nil, // nil keywords
-		},
-		{
-			URI:      "acdc://doc2",
-			Name:     "Beta Doc",
-			Content:  "The slow gray elephant walks",
-			Keywords: []string{}, // empty keywords slice
-		},
-	}
-
-	if err := indexDocsHelper(service, docs); err != nil {
-		t.Fatalf("IndexDocuments failed: %v", err)
-	}
-
-	// Search should still work normally
-	results, err := service.Search("fox", nil)
-	if err != nil {
-		t.Fatalf("Search failed: %v", err)
-	}
-	if len(results) != 1 {
-		t.Fatalf("Expected 1 result for 'fox', got %d", len(results))
-	}
-	if results[0].URI != "acdc://doc1" {
-		t.Errorf("Expected doc1, got %s", results[0].URI)
-	}
-
-	results, err = service.Search("elephant", nil)
-	if err != nil {
-		t.Fatalf("Search failed: %v", err)
-	}
-	if len(results) != 1 {
-		t.Fatalf("Expected 1 result for 'elephant', got %d", len(results))
-	}
-	if results[0].URI != "acdc://doc2" {
-		t.Errorf("Expected doc2, got %s", results[0].URI)
-	}
-}
-
-// TestSearch_MultipleKeywords verifies that multiple keywords work correctly
-func TestSearch_MultipleKeywords(t *testing.T) {
-	settings := testSettings()
-	settings.InMemory = true
-	service := NewService(settings)
-	defer service.Close()
-
-	docs := []domain.Document{
-		{
-			URI:      "acdc://api-guide",
-			Name:     "API Guide",
-			Content:  "General documentation for developers",
-			Keywords: []string{"api", "rest", "http", "json"},
-		},
-	}
-
-	if err := indexDocsHelper(service, docs); err != nil {
-		t.Fatalf("IndexDocuments failed: %v", err)
-	}
-
-	// Each keyword should match
-	for _, kw := range []string{"api", "rest", "http", "json"} {
-		results, err := service.Search(kw, nil)
-		if err != nil {
-			t.Fatalf("Search for '%s' failed: %v", kw, err)
-		}
-		if len(results) != 1 {
-			t.Errorf("Expected 1 result for keyword '%s', got %d", kw, len(results))
-		}
-	}
-}
-
-// TestSearch_KeywordsOnlyMatch verifies that keywords alone can match a document
-// even when the search term is not in the content
-func TestSearch_KeywordsOnlyMatch(t *testing.T) {
-	settings := testSettings()
-	settings.InMemory = true
-	service := NewService(settings)
-	defer service.Close()
-
-	docs := []domain.Document{
-		{
-			URI:      "acdc://guide",
-			Name:     "Programming Guide",
-			Content:  "This document discusses various programming concepts", // No "golang"
-			Keywords: []string{"golang", "go"},                               // But has it as keyword
-		},
-	}
-
-	if err := indexDocsHelper(service, docs); err != nil {
-		t.Fatalf("IndexDocuments failed: %v", err)
-	}
-
-	// Search for "golang" - only in keywords, not in content or name
-	results, err := service.Search("golang", nil)
-	if err != nil {
-		t.Fatalf("Search failed: %v", err)
-	}
-
-	if len(results) != 1 {
-		t.Fatalf("Expected 1 result for keyword-only match 'golang', got %d", len(results))
-	}
-	if results[0].URI != "acdc://guide" {
-		t.Errorf("Expected acdc://guide, got %s", results[0].URI)
-	}
+	return ids
 }

--- a/internal/search/service_test.go
+++ b/internal/search/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/blevesearch/bleve/v2"
@@ -193,6 +194,48 @@ func TestService_Index_ContextCancellation(t *testing.T) {
 	require.ErrorIs(t, service.Index(ctx, make(chan domain.Chunk)), context.Canceled)
 }
 
+func TestService_Index_FailedRebuildPreservesExistingIndex(t *testing.T) {
+	tests := []struct {
+		name   string
+		stream func(t *testing.T) (context.Context, <-chan domain.Chunk)
+	}{
+		{
+			name: "cancellation",
+			stream: func(t *testing.T) (context.Context, <-chan domain.Chunk) {
+				t.Helper()
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx, make(chan domain.Chunk)
+			},
+		},
+		{
+			name: "batch failure",
+			stream: func(t *testing.T) (context.Context, <-chan domain.Chunk) {
+				t.Helper()
+				chunks := make(chan domain.Chunk, 1)
+				chunks <- domain.Chunk{Content: "invalid"}
+				close(chunks)
+				return context.Background(), chunks
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := NewService(testSettings())
+			defer service.Close()
+			indexChunks(t, service, []domain.Chunk{{ID: "stable", SourceID: "source", SourceURI: "acdc://source", ChunkURI: "acdc://source#stable", Content: "stable content"}})
+
+			ctx, chunks := tt.stream(t)
+			require.Error(t, service.Index(ctx, chunks))
+			results, err := service.Search("stable", 10)
+			require.NoError(t, err)
+			require.Len(t, results, 1)
+			require.Equal(t, "stable", results[0].ChunkID)
+		})
+	}
+}
+
 func TestService_BatchIndexFailures(t *testing.T) {
 	service := NewService(testSettings())
 	defer service.Close()
@@ -270,6 +313,42 @@ func TestService_ReplaceSource_InvalidChunkPreservesExistingSource(t *testing.T)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	require.Equal(t, "old", results[0].ChunkID)
+}
+
+func TestService_ReplaceSource_SerializesConcurrentMutations(t *testing.T) {
+	service := NewService(testSettings())
+	defer service.Close()
+	indexChunks(t, service, []domain.Chunk{{ID: "old", SourceID: "source", SourceURI: "acdc://source", ChunkURI: "acdc://source#old", Content: "legacy"}})
+
+	const replacements = 32
+	start := make(chan struct{})
+	errs := make(chan error, replacements)
+	var wait sync.WaitGroup
+	for i := 0; i < replacements; i++ {
+		wait.Add(1)
+		go func(i int) {
+			defer wait.Done()
+			<-start
+			errs <- service.ReplaceSource(context.Background(), "source", []domain.Chunk{{
+				ID:        fmt.Sprintf("replacement-%d", i),
+				SourceID:  "source",
+				SourceURI: "acdc://source",
+				ChunkURI:  fmt.Sprintf("acdc://source#replacement-%d", i),
+				Content:   "replacement",
+			}})
+		}(i)
+	}
+	close(start)
+	wait.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	results, err := service.Search("replacement", replacements)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Equal(t, "source", results[0].SourceID)
 }
 
 func chunkIDs(results []SearchResult) []string {

--- a/internal/search/service_test.go
+++ b/internal/search/service_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"sync"
 	"testing"
 
 	"github.com/blevesearch/bleve/v2"
+	"github.com/blevesearch/bleve/v2/mapping"
 	"github.com/sha1n/mcp-acdc-server/internal/config"
 	"github.com/sha1n/mcp-acdc-server/internal/domain"
 	"github.com/stretchr/testify/require"
@@ -16,6 +18,38 @@ import (
 type mockBatchIndexer struct {
 	realIndex bleve.Index
 	batchErr  error
+}
+
+type failingSearchIndex struct {
+	backing     bleve.Index
+	batchErr    error
+	searchErr   error
+	docCountErr error
+}
+
+func (i *failingSearchIndex) NewBatch() *bleve.Batch { return i.backing.NewBatch() }
+
+func (i *failingSearchIndex) Batch(batch *bleve.Batch) error {
+	if i.batchErr != nil {
+		return i.batchErr
+	}
+	return i.backing.Batch(batch)
+}
+
+func (i *failingSearchIndex) Search(request *bleve.SearchRequest) (*bleve.SearchResult, error) {
+	if i.searchErr != nil {
+		return nil, i.searchErr
+	}
+	return i.backing.Search(request)
+}
+
+func (i *failingSearchIndex) Close() error { return i.backing.Close() }
+
+func (i *failingSearchIndex) DocCount() (uint64, error) {
+	if i.docCountErr != nil {
+		return 0, i.docCountErr
+	}
+	return i.backing.DocCount()
 }
 
 func (m *mockBatchIndexer) NewBatch() *bleve.Batch { return m.realIndex.NewBatch() }
@@ -184,6 +218,187 @@ func TestSearch_EmptyIndex(t *testing.T) {
 	results, err := service.Search("anything", 10)
 	require.NoError(t, err)
 	require.Empty(t, results)
+}
+
+func TestSearch_UsesSourceTitleWhenContentHasNoSnippet(t *testing.T) {
+	service := NewService(testSettings())
+	defer service.Close()
+	indexChunks(t, service, []domain.Chunk{{ID: "title", SourceID: "source", SourceURI: "acdc://source", ChunkURI: "acdc://source#title", SourceTitle: "Title fallback"}})
+
+	results, err := service.Search("title", 10)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Equal(t, "Title fallback", results[0].Snippet)
+}
+
+func TestSearch_FieldConversions(t *testing.T) {
+	fields := map[string]interface{}{
+		"strings":     []string{"first", "second"},
+		"interfaces":  []interface{}{"first", 1, "second"},
+		"single":      "only",
+		"unsupported": []int{1},
+		"float64":     float64(1),
+		"float32":     float32(2),
+		"int":         3,
+		"int64":       int64(4),
+		"no-number":   "five",
+	}
+
+	require.Equal(t, []string{"first", "second"}, fieldStrings(fields, "strings"))
+	require.Equal(t, []string{"first", "second"}, fieldStrings(fields, "interfaces"))
+	require.Equal(t, []string{"only"}, fieldStrings(fields, "single"))
+	require.Nil(t, fieldStrings(fields, "unsupported"))
+	require.Equal(t, 1, fieldInt(fields, "float64"))
+	require.Equal(t, 2, fieldInt(fields, "float32"))
+	require.Equal(t, 3, fieldInt(fields, "int"))
+	require.Equal(t, 4, fieldInt(fields, "int64"))
+	require.Zero(t, fieldInt(fields, "no-number"))
+}
+
+func TestService_ReportsIndexOperationFailures(t *testing.T) {
+	backing, err := bleve.NewMemOnly(buildMapping())
+	require.NoError(t, err)
+	service := NewService(testSettings())
+	defer service.Close()
+	service.index = &failingSearchIndex{backing: backing, searchErr: errors.New("search failed")}
+
+	results, err := service.Search("query", 10)
+	require.ErrorContains(t, err, "search failed")
+	require.Nil(t, results)
+}
+
+func TestService_MutationFailureBoundaries(t *testing.T) {
+	t.Run("replace cancellation and uninitialized index", func(t *testing.T) {
+		service := NewService(testSettings())
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		require.ErrorIs(t, service.ReplaceSource(ctx, "source", nil), context.Canceled)
+		require.ErrorContains(t, service.ReplaceSource(context.Background(), "source", nil), "not initialized")
+	})
+
+	t.Run("replace and delete batch failures preserve source state", func(t *testing.T) {
+		backing, err := bleve.NewMemOnly(buildMapping())
+		require.NoError(t, err)
+		index := &failingSearchIndex{backing: backing, batchErr: errors.New("batch failed")}
+		service := NewService(testSettings())
+		defer service.Close()
+		service.index = index
+		service.sourceChunks = map[string][]string{"source": {"old"}}
+
+		require.ErrorContains(t, service.ReplaceSource(context.Background(), "source", []domain.Chunk{{ID: "new"}}), "failed to replace source chunks")
+		require.ErrorContains(t, service.DeleteSource(context.Background(), "source"), "failed to delete source chunks")
+		index.batchErr = nil
+		require.NoError(t, service.DeleteSource(context.Background(), "source"))
+		require.NotContains(t, service.sourceChunks, "source")
+	})
+
+	t.Run("delete cancellation, no index, and unknown source", func(t *testing.T) {
+		service := NewService(testSettings())
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		require.ErrorIs(t, service.DeleteSource(ctx, "source"), context.Canceled)
+		require.NoError(t, service.DeleteSource(context.Background(), "source"))
+		indexChunks(t, service, []domain.Chunk{{ID: "known", SourceID: "known", SourceURI: "acdc://known", ChunkURI: "acdc://known#chunk", Content: "known"}})
+		require.NoError(t, service.DeleteSource(context.Background(), "unknown"))
+		results, err := service.Search("known", 10)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+	})
+}
+
+func TestService_IndexCreationFailuresPreserveExistingState(t *testing.T) {
+	settings := testSettings()
+	settings.InMemory = false
+	service := NewService(settings)
+	defer service.Close()
+	indexChunks(t, service, []domain.Chunk{{ID: "stable", SourceID: "source", SourceURI: "acdc://source", ChunkURI: "acdc://source#stable", Content: "stable"}})
+
+	originalMakeTempDir := makeTempDir
+	makeTempDir = func(string, string) (string, error) { return "", errors.New("temp failure") }
+	t.Cleanup(func() { makeTempDir = originalMakeTempDir })
+	chunks := make(chan domain.Chunk)
+	close(chunks)
+	require.ErrorContains(t, service.Index(context.Background(), chunks), "temp failure")
+	results, err := service.Search("stable", 10)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+}
+
+func TestService_NewIndexReportsDependencyFailures(t *testing.T) {
+	t.Run("memory index", func(t *testing.T) {
+		service := NewService(testSettings())
+		originalNewMemoryIndex := newMemoryIndex
+		newMemoryIndex = func(mapping.IndexMapping) (bleve.Index, error) { return nil, errors.New("memory failure") }
+		t.Cleanup(func() { newMemoryIndex = originalNewMemoryIndex })
+		_, _, err := service.newIndex()
+		require.ErrorContains(t, err, "memory failure")
+	})
+
+	t.Run("remove temporary directory", func(t *testing.T) {
+		settings := testSettings()
+		settings.InMemory = false
+		service := NewService(settings)
+		originalMakeTempDir, originalRemoveAll := makeTempDir, removeAll
+		makeTempDir = func(string, string) (string, error) { return filepath.Join(t.TempDir(), "index"), nil }
+		removeAll = func(string) error { return errors.New("remove failure") }
+		t.Cleanup(func() {
+			makeTempDir = originalMakeTempDir
+			removeAll = originalRemoveAll
+		})
+		_, _, err := service.newIndex()
+		require.ErrorContains(t, err, "remove failure")
+	})
+
+	t.Run("create disk index", func(t *testing.T) {
+		settings := testSettings()
+		settings.InMemory = false
+		service := NewService(settings)
+		originalNewDiskIndex := newDiskIndex
+		newDiskIndex = func(string, mapping.IndexMapping) (bleve.Index, error) { return nil, errors.New("disk failure") }
+		t.Cleanup(func() { newDiskIndex = originalNewDiskIndex })
+		_, _, err := service.newIndex()
+		require.ErrorContains(t, err, "disk failure")
+	})
+}
+
+func TestService_CloseCleansUpDiskIndexAndDocCount(t *testing.T) {
+	settings := testSettings()
+	settings.InMemory = false
+	service := NewService(settings)
+	indexChunks(t, service, []domain.Chunk{{ID: "disk", SourceID: "source", SourceURI: "acdc://source", ChunkURI: "acdc://source#disk", Content: "disk"}})
+	indexDir := service.indexDir
+	require.DirExists(t, indexDir)
+
+	service.Close()
+	require.NoDirExists(t, indexDir)
+	count, err := service.DocCount()
+	require.NoError(t, err)
+	require.Zero(t, count)
+	service.Close()
+}
+
+func TestService_DiskRebuildCleansUpPrivateAndReplacedIndexes(t *testing.T) {
+	settings := testSettings()
+	settings.InMemory = false
+	service := NewService(settings)
+	defer service.Close()
+	indexChunks(t, service, []domain.Chunk{{ID: "old", SourceID: "source", SourceURI: "acdc://source", ChunkURI: "acdc://source#old", Content: "old"}})
+	oldIndexDir := service.indexDir
+
+	invalidChunks := make(chan domain.Chunk, 1)
+	invalidChunks <- domain.Chunk{Content: "invalid"}
+	close(invalidChunks)
+	require.Error(t, service.Index(context.Background(), invalidChunks))
+	require.DirExists(t, oldIndexDir)
+	results, err := service.Search("old", 10)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	indexChunks(t, service, []domain.Chunk{{ID: "new", SourceID: "source", SourceURI: "acdc://source", ChunkURI: "acdc://source#new", Content: "new"}})
+	require.NoDirExists(t, oldIndexDir)
+	results, err = service.Search("new", 10)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
 }
 
 func TestService_Index_ContextCancellation(t *testing.T) {


### PR DESCRIPTION
## Summary
Index configured Markdown chunks as structured Bleve records so search can rank provenance-aware results and mutate one source atomically.

## Changes
- replace whole-document search fields with stored chunk identity, provenance, content, and line metadata
- apply deterministic field-weighted ranking with bounded candidate retrieval
- add atomic source replacement and deletion with synchronized index lifecycle and non-destructive failed rebuilds
- adapt current MCP and app callers at the task boundary without changing tool input schemas