### PR TITLE
feat(mcp): [6/9] present focused chunk search results

### DIFF
--- a/internal/app/factory.go
+++ b/internal/app/factory.go
@@ -73,7 +73,7 @@ func CreateMCPServer(settings *config.Settings) (*mcpsdk.Server, func(), error) 
 	IndexResources(context.Background(), resourceProvider, searchService)
 
 	// Create MCP server
-	mcpServer := mcp.CreateServer(metadata, resourceProvider, promptProvider, searchService)
+	mcpServer := mcp.CreateServer(metadata, resourceProvider, promptProvider, searchService, settings.Search)
 
 	return mcpServer, cleanup, nil
 }

--- a/internal/mcp/search_presenter.go
+++ b/internal/mcp/search_presenter.go
@@ -1,0 +1,70 @@
+package mcp
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sha1n/mcp-acdc-server/internal/config"
+	"github.com/sha1n/mcp-acdc-server/internal/search"
+)
+
+const candidateMultiplier = 5
+
+func selectSearchResults(results []search.SearchResult, mode config.SearchResultMode, limit int) []search.SearchResult {
+	if limit <= 0 {
+		return nil
+	}
+
+	selected := make([]search.SearchResult, 0, min(len(results), limit))
+	perSource := make(map[string]int)
+
+	for _, result := range results {
+		if len(selected) == limit {
+			break
+		}
+
+		if mode == config.SearchResultModeReferences {
+			if perSource[result.SourceID] > 0 {
+				continue
+			}
+		} else if perSource[result.SourceID] == 2 {
+			continue
+		}
+
+		selected = append(selected, result)
+		perSource[result.SourceID]++
+	}
+
+	return selected
+}
+
+func formatSearchResults(query string, results []search.SearchResult, mode config.SearchResultMode) string {
+	if len(results) == 0 {
+		return fmt.Sprintf("No results found for '%s'", query)
+	}
+
+	var output strings.Builder
+	fmt.Fprintf(&output, "Search results for '%s':\n\n", query)
+	for _, result := range results {
+		fmt.Fprintf(&output, "- **%s** · [%s](%s)\n", result.SourceTitle, result.ChunkURI, result.ChunkURI)
+		fmt.Fprintf(&output, "  - %s · lines %d-%d · score %.2f\n", searchBreadcrumb(result), result.StartLine, result.EndLine, result.Score)
+		fmt.Fprintf(&output, "  - %s\n", result.Snippet)
+
+		if mode == config.SearchResultModeContent {
+			fmt.Fprintf(&output, "\n%s\n", result.Content)
+		}
+
+		output.WriteString("\n")
+	}
+
+	return output.String()
+}
+
+func searchBreadcrumb(result search.SearchResult) string {
+	parts := make([]string, 0, len(result.HeadingPath)+1)
+	if result.SourcePath != "" {
+		parts = append(parts, result.SourcePath)
+	}
+	parts = append(parts, result.HeadingPath...)
+	return strings.Join(parts, " > ")
+}

--- a/internal/mcp/search_presenter_test.go
+++ b/internal/mcp/search_presenter_test.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/sha1n/mcp-acdc-server/internal/config"
@@ -20,17 +21,30 @@ func TestSelectSearchResults_ReferencesOnePerSource(t *testing.T) {
 	require.Equal(t, []string{"a1", "b1"}, selectedIDs(selected))
 }
 
-func TestSelectSearchResults_ContentCapsPerSourceAndGlobal(t *testing.T) {
+func TestSelectSearchResults_ContentCapsPerSourceAndGlobalLimit(t *testing.T) {
 	results := []search.SearchResult{
 		{ChunkID: "a1", SourceID: "a"},
 		{ChunkID: "a2", SourceID: "a"},
 		{ChunkID: "a3", SourceID: "a"},
 		{ChunkID: "b1", SourceID: "b"},
+		{ChunkID: "c1", SourceID: "c"},
 	}
 
 	selected := selectSearchResults(results, config.SearchResultModeContent, 3)
 
 	require.Equal(t, []string{"a1", "a2", "b1"}, selectedIDs(selected))
+}
+
+func TestSelectSearchResults_NonPositiveLimitReturnsNoResults(t *testing.T) {
+	results := []search.SearchResult{{ChunkID: "a1", SourceID: "a"}}
+
+	for _, limit := range []int{0, -1} {
+		t.Run(fmt.Sprintf("limit=%d", limit), func(t *testing.T) {
+			selected := selectSearchResults(results, config.SearchResultModeContent, limit)
+
+			require.Empty(t, selected)
+		})
+	}
 }
 
 func TestFormatSearchResults_Provenance(t *testing.T) {

--- a/internal/mcp/search_presenter_test.go
+++ b/internal/mcp/search_presenter_test.go
@@ -1,0 +1,65 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/sha1n/mcp-acdc-server/internal/config"
+	"github.com/sha1n/mcp-acdc-server/internal/search"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectSearchResults_ReferencesOnePerSource(t *testing.T) {
+	results := []search.SearchResult{
+		{ChunkID: "a1", SourceID: "a", SourceURI: "acdc://a", ChunkURI: "acdc://a#one", Score: 5},
+		{ChunkID: "a2", SourceID: "a", SourceURI: "acdc://a", ChunkURI: "acdc://a#two", Score: 4},
+		{ChunkID: "b1", SourceID: "b", SourceURI: "acdc://b", ChunkURI: "acdc://b#one", Score: 3},
+	}
+
+	selected := selectSearchResults(results, config.SearchResultModeReferences, 10)
+
+	require.Equal(t, []string{"a1", "b1"}, selectedIDs(selected))
+}
+
+func TestSelectSearchResults_ContentCapsPerSourceAndGlobal(t *testing.T) {
+	results := []search.SearchResult{
+		{ChunkID: "a1", SourceID: "a"},
+		{ChunkID: "a2", SourceID: "a"},
+		{ChunkID: "a3", SourceID: "a"},
+		{ChunkID: "b1", SourceID: "b"},
+	}
+
+	selected := selectSearchResults(results, config.SearchResultModeContent, 3)
+
+	require.Equal(t, []string{"a1", "a2", "b1"}, selectedIDs(selected))
+}
+
+func TestFormatSearchResults_Provenance(t *testing.T) {
+	result := search.SearchResult{
+		SourceTitle: "Configuration",
+		SourcePath:  "docs/reference/config.md",
+		HeadingPath: []string{"Authentication", "API Keys"},
+		ChunkURI:    "acdc://docs/reference/config#api-keys",
+		StartLine:   84,
+		EndLine:     112,
+		Score:       3.5,
+		Snippet:     "rotate <mark>keys</mark>",
+		Content:     "Rotate keys safely.",
+	}
+
+	reference := formatSearchResults("keys", []search.SearchResult{result}, config.SearchResultModeReferences)
+	require.Contains(t, reference, "docs/reference/config.md")
+	require.Contains(t, reference, "Authentication > API Keys")
+	require.Contains(t, reference, "lines 84-112")
+	require.NotContains(t, reference, "Rotate keys safely.")
+
+	content := formatSearchResults("keys", []search.SearchResult{result}, config.SearchResultModeContent)
+	require.Contains(t, content, "Rotate keys safely.")
+}
+
+func selectedIDs(results []search.SearchResult) []string {
+	ids := make([]string, 0, len(results))
+	for _, result := range results {
+		ids = append(ids, result.ChunkID)
+	}
+	return ids
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/sha1n/mcp-acdc-server/internal/config"
 	"github.com/sha1n/mcp-acdc-server/internal/domain"
 	"github.com/sha1n/mcp-acdc-server/internal/prompts"
 	"github.com/sha1n/mcp-acdc-server/internal/resources"
@@ -23,6 +24,7 @@ func CreateServer(
 	resourceProvider *resources.ResourceProvider,
 	promptProvider *prompts.PromptProvider,
 	searchService search.Searcher,
+	searchSettings config.SearchSettings,
 ) *mcp.Server {
 	// Create server with official SDK
 	s := mcp.NewServer(&mcp.Implementation{
@@ -59,7 +61,7 @@ func CreateServer(
 	}
 
 	// Register Tools
-	RegisterSearchTool(s, searchService, metadata.GetToolMetadata(ToolNameSearch))
+	RegisterSearchTool(s, searchService, searchSettings, metadata.GetToolMetadata(ToolNameSearch))
 	slog.Info("Registered tool", "name", ToolNameSearch)
 
 	RegisterReadTool(s, resourceProvider, metadata.GetToolMetadata(ToolNameRead))

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/sha1n/mcp-acdc-server/internal/config"
 	"github.com/sha1n/mcp-acdc-server/internal/domain"
 	"github.com/sha1n/mcp-acdc-server/internal/prompts"
 	"github.com/sha1n/mcp-acdc-server/internal/resources"
@@ -32,7 +33,7 @@ func TestCreateServer(t *testing.T) {
 	promptProvider := prompts.NewPromptProvider([]prompts.PromptDefinition{}, nil)
 	searchService := &mockSearcher{}
 
-	server := CreateServer(metadata, resourceProvider, promptProvider, searchService)
+	server := CreateServer(metadata, resourceProvider, promptProvider, searchService, config.SearchSettings{MaxResults: 10, ResultMode: config.SearchResultModeReferences})
 	if server == nil {
 		t.Fatal("Server should not be nil")
 	}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2,11 +2,10 @@ package mcp
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
-	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/sha1n/mcp-acdc-server/internal/config"
 	"github.com/sha1n/mcp-acdc-server/internal/domain"
 	"github.com/sha1n/mcp-acdc-server/internal/resources"
 	"github.com/sha1n/mcp-acdc-server/internal/search"
@@ -23,14 +22,14 @@ type ReadToolArgument struct {
 }
 
 // RegisterSearchTool registers the search tool with the server
-func RegisterSearchTool(s *mcp.Server, searchService search.Searcher, metadata domain.ToolMetadata) {
+func RegisterSearchTool(s *mcp.Server, searchService search.Searcher, settings config.SearchSettings, metadata domain.ToolMetadata) {
 	mcp.AddTool(s,
 		&mcp.Tool{
 			Name:        metadata.Name,
 			Description: metadata.Description,
 			// InputSchema auto-generated from SearchToolArgument
 		},
-		NewSearchToolHandler(searchService),
+		NewSearchToolHandler(searchService, settings),
 	)
 }
 
@@ -47,30 +46,22 @@ func RegisterReadTool(s *mcp.Server, resourceProvider *resources.ResourceProvide
 }
 
 // NewSearchToolHandler creates the handler for the search tool
-func NewSearchToolHandler(searchService search.Searcher) mcp.ToolHandlerFor[SearchToolArgument, any] {
+func NewSearchToolHandler(searchService search.Searcher, settings config.SearchSettings) mcp.ToolHandlerFor[SearchToolArgument, any] {
 	return func(ctx context.Context, req *mcp.CallToolRequest, args SearchToolArgument) (*mcp.CallToolResult, any, error) {
 		// Args are already validated and unmarshaled by SDK via jsonschema tags
 		slog.Info("Search request", "query", args.Query)
 
-		results, err := searchService.Search(args.Query, 0)
+		results, err := searchService.Search(args.Query, settings.MaxResults*candidateMultiplier)
 		if err != nil {
 			slog.Error("Search failed", "query", args.Query, "error", err)
 			return nil, nil, err
 		}
 
-		var sb strings.Builder
-		if len(results) == 0 {
-			fmt.Fprintf(&sb, "No results found for '%s'", args.Query)
-		} else {
-			fmt.Fprintf(&sb, "Search results for '%s':\n\n", args.Query)
-			for _, r := range results {
-				fmt.Fprintf(&sb, "- [%s](%s): %s\n\n", r.SourceTitle, r.SourceURI, r.Snippet)
-			}
-		}
+		selected := selectSearchResults(results, settings.ResultMode, settings.MaxResults)
 
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: sb.String()},
+				&mcp.TextContent{Text: formatSearchResults(args.Query, selected, settings.ResultMode)},
 			},
 		}, nil, nil
 	}

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/sha1n/mcp-acdc-server/internal/config"
 	"github.com/sha1n/mcp-acdc-server/internal/domain"
 	"github.com/sha1n/mcp-acdc-server/internal/resources"
 	"github.com/sha1n/mcp-acdc-server/internal/search"
@@ -17,14 +19,16 @@ import (
 
 // Mock searcher for testing
 type TestMockSearcher struct {
-	MockSearch func(queryStr string, candidateLimit int) ([]search.SearchResult, error)
+	results        []search.SearchResult
+	err            error
+	query          string
+	candidateLimit int
 }
 
 func (m *TestMockSearcher) Search(query string, candidateLimit int) ([]search.SearchResult, error) {
-	if m.MockSearch != nil {
-		return m.MockSearch(query, candidateLimit)
-	}
-	return nil, nil
+	m.query = query
+	m.candidateLimit = candidateLimit
+	return m.results, m.err
 }
 
 func (m *TestMockSearcher) Close() {}
@@ -42,7 +46,7 @@ func (m *TestMockSearcher) DeleteSource(context.Context, string) error          
 func TestToolRegistration(t *testing.T) {
 	// Just verify tools can be created without panic
 	mockSearcher := &TestMockSearcher{}
-	searchHandler := NewSearchToolHandler(mockSearcher)
+	searchHandler := NewSearchToolHandler(mockSearcher, config.SearchSettings{})
 	if searchHandler == nil {
 		t.Error("Search handler should not be nil")
 	}
@@ -55,27 +59,30 @@ func TestToolRegistration(t *testing.T) {
 	}
 }
 
+func TestToolArgumentSchemas_ContainOnlyQueryAndURI(t *testing.T) {
+	require.Equal(t, []string{"Query"}, publicFieldNames(reflect.TypeFor[SearchToolArgument]()))
+	require.Equal(t, []string{"URI"}, publicFieldNames(reflect.TypeFor[ReadToolArgument]()))
+}
+
 func TestSearchToolHandler_Success_WithResults(t *testing.T) {
 	mockSearcher := &TestMockSearcher{
-		MockSearch: func(query string, candidateLimit int) ([]search.SearchResult, error) {
-			assert.Equal(t, "test query", query)
-			assert.Equal(t, 0, candidateLimit)
-			return []search.SearchResult{
-				{
-					SourceTitle: "Result 1",
-					SourceURI:   "acdc://result1",
-					Snippet:     "This is result 1",
-				},
-				{
-					SourceTitle: "Result 2",
-					SourceURI:   "acdc://result2",
-					Snippet:     "This is result 2",
-				},
-			}, nil
+		results: []search.SearchResult{
+			{
+				SourceID:    "result1",
+				SourceTitle: "Result 1",
+				ChunkURI:    "acdc://result1#chunk",
+				Snippet:     "This is result 1",
+			},
+			{
+				SourceID:    "result2",
+				SourceTitle: "Result 2",
+				ChunkURI:    "acdc://result2#chunk",
+				Snippet:     "This is result 2",
+			},
 		},
 	}
 
-	handler := NewSearchToolHandler(mockSearcher)
+	handler := NewSearchToolHandler(mockSearcher, config.SearchSettings{MaxResults: 10, ResultMode: config.SearchResultModeReferences})
 	require.NotNil(t, handler)
 
 	ctx := context.Background()
@@ -93,19 +100,33 @@ func TestSearchToolHandler_Success_WithResults(t *testing.T) {
 	require.True(t, ok)
 	assert.Contains(t, textContent.Text, "Search results for 'test query'")
 	assert.Contains(t, textContent.Text, "Result 1")
-	assert.Contains(t, textContent.Text, "acdc://result1")
+	assert.Contains(t, textContent.Text, "acdc://result1#chunk")
 	assert.Contains(t, textContent.Text, "This is result 1")
 	assert.Contains(t, textContent.Text, "Result 2")
+	assert.Equal(t, "test query", mockSearcher.query)
+}
+
+func TestSearchToolHandler_UsesServerWideModeAndCandidateWindow(t *testing.T) {
+	searcher := &TestMockSearcher{results: []search.SearchResult{{
+		ChunkID:     "one",
+		SourceID:    "one",
+		ChunkURI:    "acdc://one#document",
+		SourceTitle: "One",
+		Content:     "full chunk",
+	}}}
+	handler := NewSearchToolHandler(searcher, config.SearchSettings{MaxResults: 10, ResultMode: config.SearchResultModeContent})
+
+	result, _, err := handler(context.Background(), nil, SearchToolArgument{Query: "chunk"})
+
+	require.NoError(t, err)
+	require.Equal(t, 50, searcher.candidateLimit)
+	require.Contains(t, result.Content[0].(*mcp.TextContent).Text, "full chunk")
 }
 
 func TestSearchToolHandler_Success_NoResults(t *testing.T) {
-	mockSearcher := &TestMockSearcher{
-		MockSearch: func(query string, candidateLimit int) ([]search.SearchResult, error) {
-			return []search.SearchResult{}, nil
-		},
-	}
+	mockSearcher := &TestMockSearcher{}
 
-	handler := NewSearchToolHandler(mockSearcher)
+	handler := NewSearchToolHandler(mockSearcher, config.SearchSettings{MaxResults: 10, ResultMode: config.SearchResultModeReferences})
 	ctx := context.Background()
 	req := &mcp.CallToolRequest{}
 	args := SearchToolArgument{Query: "nonexistent"}
@@ -125,12 +146,10 @@ func TestSearchToolHandler_Success_NoResults(t *testing.T) {
 func TestSearchToolHandler_Error(t *testing.T) {
 	expectedErr := errors.New("search service error")
 	mockSearcher := &TestMockSearcher{
-		MockSearch: func(query string, candidateLimit int) ([]search.SearchResult, error) {
-			return nil, expectedErr
-		},
+		err: expectedErr,
 	}
 
-	handler := NewSearchToolHandler(mockSearcher)
+	handler := NewSearchToolHandler(mockSearcher, config.SearchSettings{MaxResults: 10, ResultMode: config.SearchResultModeReferences})
 	ctx := context.Background()
 	req := &mcp.CallToolRequest{}
 	args := SearchToolArgument{Query: "failing query"}
@@ -141,6 +160,17 @@ func TestSearchToolHandler_Error(t *testing.T) {
 	assert.Equal(t, expectedErr, err)
 	assert.Nil(t, result)
 	assert.Nil(t, extra)
+}
+
+func publicFieldNames(t reflect.Type) []string {
+	fieldNames := make([]string, 0, t.NumField())
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if field.IsExported() {
+			fieldNames = append(fieldNames, field.Name)
+		}
+	}
+	return fieldNames
 }
 
 func TestReadToolHandler_Success(t *testing.T) {


### PR DESCRIPTION
## Summary
Present ranked chunk search results through a bounded, process-wide references or content policy while preserving the existing MCP tool schemas.

## Changes
- select ranked chunks with mode-specific per-source diversity and a global result cap
- format deterministic provenance, highlighted excerpts, scores, and opt-in full chunk bodies
- request the configured candidate window and pass search settings through MCP server composition
- keep search and read tool arguments unchanged