### PR TITLE
feat(app): [7/9] compose configured chunk indexing

### DIFF
--- a/internal/app/factory.go
+++ b/internal/app/factory.go
@@ -16,8 +16,26 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// CreateMCPServer initializes the core MCP server components
-func CreateMCPServer(settings *config.Settings) (*mcpsdk.Server, func(), error) {
+type factoryDeps struct {
+	discover  func(context.Context, *content.ContentProvider, *domain.IndexMetadata, string) (resources.DiscoveryResult, error)
+	newSearch func(config.SearchSettings) search.Searcher
+}
+
+func defaultFactoryDeps() factoryDeps {
+	return factoryDeps{
+		discover: resources.Discover,
+		newSearch: func(settings config.SearchSettings) search.Searcher {
+			return search.NewService(settings)
+		},
+	}
+}
+
+// CreateMCPServer initializes the core MCP server components.
+func CreateMCPServer(ctx context.Context, settings *config.Settings) (*mcpsdk.Server, func(), error) {
+	return createMCPServer(ctx, settings, defaultFactoryDeps())
+}
+
+func createMCPServer(ctx context.Context, settings *config.Settings, deps factoryDeps) (*mcpsdk.Server, func(), error) {
 	// Initialize content provider
 	cp := content.NewContentProvider(settings.ContentDir)
 
@@ -39,7 +57,7 @@ func CreateMCPServer(settings *config.Settings) (*mcpsdk.Server, func(), error) 
 	}
 
 	// Discover resources
-	discovery, err := resources.Discover(context.Background(), cp, metadata.Index, settings.Scheme)
+	discovery, err := deps.discover(ctx, cp, metadata.Index, settings.Scheme)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to discover resources: %w", err)
 	}
@@ -64,16 +82,16 @@ func CreateMCPServer(settings *config.Settings) (*mcpsdk.Server, func(), error) 
 	promptProvider := prompts.NewPromptProvider(promptDefinitions, cp)
 
 	// Initialize search service
-	searchService := search.NewService(settings.Search)
-	cleanup := func() {
-		searchService.Close()
-	}
+	searchService := deps.newSearch(settings.Search)
 
 	// Index resources
-	IndexResources(context.Background(), resourceProvider, searchService)
+	if err := IndexResources(ctx, resourceProvider, searchService); err != nil {
+		searchService.Close()
+		return nil, nil, err
+	}
 
 	// Create MCP server
 	mcpServer := mcp.CreateServer(metadata, resourceProvider, promptProvider, searchService, settings.Search)
 
-	return mcpServer, cleanup, nil
+	return mcpServer, searchService.Close, nil
 }

--- a/internal/app/factory_test.go
+++ b/internal/app/factory_test.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -8,9 +10,32 @@ import (
 
 	"github.com/sha1n/mcp-acdc-server/internal/config"
 	"github.com/sha1n/mcp-acdc-server/internal/content"
+	"github.com/sha1n/mcp-acdc-server/internal/domain"
 	"github.com/sha1n/mcp-acdc-server/internal/resources"
+	"github.com/sha1n/mcp-acdc-server/internal/search"
 	"github.com/stretchr/testify/require"
 )
+
+func writeMetadataOnly(t *testing.T, metadata string) string {
+	t.Helper()
+	contentDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(contentDir, "mcp-metadata.yaml"), []byte(metadata), 0o600))
+	return contentDir
+}
+
+func appTestSettings(contentDir string) *config.Settings {
+	return &config.Settings{
+		ContentDir: contentDir,
+		Scheme:     "acdc",
+		Search: config.SearchSettings{
+			InMemory:   true,
+			ResultMode: config.SearchResultModeReferences,
+			MaxResults: 10,
+		},
+	}
+}
+
+type factoryContextKey struct{}
 
 func TestCreateMCPServer_Success(t *testing.T) {
 	tempDir := t.TempDir()
@@ -44,7 +69,7 @@ tools: []
 		},
 	}
 
-	server, cleanup, err := CreateMCPServer(settings)
+	server, cleanup, err := CreateMCPServer(context.Background(), settings)
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}
@@ -68,7 +93,7 @@ func TestCreateMCPServer_MissingMetadata(t *testing.T) {
 		},
 	}
 
-	_, _, err := CreateMCPServer(settings)
+	_, _, err := CreateMCPServer(context.Background(), settings)
 	if err == nil {
 		t.Fatal("Expected error when metadata is missing")
 	}
@@ -93,7 +118,7 @@ func TestCreateMCPServer_InvalidMetadataYAML(t *testing.T) {
 		},
 	}
 
-	_, _, err := CreateMCPServer(settings)
+	_, _, err := CreateMCPServer(context.Background(), settings)
 	if err == nil {
 		t.Fatal("Expected error for invalid YAML")
 	}
@@ -124,7 +149,7 @@ server:
 		},
 	}
 
-	_, _, err := CreateMCPServer(settings)
+	_, _, err := CreateMCPServer(context.Background(), settings)
 	if err == nil {
 		t.Fatal("Expected error for invalid metadata")
 	}
@@ -161,7 +186,7 @@ tools: []
 	}
 
 	// Invalid resources are skipped, not failed
-	server, cleanup, err := CreateMCPServer(settings)
+	server, cleanup, err := CreateMCPServer(context.Background(), settings)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -192,7 +217,7 @@ func TestCreateMCPServer_ResourceWithKeywords(t *testing.T) {
 		Search:     config.SearchSettings{InMemory: true, MaxResults: 10},
 	}
 
-	server, cleanup, err := CreateMCPServer(settings)
+	server, cleanup, err := CreateMCPServer(context.Background(), settings)
 	if err != nil {
 		t.Fatalf("Failed: %v", err)
 	}
@@ -228,7 +253,7 @@ tools: []
 	}
 
 	// Should succeed with no resources
-	server, cleanup, err := CreateMCPServer(settings)
+	server, cleanup, err := CreateMCPServer(context.Background(), settings)
 	if err != nil {
 		t.Fatalf("Failed to create server with no resources: %v", err)
 	}
@@ -238,6 +263,70 @@ tools: []
 	if server == nil {
 		t.Fatal("Server is nil")
 	}
+}
+
+func TestCreateMCPServer_ConfiguredDiscoveryFailure(t *testing.T) {
+	contentDir := writeMetadataOnly(t, `server:
+  name: test
+  version: "1"
+  instructions: test
+index:
+  include: ["docs/**/*.md"]
+`)
+
+	_, cleanup, err := CreateMCPServer(context.Background(), appTestSettings(contentDir))
+
+	require.ErrorContains(t, err, "configured index matched no files")
+	require.Nil(t, cleanup)
+}
+
+func TestCreateMCPServer_IndexFailureStopsConstruction(t *testing.T) {
+	contentDir := writeMetadataOnly(t, `server:
+  name: test
+  version: "1"
+  instructions: test
+`)
+	indexer := &fakeSearcher{indexErr: errors.New("index failed")}
+	deps := defaultFactoryDeps()
+	deps.discover = func(context.Context, *content.ContentProvider, *domain.IndexMetadata, string) (resources.DiscoveryResult, error) {
+		return resources.DiscoveryResult{}, nil
+	}
+	deps.newSearch = func(config.SearchSettings) search.Searcher {
+		return indexer
+	}
+
+	server, cleanup, err := createMCPServer(context.Background(), appTestSettings(contentDir), deps)
+
+	require.ErrorContains(t, err, "index chunks: index failed")
+	require.Nil(t, server)
+	require.Nil(t, cleanup)
+	require.Equal(t, 1, indexer.closeCalls)
+}
+
+func TestCreateMCPServer_PassesCallerContextToDiscovery(t *testing.T) {
+	contentDir := writeMetadataOnly(t, `server:
+  name: test
+  version: "1"
+  instructions: test
+`)
+	ctx := context.WithValue(context.Background(), factoryContextKey{}, "request-context")
+	deps := defaultFactoryDeps()
+	var discoveryCtx context.Context
+	deps.discover = func(gotCtx context.Context, _ *content.ContentProvider, _ *domain.IndexMetadata, _ string) (resources.DiscoveryResult, error) {
+		discoveryCtx = gotCtx
+		return resources.DiscoveryResult{}, nil
+	}
+	deps.newSearch = func(config.SearchSettings) search.Searcher {
+		return &fakeSearcher{drain: true}
+	}
+
+	server, cleanup, err := createMCPServer(ctx, appTestSettings(contentDir), deps)
+
+	require.NoError(t, err)
+	require.NotNil(t, server)
+	require.NotNil(t, cleanup)
+	require.Same(t, ctx, discoveryCtx)
+	cleanup()
 }
 
 func TestCreateMCPServer_FailsWhenConfiguredDiscoveryFails(t *testing.T) {
@@ -252,7 +341,7 @@ index:
 	require.NoError(t, os.MkdirAll(filepath.Join(contentDir, "docs"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(contentDir, "docs", "data.txt"), []byte("not markdown"), 0o644))
 
-	_, _, err := CreateMCPServer(&config.Settings{ContentDir: contentDir, Scheme: "acdc", Search: config.SearchSettings{InMemory: true}})
+	_, _, err := CreateMCPServer(context.Background(), &config.Settings{ContentDir: contentDir, Scheme: "acdc", Search: config.SearchSettings{InMemory: true}})
 	require.ErrorContains(t, err, "failed to discover resources")
 	require.ErrorContains(t, err, "configured index selected non-Markdown file")
 }
@@ -270,7 +359,7 @@ index:
 	require.NoError(t, os.WriteFile(filepath.Join(contentDir, "docs", "guide.md"), []byte("# Guide"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(contentDir, "docs", "guide.markdown"), []byte("# Guide duplicate"), 0o644))
 
-	_, _, err := CreateMCPServer(&config.Settings{ContentDir: contentDir, Scheme: "acdc", Search: config.SearchSettings{InMemory: true}})
+	_, _, err := CreateMCPServer(context.Background(), &config.Settings{ContentDir: contentDir, Scheme: "acdc", Search: config.SearchSettings{InMemory: true}})
 	require.ErrorContains(t, err, "failed to create resource provider")
 	require.ErrorContains(t, err, "duplicate source URI: acdc://docs/guide")
 }
@@ -289,7 +378,7 @@ tools:
 	_ = os.WriteFile(filepath.Join(contentDir, "mcp-metadata.yaml"), []byte(metadataContent), 0644)
 
 	settings := &config.Settings{ContentDir: contentDir}
-	_, _, err := CreateMCPServer(settings)
+	_, _, err := CreateMCPServer(context.Background(), settings)
 	if err == nil || !strings.Contains(err.Error(), "metadata validation failed") {
 		t.Errorf("Expected metadata validation error, got: %v", err)
 	}
@@ -309,7 +398,7 @@ tools:
 	_ = os.WriteFile(filepath.Join(contentDir, "mcp-metadata.yaml"), []byte(metadataContent), 0644)
 
 	settings := &config.Settings{ContentDir: contentDir}
-	_, _, err := CreateMCPServer(settings)
+	_, _, err := CreateMCPServer(context.Background(), settings)
 	if err == nil || !strings.Contains(err.Error(), "metadata validation failed") {
 		t.Errorf("Expected metadata validation error, got: %v", err)
 	}
@@ -329,7 +418,7 @@ tools:
 	_ = os.WriteFile(filepath.Join(contentDir, "mcp-metadata.yaml"), []byte(metadataContent), 0644)
 
 	settings := &config.Settings{ContentDir: contentDir}
-	_, _, err := CreateMCPServer(settings)
+	_, _, err := CreateMCPServer(context.Background(), settings)
 	if err == nil || !strings.Contains(err.Error(), "duplicate tool name") {
 		t.Errorf("Expected duplicate tool name error, got: %v", err)
 	}
@@ -356,7 +445,7 @@ func TestCreateMCPServer_PromptDiscoveryError(t *testing.T) {
 		Search:     config.SearchSettings{InMemory: true},
 	}
 
-	_, _, err := CreateMCPServer(settings)
+	_, _, err := CreateMCPServer(context.Background(), settings)
 	if err == nil {
 		t.Fatal("Expected error for prompt discovery failure")
 	}
@@ -391,7 +480,7 @@ func TestCreateMCPServer_CrossRefTransformation(t *testing.T) {
 		Search:     config.SearchSettings{InMemory: true, MaxResults: 10},
 	}
 
-	server, cleanup, err := CreateMCPServer(settings)
+	server, cleanup, err := CreateMCPServer(context.Background(), settings)
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}

--- a/internal/app/indexing.go
+++ b/internal/app/indexing.go
@@ -37,7 +37,8 @@ func IndexResources(ctx context.Context, streamer ChunkStreamer, indexer search.
 		producerErr = <-producerErrs
 	}
 
-	if producerErr != nil && (!errors.Is(producerErr, context.Canceled) || indexErr == nil) {
+	producerCanceled := errors.Is(producerErr, context.Canceled) || errors.Is(producerErr, context.DeadlineExceeded)
+	if producerErr != nil && (!producerCanceled || indexErr == nil) {
 		return fmt.Errorf("stream chunks: %w", producerErr)
 	}
 	if indexErr != nil {

--- a/internal/app/indexing.go
+++ b/internal/app/indexing.go
@@ -2,33 +2,46 @@ package app
 
 import (
 	"context"
-	"log/slog"
+	"errors"
+	"fmt"
 
 	"github.com/sha1n/mcp-acdc-server/internal/domain"
 	"github.com/sha1n/mcp-acdc-server/internal/search"
 )
 
-// ResourceStreamer streams chunks for indexing.
-type ResourceStreamer interface {
+// ChunkStreamer streams chunks for indexing.
+type ChunkStreamer interface {
 	StreamChunks(ctx context.Context, ch chan<- domain.Chunk) error
 }
 
-// IndexResources coordinates the streaming and indexing of resources
-func IndexResources(ctx context.Context, rs ResourceStreamer, indexer search.Searcher) {
-	chunksChan := make(chan domain.Chunk, 100)
+// IndexResources coordinates the streaming and indexing of resources.
+func IndexResources(ctx context.Context, streamer ChunkStreamer, indexer search.Searcher) error {
+	indexCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
-	// Start producer
+	chunksChan := make(chan domain.Chunk, 100)
+	producerErrs := make(chan error, 1)
+
 	go func() {
 		defer close(chunksChan)
-		if err := rs.StreamChunks(ctx, chunksChan); err != nil {
-			slog.Error("StreamChunks failed", "error", err)
-		}
+		producerErrs <- streamer.StreamChunks(indexCtx, chunksChan)
 	}()
 
-	// Run consumer (blocking)
-	if err := indexer.Index(ctx, chunksChan); err != nil {
-		slog.Error("Failed to index chunks", "error", err)
-	} else {
-		slog.Info("Indexed chunks finished")
+	indexErr := indexer.Index(indexCtx, chunksChan)
+
+	var producerErr error
+	select {
+	case producerErr = <-producerErrs:
+	default:
+		cancel()
+		producerErr = <-producerErrs
 	}
+
+	if producerErr != nil && (!errors.Is(producerErr, context.Canceled) || indexErr == nil) {
+		return fmt.Errorf("stream chunks: %w", producerErr)
+	}
+	if indexErr != nil {
+		return fmt.Errorf("index chunks: %w", indexErr)
+	}
+	return nil
 }

--- a/internal/app/indexing_test.go
+++ b/internal/app/indexing_test.go
@@ -110,6 +110,18 @@ func TestIndexResources_PrefersProducerErrorWhenIndexerFinishesFirst(t *testing.
 	require.ErrorContains(t, err, "stream chunks: stream failed")
 }
 
+func TestIndexResources_PrefersIndexerErrorOverProducerDeadline(t *testing.T) {
+	streamer := &fakeChunkStreamer{
+		err:                 context.DeadlineExceeded,
+		waitForCancellation: true,
+	}
+	indexer := &fakeSearcher{indexErr: errors.New("index failed")}
+
+	err := IndexResources(context.Background(), streamer, indexer)
+
+	require.ErrorContains(t, err, "index chunks: index failed")
+}
+
 func TestIndexResources_CancelsProducerWhenIndexerFails(t *testing.T) {
 	canceled := make(chan struct{}, 1)
 	streamer := &fakeChunkStreamer{waitForCancellation: true, canceled: canceled}

--- a/internal/app/indexing_test.go
+++ b/internal/app/indexing_test.go
@@ -7,61 +7,116 @@ import (
 
 	"github.com/sha1n/mcp-acdc-server/internal/domain"
 	"github.com/sha1n/mcp-acdc-server/internal/search"
+	"github.com/stretchr/testify/require"
 )
 
-type mockResourceStreamer struct {
-	err error
+type fakeChunkStreamer struct {
+	chunks              []domain.Chunk
+	err                 error
+	waitForCancellation bool
+	canceled            chan<- struct{}
 }
 
-func (m *mockResourceStreamer) StreamChunks(ctx context.Context, ch chan<- domain.Chunk) error {
-	if m.err != nil {
-		return m.err
+func (s *fakeChunkStreamer) StreamChunks(ctx context.Context, ch chan<- domain.Chunk) error {
+	for _, chunk := range s.chunks {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ch <- chunk:
+		}
 	}
-	// Simulate one chunk.
-	ch <- domain.Chunk{ID: "1", SourceID: "source"}
+	if s.waitForCancellation {
+		<-ctx.Done()
+		if s.canceled != nil {
+			s.canceled <- struct{}{}
+		}
+		if s.err != nil {
+			return s.err
+		}
+		return ctx.Err()
+	}
+	return s.err
+}
+
+type fakeSearcher struct {
+	indexErr   error
+	drain      bool
+	indexed    []domain.Chunk
+	closeCalls int
+}
+
+func (s *fakeSearcher) Index(_ context.Context, chunks <-chan domain.Chunk) error {
+	if s.drain {
+		for chunk := range chunks {
+			s.indexed = append(s.indexed, chunk)
+		}
+	}
+	return s.indexErr
+}
+
+func (*fakeSearcher) Search(string, int) ([]search.SearchResult, error) { return nil, nil }
+func (*fakeSearcher) ReplaceSource(context.Context, string, []domain.Chunk) error {
 	return nil
 }
-
-type mockIndexer struct {
-	err error
-}
-
-func (m *mockIndexer) Index(ctx context.Context, chunks <-chan domain.Chunk) error {
-	if m.err != nil {
-		return m.err
-	}
-	for range chunks {
-		// drain
-	}
-	return nil
-}
-
-func (m *mockIndexer) Search(queryStr string, candidateLimit int) ([]search.SearchResult, error) {
-	return nil, nil
-}
-func (m *mockIndexer) Close()                                                      {}
-func (m *mockIndexer) ReplaceSource(context.Context, string, []domain.Chunk) error { return nil }
-func (m *mockIndexer) DeleteSource(context.Context, string) error                  { return nil }
+func (*fakeSearcher) DeleteSource(context.Context, string) error { return nil }
+func (s *fakeSearcher) Close()                                   { s.closeCalls++ }
 
 func TestIndexResources_Success(t *testing.T) {
-	rs := &mockResourceStreamer{}
-	idx := &mockIndexer{}
+	streamer := &fakeChunkStreamer{chunks: []domain.Chunk{{ID: "one"}}}
+	indexer := &fakeSearcher{drain: true}
 
-	IndexResources(context.Background(), rs, idx)
+	err := IndexResources(context.Background(), streamer, indexer)
+
+	require.NoError(t, err)
+	require.Equal(t, []domain.Chunk{{ID: "one"}}, indexer.indexed)
 }
 
-func TestIndexResources_StreamError(t *testing.T) {
-	rs := &mockResourceStreamer{err: errors.New("stream error")}
-	idx := &mockIndexer{}
+func TestIndexResources_ReturnsProducerError(t *testing.T) {
+	streamer := &fakeChunkStreamer{err: errors.New("stream failed")}
+	indexer := &fakeSearcher{drain: true}
 
-	// Should not panic, logs error
-	IndexResources(context.Background(), rs, idx)
+	err := IndexResources(context.Background(), streamer, indexer)
+
+	require.ErrorContains(t, err, "stream chunks: stream failed")
 }
 
-func TestIndexResources_IndexError(t *testing.T) {
-	rs := &mockResourceStreamer{}
-	idx := &mockIndexer{err: errors.New("index error")}
+func TestIndexResources_ReturnsIndexerError(t *testing.T) {
+	streamer := &fakeChunkStreamer{chunks: []domain.Chunk{{ID: "one"}}}
+	indexer := &fakeSearcher{indexErr: errors.New("index failed")}
 
-	// Should not panic, logs error
-	IndexResources(context.Background(), rs, idx)
+	err := IndexResources(context.Background(), streamer, indexer)
+
+	require.ErrorContains(t, err, "index chunks: index failed")
+}
+
+func TestIndexResources_PrefersProducerErrorWhenProducerFinishesFirst(t *testing.T) {
+	streamer := &fakeChunkStreamer{err: errors.New("stream failed")}
+	indexer := &fakeSearcher{drain: true, indexErr: errors.New("index failed")}
+
+	err := IndexResources(context.Background(), streamer, indexer)
+
+	require.ErrorContains(t, err, "stream chunks: stream failed")
+}
+
+func TestIndexResources_PrefersProducerErrorWhenIndexerFinishesFirst(t *testing.T) {
+	streamer := &fakeChunkStreamer{
+		err:                 errors.New("stream failed"),
+		waitForCancellation: true,
+	}
+	indexer := &fakeSearcher{indexErr: errors.New("index failed")}
+
+	err := IndexResources(context.Background(), streamer, indexer)
+
+	require.ErrorContains(t, err, "stream chunks: stream failed")
+}
+
+func TestIndexResources_CancelsProducerWhenIndexerFails(t *testing.T) {
+	canceled := make(chan struct{}, 1)
+	streamer := &fakeChunkStreamer{waitForCancellation: true, canceled: canceled}
+	indexer := &fakeSearcher{indexErr: errors.New("index failed")}
+
+	err := IndexResources(context.Background(), streamer, indexer)
+
+	require.ErrorContains(t, err, "index chunks: index failed")
+	require.Len(t, canceled, 1)
 }

--- a/internal/app/runner.go
+++ b/internal/app/runner.go
@@ -16,7 +16,7 @@ type RunParams struct {
 	LoadSettings      func(*pflag.FlagSet) (*config.Settings, error)
 	ValidSettings     func(*config.Settings) error
 	StartSSEServer    func(*mcp.Server, *config.Settings) error
-	CreateServer      func(*config.Settings) (*mcp.Server, func(), error)
+	CreateServer      func(context.Context, *config.Settings) (*mcp.Server, func(), error)
 	CustomIOTransport mcp.Transport // Optional: for testing with custom IO
 }
 
@@ -50,7 +50,7 @@ func RunWithDeps(ctx context.Context, params RunParams, flags *pflag.FlagSet, ve
 	slog.Info("Starting MCP Acdc server", "version", version)
 	config.Log(settings)
 
-	mcpServer, cleanup, err := params.CreateServer(settings)
+	mcpServer, cleanup, err := params.CreateServer(ctx, settings)
 	if err != nil {
 		return err
 	}

--- a/internal/app/runner_test.go
+++ b/internal/app/runner_test.go
@@ -16,6 +16,8 @@ func noopValidate(*config.Settings) error {
 	return nil
 }
 
+type runnerContextKey struct{}
+
 func TestRunWithDeps_ErrorCases(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -51,7 +53,7 @@ func TestRunWithDeps_ErrorCases(t *testing.T) {
 					return &config.Settings{Transport: "sse"}, nil
 				},
 				ValidSettings: noopValidate,
-				CreateServer: func(*config.Settings) (*mcp.Server, func(), error) {
+				CreateServer: func(context.Context, *config.Settings) (*mcp.Server, func(), error) {
 					return nil, nil, errors.New("create server error")
 				},
 			},
@@ -64,7 +66,7 @@ func TestRunWithDeps_ErrorCases(t *testing.T) {
 					return &config.Settings{Transport: "sse"}, nil
 				},
 				ValidSettings: noopValidate,
-				CreateServer: func(*config.Settings) (*mcp.Server, func(), error) {
+				CreateServer: func(context.Context, *config.Settings) (*mcp.Server, func(), error) {
 					return nil, nil, nil
 				},
 				StartSSEServer: func(*mcp.Server, *config.Settings) error {
@@ -95,7 +97,7 @@ func TestRunWithDeps_Cleanup(t *testing.T) {
 			return &config.Settings{Transport: "sse"}, nil
 		},
 		ValidSettings: noopValidate,
-		CreateServer: func(*config.Settings) (*mcp.Server, func(), error) {
+		CreateServer: func(context.Context, *config.Settings) (*mcp.Server, func(), error) {
 			return nil, func() { cleanupCalled = true }, nil
 		},
 		StartSSEServer: func(*mcp.Server, *config.Settings) error {
@@ -137,7 +139,7 @@ func TestRunWithDeps_StdioWithDefaultTransport(t *testing.T) {
 			return &config.Settings{Transport: "stdio"}, nil
 		},
 		ValidSettings: noopValidate,
-		CreateServer: func(*config.Settings) (*mcp.Server, func(), error) {
+		CreateServer: func(context.Context, *config.Settings) (*mcp.Server, func(), error) {
 			// Create a minimal server
 			impl := &mcp.Implementation{Name: "test", Version: "1.0"}
 			server := mcp.NewServer(impl, nil)
@@ -174,7 +176,7 @@ func TestRunWithDeps_StdioWithCustomTransport(t *testing.T) {
 			return &config.Settings{Transport: "stdio"}, nil
 		},
 		ValidSettings: noopValidate,
-		CreateServer: func(*config.Settings) (*mcp.Server, func(), error) {
+		CreateServer: func(context.Context, *config.Settings) (*mcp.Server, func(), error) {
 			impl := &mcp.Implementation{Name: "test", Version: "1.0"}
 			server := mcp.NewServer(impl, nil)
 			return server, nil, nil
@@ -191,6 +193,31 @@ func TestRunWithDeps_StdioWithCustomTransport(t *testing.T) {
 	// Verify that the custom transport was used (Connect was called)
 	if !transportUsed {
 		t.Error("Custom transport Connect was not called")
+	}
+}
+
+func TestRunWithDeps_PassesExactCallerContextToCreateServer(t *testing.T) {
+	ctx := context.WithValue(context.Background(), runnerContextKey{}, "request-context")
+	var createServerCtx context.Context
+	params := RunParams{
+		LoadSettings: func(*pflag.FlagSet) (*config.Settings, error) {
+			return &config.Settings{Transport: "sse"}, nil
+		},
+		ValidSettings: noopValidate,
+		CreateServer: func(gotCtx context.Context, _ *config.Settings) (*mcp.Server, func(), error) {
+			createServerCtx = gotCtx
+			return nil, nil, nil
+		},
+		StartSSEServer: func(*mcp.Server, *config.Settings) error { return nil },
+	}
+
+	err := RunWithDeps(ctx, params, nil, "test")
+
+	if err != nil {
+		t.Fatalf("RunWithDeps returned error: %v", err)
+	}
+	if createServerCtx != ctx {
+		t.Fatal("CreateServer did not receive the exact caller context")
 	}
 }
 


### PR DESCRIPTION
## Summary
Compose configured chunk discovery and indexing into startup so the server is exposed only after a complete index is available. Propagate the caller context through construction and preserve deterministic producer/indexer error precedence.

## Changes
- Make chunk indexing cancellation-safe and return producer or indexer failures with contextual errors.
- Add a private factory dependency seam while keeping production composition centralized.
- Close the search service on failed indexing and return cleanup only after successful construction.