### PR TITLE
test(integration): [8/9] verify configured chunk search

### DIFF
--- a/tests/integration/configured_search_test.go
+++ b/tests/integration/configured_search_test.go
@@ -1,0 +1,166 @@
+package integration
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/sha1n/mcp-acdc-server/tests/integration/testkit"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConfiguredSearch_ReferencesAndFragmentRead verifies configured discovery, chunk
+// search in the default "references" result mode, and chunk-fragment read through a
+// real stdio MCP session.
+func TestConfiguredSearch_ReferencesAndFragmentRead(t *testing.T) {
+	client := testkit.NewStdioTestClient(t, &testkit.ContentDirOptions{
+		Metadata: `server:
+  name: repo-docs
+  version: "1"
+  instructions: search docs
+index:
+  include: ["docs/**/*.md"]
+  exclude: ["docs/generated/**"]
+`,
+		Files: map[string]string{
+			"docs/platform/auth.md":     "# Authentication\n\n## Rotating API Keys\n\nRotate keys safely.\n",
+			"docs/generated/ignored.md": "# Ignored\n\nRotate keys unsafely.\n",
+		},
+	})
+	defer client.Close()
+	ctx := context.Background()
+
+	resources, err := client.ListResources(ctx)
+	require.NoError(t, err)
+	require.Len(t, resources.Resources, 1)
+	require.Equal(t, "acdc://docs/platform/auth", resources.Resources[0].URI)
+
+	searchText := callTextTool(t, ctx, client, "search", map[string]any{"query": "rotate api keys"})
+	require.Contains(t, searchText, "docs/platform/auth.md")
+	require.Contains(t, searchText, "Authentication > Rotating API Keys")
+	require.NotContains(t, searchText, "ignored")
+
+	chunkURI := extractFirstMarkdownURI(t, searchText)
+	chunkText := callTextTool(t, ctx, client, "read", map[string]any{"uri": chunkURI})
+	require.Contains(t, chunkText, "Rotate keys safely.")
+	require.NotContains(t, chunkText, "# Authentication")
+}
+
+func callTextTool(t *testing.T, ctx context.Context, client *testkit.TestClient, name string, arguments map[string]any) string {
+	t.Helper()
+	result, err := client.CallTool(ctx, name, arguments)
+	require.NoError(t, err)
+	for _, item := range result.Content {
+		if content, ok := item.(*mcp.TextContent); ok {
+			return content.Text
+		}
+	}
+	t.Fatal("tool result did not contain text content")
+	return ""
+}
+
+var markdownURIRegexp = regexp.MustCompile(`\((acdc://[^)]+)\)`)
+
+func extractFirstMarkdownURI(t *testing.T, text string) string {
+	t.Helper()
+	match := markdownURIRegexp.FindStringSubmatch(text)
+	require.Len(t, match, 2)
+	return match[1]
+}
+
+// TestConfiguredSearch_ContentModeIncludesFullChunkBody verifies that the process-wide
+// "content" result mode, requested through ContentDirOptions.ResultMode, causes the
+// search tool itself to return the exact matched chunk body without a follow-up read.
+func TestConfiguredSearch_ContentModeIncludesFullChunkBody(t *testing.T) {
+	client := testkit.NewStdioTestClient(t, &testkit.ContentDirOptions{
+		ResultMode: "content",
+		Metadata: `server:
+  name: repo-docs
+  version: "1"
+  instructions: search docs
+index:
+  include: ["docs/**/*.md"]
+`,
+		Files: map[string]string{
+			"docs/platform/auth.md": "# Authentication\n\n## Rotating API Keys\n\nRotate keys safely.\n",
+		},
+	})
+	defer client.Close()
+	ctx := context.Background()
+
+	searchText := callTextTool(t, ctx, client, "search", map[string]any{"query": "rotate api keys"})
+	require.Contains(t, searchText, "## Rotating API Keys\n\nRotate keys safely.")
+}
+
+// TestConfiguredSearch_LegacyDiscoveryUnaffected verifies that content directories with
+// no index: section keep the pre-existing legacy behavior end to end: legacy resource
+// URIs, prompts, the unchanged search/read tool input schemas, full-document reads, and
+// cross-reference link rewriting all continue to work through a real stdio MCP session.
+func TestConfiguredSearch_LegacyDiscoveryUnaffected(t *testing.T) {
+	client := testkit.NewStdioTestClient(t, &testkit.ContentDirOptions{
+		CrossRef: true,
+		Resources: map[string]string{
+			"doc-a.md": "---\nname: Doc A\ndescription: First doc\n---\nSee [Doc B](doc-b.md) for details.\n",
+			"doc-b.md": "---\nname: Doc B\ndescription: Second doc\n---\nBack to [Doc A](doc-a.md).\n",
+		},
+		Prompts: map[string]string{
+			"greet.md": "---\nname: greet\ndescription: Greeting prompt\narguments:\n  - name: who\n    description: who to greet\n    required: true\n---\nHello {{.who}}",
+		},
+	})
+	defer client.Close()
+	ctx := context.Background()
+
+	// Legacy resource URIs remain <scheme>://<relative-path-without-extension>.
+	resourcesResult, err := client.ListResources(ctx)
+	require.NoError(t, err)
+	uris := make([]string, 0, len(resourcesResult.Resources))
+	for _, r := range resourcesResult.Resources {
+		uris = append(uris, r.URI)
+	}
+	require.Contains(t, uris, "acdc://doc-a")
+	require.Contains(t, uris, "acdc://doc-b")
+
+	// The search/read tool input schemas remain unchanged: query only, uri only.
+	toolsResult, err := client.ListTools(ctx)
+	require.NoError(t, err)
+	schemasByTool := make(map[string]any)
+	for _, tool := range toolsResult.Tools {
+		schemasByTool[tool.Name] = tool.InputSchema
+	}
+	require.ElementsMatch(t, []string{"query"}, schemaPropertyNames(t, schemasByTool["search"]))
+	require.ElementsMatch(t, []string{"uri"}, schemaPropertyNames(t, schemasByTool["read"]))
+
+	// The prompt still works.
+	promptsResult, err := client.ListPrompts(ctx)
+	require.NoError(t, err)
+	require.Len(t, promptsResult.Prompts, 1)
+	require.Equal(t, "greet", promptsResult.Prompts[0].Name)
+
+	promptResult, err := client.GetPrompt(ctx, "greet", map[string]string{"who": "ACDC"})
+	require.NoError(t, err)
+	require.Len(t, promptResult.Messages, 1)
+
+	// Full-document read strips frontmatter and rewrites the cross-referenced link.
+	readText := callTextTool(t, ctx, client, "read", map[string]any{"uri": "acdc://doc-a"})
+	require.Contains(t, readText, "See [Doc B](acdc://doc-b) for details.")
+	require.NotContains(t, readText, "---")
+}
+
+// schemaPropertyNames extracts the top-level "properties" keys from a client-observed
+// tool input schema, which the SDK exposes as the default JSON marshaling of the
+// server's schema (a map[string]any).
+func schemaPropertyNames(t *testing.T, schema any) []string {
+	t.Helper()
+	schemaMap, ok := schema.(map[string]any)
+	require.True(t, ok, "expected input schema to be a map[string]any, got %T", schema)
+
+	properties, ok := schemaMap["properties"].(map[string]any)
+	require.True(t, ok, "expected input schema to have a properties map")
+
+	names := make([]string, 0, len(properties))
+	for name := range properties {
+		names = append(names, name)
+	}
+	return names
+}

--- a/tests/integration/testkit/client.go
+++ b/tests/integration/testkit/client.go
@@ -25,8 +25,16 @@ func NewStdioTestClient(t testing.TB, contentOpts *ContentDirOptions) *TestClien
 
 	contentDir := CreateTestContentDir(t, contentOpts)
 
+	resultMode := ""
+	crossRef := false
+	if contentOpts != nil {
+		resultMode = contentOpts.ResultMode
+		crossRef = contentOpts.CrossRef
+	}
 	flags := NewTestFlags(t, contentDir, &FlagOptions{
-		Transport: "stdio",
+		Transport:  "stdio",
+		ResultMode: resultMode,
+		CrossRef:   crossRef,
 	})
 
 	service := NewACDCService("acdc-client-test", flags)

--- a/tests/integration/testkit/testkit.go
+++ b/tests/integration/testkit/testkit.go
@@ -112,9 +112,12 @@ func getFreePortWithAddr(addrStr string) (int, error) {
 
 // ContentDirOptions configures CreateTestContentDir
 type ContentDirOptions struct {
-	Metadata  string            // Custom metadata YAML (uses default if empty)
-	Resources map[string]string // filename -> content (no resources if nil)
-	Prompts   map[string]string // filename -> content (no prompts if nil)
+	Metadata   string            // Custom metadata YAML (uses default if empty)
+	Resources  map[string]string // filename -> content (no resources if nil)
+	Prompts    map[string]string // filename -> content (no prompts if nil)
+	Files      map[string]string // path (relative to content root) -> content (no extra files if nil)
+	ResultMode string            // Search result mode to request via NewStdioTestClient (process default if empty)
+	CrossRef   bool              // Cross-reference link rewriting to request via NewStdioTestClient (process default if false)
 }
 
 // DefaultMetadata returns the default test metadata YAML
@@ -177,16 +180,34 @@ func CreateTestContentDir(t testing.TB, opts *ContentDirOptions) string {
 		}
 	}
 
+	if opts != nil && opts.Files != nil {
+		for name, content := range opts.Files {
+			if !filepath.IsLocal(name) {
+				t.Fatalf("Invalid Files path %q: must be relative and confined to the content root", name)
+				continue
+			}
+			path := filepath.Join(contentDir, filepath.Clean(name))
+			if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+				t.Fatalf("Failed to create parent dir for file %s: %v", name, err)
+			}
+			if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+				t.Fatalf("Failed to write file %s: %v", name, err)
+			}
+		}
+	}
+
 	return contentDir
 }
 
 // FlagOptions configures NewTestFlags
 type FlagOptions struct {
-	Port      int    // Uses free port if 0
-	Transport string // Defaults to "sse"
-	AuthType  string // Defaults to "none"
-	Host      string // Defaults to "localhost"
-	Scheme    string // Defaults to "" (uses config default "acdc")
+	Port       int    // Uses free port if 0
+	Transport  string // Defaults to "sse"
+	AuthType   string // Defaults to "none"
+	Host       string // Defaults to "localhost"
+	Scheme     string // Defaults to "" (uses config default "acdc")
+	ResultMode string // Defaults to "" (uses config default "references"); sets --search-result-mode only when non-empty
+	CrossRef   bool   // Defaults to false; sets --cross-ref only when true
 }
 
 // NewTestFlags creates a configured pflag.FlagSet for testing
@@ -232,6 +253,12 @@ func NewTestFlags(t testing.TB, contentDir string, opts *FlagOptions) *pflag.Fla
 	_ = flags.Set("host", host)
 	if scheme != "" {
 		_ = flags.Set("uri-scheme", scheme)
+	}
+	if opts != nil && opts.ResultMode != "" {
+		_ = flags.Set("search-result-mode", opts.ResultMode)
+	}
+	if opts != nil && opts.CrossRef {
+		_ = flags.Set("cross-ref", "true")
 	}
 
 	return flags

--- a/tests/integration/testkit/testkit_test.go
+++ b/tests/integration/testkit/testkit_test.go
@@ -442,3 +442,151 @@ func TestCreateTestContentDir_PromptsWriteError(t *testing.T) {
 		t.Error("Expected failure for prompts WriteFile")
 	}
 }
+
+func TestCreateTestContentDir_WithFiles(t *testing.T) {
+	opts := &ContentDirOptions{
+		Files: map[string]string{
+			"docs/platform/auth.md":    "# Authentication\n\nContent.\n",
+			"docs/generated/skip.md":   "# Generated\n\nContent.\n",
+			"mcp-metadata-sibling.txt": "not a resource",
+		},
+	}
+	contentDir := CreateTestContentDir(t, opts)
+
+	for name, content := range opts.Files {
+		path := filepath.Join(contentDir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("Failed to read file %s: %v", name, err)
+		}
+		if string(data) != content {
+			t.Errorf("Unexpected content for %s: got %q, want %q", name, data, content)
+		}
+	}
+
+	// Files must be written beneath the content root, not mcp-resources.
+	if _, err := os.Stat(filepath.Join(contentDir, "mcp-resources", "docs")); !os.IsNotExist(err) {
+		t.Error("Files should not be written under mcp-resources")
+	}
+}
+
+func TestCreateTestContentDir_FilesRejectsAbsolutePath(t *testing.T) {
+	tempDir := t.TempDir()
+	mt := &mockTB{T: t, tempDir: tempDir}
+	opts := &ContentDirOptions{
+		Files: map[string]string{
+			"/etc/passwd": "malicious",
+		},
+	}
+
+	CreateTestContentDir(mt, opts)
+
+	if !mt.failed {
+		t.Error("Expected failure for absolute Files path")
+	}
+}
+
+func TestCreateTestContentDir_FilesRejectsEscapingPath(t *testing.T) {
+	tempDir := t.TempDir()
+	mt := &mockTB{T: t, tempDir: tempDir}
+	opts := &ContentDirOptions{
+		Files: map[string]string{
+			"../escape.md": "malicious",
+		},
+	}
+
+	CreateTestContentDir(mt, opts)
+
+	if !mt.failed {
+		t.Error("Expected failure for escaping Files path")
+	}
+}
+
+func TestCreateTestContentDir_FilesMkdirError(t *testing.T) {
+	tempDir := t.TempDir()
+	contentDir := filepath.Join(tempDir, "mkdir-err")
+	_ = os.MkdirAll(filepath.Join(contentDir, "content"), 0755)
+
+	// Create a file where a directory is expected to cause MkdirAll failure
+	filesParentDir := filepath.Join(contentDir, "content", "docs")
+	_ = os.WriteFile(filesParentDir, []byte("not a directory"), 0644)
+
+	mt := &mockTB{T: t, tempDir: contentDir}
+	opts := &ContentDirOptions{
+		Files: map[string]string{"docs/auth.md": "content"},
+	}
+
+	CreateTestContentDir(mt, opts)
+
+	if !mt.failed {
+		t.Error("Expected failure for Files MkdirAll")
+	}
+}
+
+func TestCreateTestContentDir_FilesWriteError(t *testing.T) {
+	tempDir := t.TempDir()
+	contentDir := filepath.Join(tempDir, "write-err")
+	_ = os.MkdirAll(filepath.Join(contentDir, "content"), 0755)
+
+	mt := &mockTB{T: t, tempDir: contentDir}
+	opts := &ContentDirOptions{
+		Files: map[string]string{"auth.md": "content"},
+	}
+
+	// Create a directory where a file is expected to cause WriteFile failure
+	_ = os.MkdirAll(filepath.Join(contentDir, "content", "auth.md"), 0755)
+
+	CreateTestContentDir(mt, opts)
+
+	if !mt.failed {
+		t.Error("Expected failure for Files WriteFile")
+	}
+}
+
+func TestNewTestFlags_WithResultMode(t *testing.T) {
+	contentDir := CreateTestContentDir(t, nil)
+	opts := &FlagOptions{
+		Transport:  "stdio",
+		ResultMode: "content",
+	}
+	flags := NewTestFlags(t, contentDir, opts)
+
+	resultMode, _ := flags.GetString("search-result-mode")
+	if resultMode != "content" {
+		t.Errorf("Expected search-result-mode 'content', got '%s'", resultMode)
+	}
+}
+
+func TestNewTestFlags_WithoutResultMode(t *testing.T) {
+	contentDir := CreateTestContentDir(t, nil)
+	flags := NewTestFlags(t, contentDir, nil)
+
+	resultMode, _ := flags.GetString("search-result-mode")
+	if resultMode != "" {
+		t.Errorf("Expected empty search-result-mode (use config default), got '%s'", resultMode)
+	}
+}
+
+func TestNewTestFlags_WithCrossRef(t *testing.T) {
+	contentDir := CreateTestContentDir(t, nil)
+	opts := &FlagOptions{
+		Transport: "stdio",
+		CrossRef:  true,
+	}
+	flags := NewTestFlags(t, contentDir, opts)
+
+	crossRef, _ := flags.GetBool("cross-ref")
+	if !crossRef {
+		t.Error("Expected cross-ref true, got false")
+	}
+}
+
+func TestNewTestFlags_WithoutCrossRef(t *testing.T) {
+	contentDir := CreateTestContentDir(t, nil)
+	flags := NewTestFlags(t, contentDir, nil)
+
+	crossRef, _ := flags.GetBool("cross-ref")
+	if crossRef {
+		t.Error("Expected cross-ref false (use config default), got true")
+	}
+}


### PR DESCRIPTION
## Summary
Add black-box acceptance coverage for configured chunk search through a real stdio MCP session, verifying the behavior composed by the preceding tasks in this series. Test-only change: no production code is touched, and neither the `search` nor the `read` tool input schema changes.

## Changes
- Extend the integration testkit with additive options only — `ContentDirOptions.Files` (arbitrary Markdown beneath the content root, rejecting absolute or escaping paths), plus `ResultMode` and `CrossRef` carried through `NewTestFlags` and `NewStdioTestClient`. Existing callers and defaults are unchanged; each flag is set only when its field is non-empty.
- Cover configured discovery end to end: `index.include`/`index.exclude` selection, reference-mode search provenance, and reading a search-returned chunk fragment back through the `read` tool.
- Cover `--search-result-mode=content`, asserting the matched chunk body appears in the search result itself.
- Cover legacy compatibility with no `index` section: resource URIs, tool input schemas, prompts, full-document reads, and cross-reference rewriting all behave as before.