### PR TITLE
docs(search): [9/9] document configured chunk search

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ readinessProbe:
 | `--cross-ref` | — | `ACDC_MCP_CROSS_REF` | `false` |
 | `--search-max-results` | `-m` | `ACDC_MCP_SEARCH_MAX_RESULTS` | `10` |
 | `--search-keywords-boost` | — | `ACDC_MCP_SEARCH_KEYWORDS_BOOST` | `3.0` |
+| `--search-result-mode` | — | `ACDC_MCP_SEARCH_RESULT_MODE` | `references` |
 | `--auth-type` | `-a` | `ACDC_MCP_AUTH_TYPE` | `none` |
 
 For full configuration options including authentication, see [Configuration Reference](docs/configuration.md).
@@ -145,6 +146,8 @@ claude mcp add --scope user --transport sse acdc http://<host>:<port>/sse
 
 The server requires an `mcp-metadata.yaml` file in your content directory to define server identity. Tool metadata is optional and the server provides high-quality default descriptions for `search` and `read` tools.
 
+By default, the server discovers markdown files under `mcp-resources/`. Adding an `index` block to `mcp-metadata.yaml` switches document discovery instead to any Markdown matched by glob patterns (e.g. `docs/**/*.md`), without needing frontmatter or a dedicated `mcp-resources/` layout. Either way, discovered documents are split into heading-aware chunks for search.
+
 For details on authoring resource files, including frontmatter format and search keyword boosting, see the [Authoring Resources Guide](docs/authoring-resources.md).
 
 ### Examples
@@ -152,6 +155,7 @@ For details on authoring resource files, including frontmatter format and search
 Check out the [examples/](examples/) directory for structured deployment patterns:
 - [Local Content Demo](examples/docker-local-content/) — Direct mount for rapid iteration.
 - [Remote Image Demo](examples/docker-image-content/) — Production-like init container pattern.
+- [Repository Docs Demo](examples/repository-docs/) — Configured chunk indexing over an existing repository's `docs/` directory.
 
 ## 🛠️ Development
 

--- a/docs/SPECIFICATIONS.md
+++ b/docs/SPECIFICATIONS.md
@@ -18,7 +18,7 @@ The server is configured via environment variables, command-line flags, or a `.e
 
 | Environment Variable | CLI Flag | Description | Default |
 | :--- | :--- | :--- | :--- |
-| `ACDC_MCP_CONTENT_DIR` | `--content-dir`, `-c` | Root directory containing `mcp-metadata.yaml` and `mcp-resources/`. | `./content` |
+| `ACDC_MCP_CONTENT_DIR` | `--content-dir`, `-c` | Root directory containing `mcp-metadata.yaml` (see Content Repository Structure). | `./content` |
 | `ACDC_MCP_TRANSPORT` | `--transport`, `-t` | Communication transport: `stdio` or `sse`. | `stdio` |
 | `ACDC_MCP_HOST` | `--host`, `-H` | Host interface to bind for SSE transport. | `0.0.0.0` |
 | `ACDC_MCP_PORT` | `--port`, `-p` | Port to listen on for SSE transport. | `8080` |
@@ -26,6 +26,7 @@ The server is configured via environment variables, command-line flags, or a `.e
 | `ACDC_MCP_SEARCH_KEYWORDS_BOOST` | `--search-keywords-boost` | Boost factor for keyword matches. | `3.0` |
 | `ACDC_MCP_SEARCH_NAME_BOOST` | `--search-name-boost` | Boost factor for name matches. | `2.0` |
 | `ACDC_MCP_SEARCH_CONTENT_BOOST` | `--search-content-boost` | Boost factor for content matches. | `1.0` |
+| `ACDC_MCP_SEARCH_RESULT_MODE` | `--search-result-mode` | Search output detail: `references` or `content`. | `references` |
 | `ACDC_MCP_AUTH_TYPE` | `--auth-type`, `-a` | Authentication mode for SSE: `none`, `basic`, `apikey`. | `none` |
 | `ACDC_MCP_AUTH_BASIC_USERNAME` | `--auth-basic-username`, `-u` | Username for Basic Auth. | - |
 | `ACDC_MCP_AUTH_BASIC_PASSWORD` | `--auth-basic-password`, `-P` | Password for Basic Auth. | - |
@@ -36,12 +37,12 @@ The server is configured via environment variables, command-line flags, or a `.e
 
 ## Content Repository Structure
 
-The server expects a specific directory structure within `ACDC_MCP_CONTENT_DIR`:
+The server expects `mcp-metadata.yaml` at the root of `ACDC_MCP_CONTENT_DIR`. Source documents are then discovered in one of two mutually exclusive modes, selected by the presence of an `index` block in `mcp-metadata.yaml`:
 
 ```text
 / (Content Root)
-├── mcp-metadata.yaml       # Server identity and tool configuration (Required)
-└── mcp-resources/          # Directory containing resource files (Required)
+├── mcp-metadata.yaml       # Server identity, tool, and index configuration (Required)
+└── mcp-resources/          # Legacy discovery: used when `index` is absent
     ├── guide.md
     └── subfolder/
         └── details.md
@@ -49,7 +50,7 @@ The server expects a specific directory structure within `ACDC_MCP_CONTENT_DIR`:
 
 ### 1. Metadata Manifest (`mcp-metadata.yaml`)
 
-Defines the server's identity and optional tool overrides.
+Defines the server's identity, optional tool overrides, and optional configured indexing.
 
 **Schema:**
 ```yaml
@@ -63,18 +64,25 @@ tools:                  # Optional: Override default tool descriptions
     description: <string> 
   - name: read
     description: <string> 
+
+index:                  # Optional: switches discovery to configured chunk indexing
+  include:               # Required if `index` is present: glob patterns, relative to content root
+    - docs/**/*.md
+  exclude:               # Optional: glob patterns; always wins over `include`
+    - docs/generated/**
 ```
 *Note: If the `tools` section is omitted or a specific tool is not listed, the server provides high-quality default descriptions for the `search` and `read` tools.*
 
-### 2. Resources (`mcp-resources/`)
+### 2a. Legacy Resource Discovery (`mcp-resources/`, `index` absent)
 
--   **Discovery**: The server recursively scans `mcp-resources/` for `.md` files.
+-   **Discovery**: The server recursively scans `mcp-resources/` for `.md` and `.markdown` files. A missing directory yields zero resources (not an error).
 -   **URI Scheme**: `<scheme>://<relative_path_without_extension>` (default scheme: `acdc`)
     -   Example: `mcp-resources/docs/guide.md` -> `acdc://docs/guide`
     -   With `--uri-scheme myorg`: `mcp-resources/docs/guide.md` -> `myorg://docs/guide`
     -   The scheme must be RFC 3986 compliant (starts with a letter, followed by letters/digits/`+`/`-`/`.`).
     -   Windows backslashes are normalized to forward slashes.
 -   **File Format**: Must be Markdown with YAML Frontmatter.
+-   **Error handling**: A file with invalid YAML, missing frontmatter, or missing `name`/`description` is skipped with a warning log; it does not fail startup.
 
 **Frontmatter Requirements:**
 ```markdown
@@ -88,6 +96,28 @@ keywords:               # Optional: List of keywords for search boosting
 Markdown content follows...
 ```
 
+### 2b. Configured Chunk Indexing (`index` present)
+
+-   **Discovery**: Files under the content root matching `index.include` (and not matching `index.exclude`) are indexed, using [doublestar](https://github.com/bmatcuk/doublestar) glob syntax where `**` matches zero or more path segments (`docs/**/*.md` matches both `docs/guide.md` and `docs/api/guide.md`). Patterns must be relative to the content root; absolute or root-escaping patterns fail startup. `exclude` always wins over `include`.
+-   **URI Scheme**: Same construction as legacy discovery, relative to `--content-dir` instead of `mcp-resources/`.
+-   **File Format**: Must be `.md` or `.markdown`. YAML frontmatter is **optional**; when present it must still be valid.
+-   **Metadata derivation**: `name` falls back to the first `#` (H1) heading, `description` to the first paragraph, when frontmatter omits them. `description` is always truncated to 200 Unicode characters, whether it came from frontmatter or the fallback paragraph. `keywords` has no fallback.
+-   **Error handling (strict)**: Any of the following fails server startup: `index.include` missing/empty, an invalid/absolute/root-escaping glob pattern, zero files matched, a matched file that is not Markdown, a matched file that cannot be read or parsed, or the content root itself cannot be resolved (e.g. a broken symlink).
+-   **Not part of this release**: persistence across restarts and live filesystem watching. The chunk catalog and search index are rebuilt fully at each startup.
+
+### 3. Chunking and Fragment URIs (Both Modes)
+
+Chunking is not specific to configured indexing: regardless of which discovery mode selected a document, every discovered document — legacy or configured — is split into chunks before indexing, and `search` always returns chunk URIs, never bare document URIs.
+
+-   **Chunk boundaries**: A new chunk starts at *every* heading, of any level — a chunk's content never includes its subsections' content, though its `heading_path` still records the full ancestry (e.g. `["Configuration", "Authentication"]`). Content before the first heading forms its own chunk, addressed with the reserved fragment `document`. A heading whose text has no letters or digits (e.g. `# !!!`) falls back to the fragment `section`.
+-   **Soft splitting**: A section exceeding a soft limit of **4,000 Unicode code points** is further split along block boundaries into multiple parts, each still tagged with the section's full heading path.
+-   **Fragment URIs**: An unsplit section is `<document-uri>#<heading-slug>` (or `<document-uri>#document` for the pre-heading preamble). A split section's parts are `<document-uri>#<heading-slug>~1`, `~2`, ... — every part, including the first, carries the suffix. Reading the bare `#<heading-slug>` of a split section reconstructs the full section by joining its parts. Duplicate heading text produces de-duplicated slugs (`#overview-1`, `#overview-2`, ...).
+-   **Result diversity**: `search` fetches up to `ACDC_MCP_SEARCH_MAX_RESULTS` × 5 candidates internally, then caps results per source document before returning up to the configured limit: 1 chunk per document in `references` mode, 2 in `content` mode.
+-   **Path labels**: Each chunk is also ranked on path labels derived from the document's relative path (split on `/`, `-`, `_`, whitespace, and camelCase boundaries; lowercased; deduplicated), indexed with a 1.25x boost — see `path_labels` below.
+-   **Duplicate identity**: Startup fails if two discovered documents or chunks resolve to the same URI or ID — for example, `guide.md` and `guide.markdown` selected side by side both produce the URI `<scheme>://guide`. This applies to both discovery modes.
+
+See the [Authoring Resources Guide](authoring-resources.md#chunking-and-fragment-uris) for full details and the [Repository Docs example](../examples/repository-docs/).
+
 ---
 
 ## Tools
@@ -95,7 +125,7 @@ Markdown content follows...
 The server always implements and registers the following MCP tools. Their descriptions can be customized via `mcp-metadata.yaml`, but sensible defaults are provided.
 
 ### `search`
-Performs a full-text search across all indexed resources.
+Performs a full-text search over indexed chunks and returns chunk citations, optionally with the full chunk body.
 
 *   **Input Schema:**
     ```json
@@ -104,44 +134,50 @@ Performs a full-text search across all indexed resources.
     }
     ```
 *   **Behavior:**
-    *   Searches against `name`, `content`, and `keywords` using fuzzy matching (distance 1) and stemming.
-    *   Applies boosting: `keywords` (3.0), `name` (2.0), `content` (1.0) by default.
-    *   Returns a maximum of `ACDC_MCP_SEARCH_MAX_RESULTS`.
+    *   Searches against `source_title`, `path_labels`, `heading_path`, `content`, and `keywords` fields using fuzzy matching (distance 1) and stemming.
+    *   Applies boosting: `keywords` (3.0, configurable), `heading_path` (2.5), `source_title` (2.0, configurable), `path_labels` (1.25), `content` (1.0, configurable).
+    *   Applies per-source-document result diversity — see [Chunking and Fragment URIs](#3-chunking-and-fragment-uris-both-modes).
 *   **Output:**
     Text summary of results in the format:
     ```text
     Search results for '<query>':
 
-    - [<Name>](<URI>): <Snippet> (relevance: <Score>)
+    - **<Source Title>** · [<Chunk URI>](<Chunk URI>)
+      - <Source Path> > <Heading Path> · lines <Start>-<End> · score <Score>
+      - <Highlighted Snippet>
+
+    <Full chunk body — only when ACDC_MCP_SEARCH_RESULT_MODE=content>
     ...
     ```
     *If no results found, returns a descriptive message.*
 
 ### `read`
-Retrieves the full raw content of a resource.
+Retrieves the raw content addressed by a URI: a full source document, a single chunk, or a whole (possibly multi-part) section — see [Chunking and Fragment URIs](#3-chunking-and-fragment-uris-both-modes).
 
 *   **Input Schema:**
     ```json
     {
-      "uri": "string (Required) - The resource URI (e.g. acdc://path)"
+      "uri": "string (Required) - The resource URI (e.g. acdc://path or acdc://path#fragment)"
     }
     ```
 *   **Behavior:**
-    *   Resolves the URI to the corresponding file path.
-    *   Reads the file content (excluding frontmatter, effectively returning the body).
+    *   A base document URI (`<scheme>://path`) returns the full document (frontmatter stripped).
+    *   A chunk fragment URI (`<scheme>://path#fragment`) returns that chunk's content only.
+    *   A section fragment URI for a split section returns all of its parts joined together.
 *   **Output:**
-    Raw string content of the markdown body.
+    Raw markdown content of the resolved document, chunk, or section.
 
 ---
 
 ## MCP Resources
 
-In addition to tools, the server exposes resources directly via the MCP `resources/list` capability.
+In addition to tools, the server exposes source documents (not individual chunks) directly via the MCP `resources/list` capability.
 
-*   **URI**: Same as the `<scheme>://` URI used in tools (default scheme: `acdc`).
-*   **Name**: From frontmatter `name`.
-*   **Description**: From frontmatter `description`.
+*   **URI**: Same as the `<scheme>://` document URI used in tools (default scheme: `acdc`).
+*   **Name**: From frontmatter `name`, or the first `#` heading when using configured indexing without a `name` field.
+*   **Description**: From frontmatter `description`, or the first paragraph when using configured indexing without a `description` field. Always truncated to 200 Unicode characters, whether it came from frontmatter or the fallback paragraph.
 *   **MIME Type**: `text/markdown`.
+*   Chunk and section URIs (`<scheme>://path#fragment`) are not listed; they are reachable via `read` once obtained from a `search` result.
 
 ---
 
@@ -171,13 +207,18 @@ Used for remote connections.
 ## Search Implementation Details
 
 *   **Engine**: Bleve (Go) full-text search engine.
-*   **Indexing**: Occurs at server startup (in-memory or temporary directory).
+*   **Indexing**: Indexes document chunks (not whole documents). Occurs at server startup (in-memory or temporary directory) and is rebuilt in full on every restart — there is no persistence across restarts and no live filesystem watching in this release.
 *   **Features**:
     *   **Fuzzy Search**: Matches terms with an edit distance of 1.
     *   **Stemming**: Uses the standard English analyzer for language-aware matching.
     *   **Highlighting**: Generates dynamic snippets with search term context.
+    *   **Result Diversity**: Caps results per source document (1 in `references` mode, 2 in `content` mode) so results aren't dominated by a single document.
 *   **Indexed Fields (Default Boosts)**:
-    *   `uri` (Stored, Indexed)
-    *   `name` (Stored, Indexed, Boost x2.0)
+    *   `chunk_id`, `source_id`, `source_uri`, `chunk_uri`, `source_path` (Stored, Identifier)
+    *   `source_title` (Stored, Indexed, Boost x2.0)
+    *   `path_labels` (Stored, Indexed, Boost x1.25)
+    *   `heading_path` (Stored, Indexed, Boost x2.5)
     *   `content` (Stored, Indexed, Boost x1.0)
-    *   `keywords` (Indexed, Boost x3.0, Optional)
+    *   `keywords` (Stored, Indexed, Boost x3.0, Optional)
+    *   `start_line`, `end_line` (Stored, Numeric)
+    *   `section_fragment`, `fragment`, `part`, `part_count` (Stored, indexed via Bleve's dynamic default mapping; not explicitly boosted or queried)

--- a/docs/authoring-resources.md
+++ b/docs/authoring-resources.md
@@ -4,7 +4,7 @@ This guide explains how to create and structure markdown resource files for the 
 
 ## File Location
 
-Place all resource markdown files inside the `mcp-resources/` subdirectory of your content directory:
+By default (when `mcp-metadata.yaml` has no `index` block — see [Configured Chunk Indexing](#configured-chunk-indexing-index)), place all resource markdown files inside the `mcp-resources/` subdirectory of your content directory:
 
 ```
 content/
@@ -91,9 +91,120 @@ The server validates `mcp-metadata.yaml` at startup and will fail to start if:
 - Any tool defined in the `tools` section is missing a `name` or `description`
 - Duplicate tool names exist
 
+## Chunking and Fragment URIs
+
+Every discovered document — whether found via legacy `mcp-resources/` scanning or a configured `index` (see below) — is split into chunks before indexing, and the `search` tool always returns chunk URIs (`<document-uri>#<fragment>`), never bare document URIs. This section applies to both discovery modes.
+
+### How Documents Are Split
+
+A new chunk starts at *every* Markdown heading, regardless of level — a chunk's content never includes its subsections' content. For example:
+
+```markdown
+# Configuration
+Parent text.
+
+## Authentication
+API keys.
+```
+
+produces **two** chunks: one for `# Configuration` containing only "Parent text.", and a separate one for `## Authentication` containing "API keys." The `## Authentication` chunk's heading path is still `["Configuration", "Authentication"]`, so its provenance reflects the nesting even though its content does not include the parent section's body.
+
+Content before the first heading (if any) forms its own chunk, addressed with the reserved fragment `document`. A heading whose text has no letters or digits (e.g. `# !!!`) falls back to the fragment `section`.
+
+A section that exceeds a soft limit of **4,000 Unicode code points** is further split along block boundaries into multiple parts, each still tagged with the section's full heading path.
+
+### Fragment URIs
+
+- An unsplit section is addressable as `<document-uri>#<heading-slug>` (e.g. `acdc://docs/guide#rotating-keys`, or `acdc://docs/guide#document` for the pre-heading preamble).
+- A section split into multiple parts addresses each part as `<document-uri>#<heading-slug>~1`, `#<heading-slug>~2`, and so on — the suffix applies to every part, including the first.
+- Reading the bare `<document-uri>#<heading-slug>` of a *split* section returns the full section, reconstructed by joining all of its parts.
+- Duplicate heading text within the same document produces de-duplicated slugs (e.g. a second "Overview" heading becomes `#overview-1`).
+
+### Result Diversity
+
+To keep results varied across documents, the `search` tool over-fetches candidate chunks internally (5x the configured result limit) and then applies a per-document cap before returning up to the configured limit: `references` mode keeps at most one chunk per source document; `content` mode keeps at most two.
+
+### Fragment Reads
+
+The `read` tool resolves any URI returned by `search` or `resources/list`:
+
+- The base document URI (e.g. `acdc://docs/guide`) returns the full document (frontmatter stripped).
+- A chunk fragment URI (e.g. `acdc://docs/guide#rotating-keys~2`) returns only that chunk's content.
+- A section fragment URI for a split section (e.g. `acdc://docs/guide#rotating-keys`) returns all of that section's parts joined together.
+
+Only source documents (not individual chunks) appear in `resources/list`; chunk and section URIs are reachable once you have one, typically from a `search` result.
+
+### Path Labels
+
+Each chunk's search ranking also considers **path labels**, derived from the document's relative path: the path (extension stripped) is split on `/`, `-`, `_`, whitespace, and camelCase boundaries, lowercased, and deduplicated. For example, `docs/apiReference/authGuide.md` produces labels `["docs", "api", "reference", "auth", "guide"]`. Path labels are indexed with a 1.25x boost, so file and directory names that match query terms help a document rank higher — see [Keywords and Search Boosting](#keywords-and-search-boosting).
+
+### Duplicate Identity
+
+Regardless of discovery mode, server startup fails if two discovered documents or chunks resolve to the same URI or ID — for example, `guide.md` and `guide.markdown` sitting side by side and both being selected produces the identical document URI `acdc://guide` for both.
+
+## Configured Chunk Indexing (`index`)
+
+By default the server discovers documents under `mcp-resources/`, each requiring frontmatter (see [Resource Frontmatter Format](#resource-frontmatter-format) below). Adding an `index` block to `mcp-metadata.yaml` switches **document discovery** to configured indexing instead: any Markdown matched by glob patterns is discovered directly, without requiring the `mcp-resources/` layout or frontmatter. When `index` is present, it replaces `mcp-resources/` discovery entirely — the two modes are not combined. Discovered documents are chunked and searched identically either way — see [Chunking and Fragment URIs](#chunking-and-fragment-uris) above.
+
+### Schema
+
+```yaml
+index:
+  include:
+    - docs/**/*.md
+  exclude:
+    - docs/generated/**
+```
+
+| Field     | Required | Description                                              |
+| --------- | -------- | ---------------------------------------------------------- |
+| `include` | Yes      | List of glob patterns selecting Markdown files. At least one pattern is required. |
+| `exclude` | No       | List of glob patterns to skip, evaluated after `include`.  |
+
+### Pattern Semantics
+
+- Patterns are relative to `--content-dir`. Absolute patterns or patterns that escape the content root (e.g. `../x.md`) fail at startup.
+- Patterns use [doublestar](https://github.com/bmatcuk/doublestar) glob syntax, where `**` matches zero or more path segments. `docs/**/*.md` therefore matches files directly under `docs/` (e.g. `docs/guide.md`) as well as nested files (e.g. `docs/api/auth.md`) — a "zero-depth" match.
+- `exclude` always wins: a file matched by `include` is dropped if it also matches any `exclude` pattern.
+- Every selected file must have a `.md` or `.markdown` extension; a pattern that selects any other file type fails startup.
+- Symlinked files and directories are skipped during discovery.
+
+### Metadata Derivation for Configured Markdown
+
+Frontmatter is **optional** for configured Markdown. When present, it is still parsed as YAML and must be valid. Title, description, and keywords are derived as follows:
+
+| Field         | Source                                                                 |
+| ------------- | ----------------------------------------------------------------------- |
+| `name`        | Frontmatter `name`, or the document's first `#` (H1) heading if absent. A document whose first heading is `##` or deeper has no fallback and gets an empty name. |
+| `description` | Frontmatter `description`, or the document's first paragraph if absent. Always truncated to 200 Unicode characters, whether it came from frontmatter or the fallback. |
+| `keywords`    | Frontmatter `keywords` list. Empty if absent — no fallback derivation.  |
+
+### Strict Configured Discovery Errors
+
+Unlike legacy `mcp-resources/` discovery, configured indexing fails the server at startup — rather than skipping the offending file — if any of the following occur:
+
+- `index.include` is missing or empty.
+- Any `include`/`exclude` pattern is absolute, escapes the content root, or is not a valid glob.
+- No files match the configured patterns.
+- A matched file is not `.md`/`.markdown`.
+- A matched file cannot be read or fails to parse (including invalid frontmatter YAML, when frontmatter is present).
+- The content root itself cannot be resolved (e.g. a broken symlink at `--content-dir`).
+
+See also [Duplicate Identity](#duplicate-identity) above, which fails startup in both discovery modes.
+
+### Unchanged Legacy Behavior
+
+When `index` is absent from `mcp-metadata.yaml`, discovery keeps scanning `mcp-resources/` for `.md` and `.markdown` files exactly as before: frontmatter with `name` and `description` remains required per file, and files that are missing, invalid, or incomplete are skipped with a warning log rather than failing startup. A missing `mcp-resources/` directory yields zero resources, not an error.
+
+### Not Yet Supported
+
+Persistence across restarts and live filesystem watching are not part of this release. The chunk catalog and search index are rebuilt fully at startup (in memory or a temporary directory); pick up content changes by restarting the server.
+
+See [Configuration Reference](configuration.md) for the `--search-result-mode` flag that controls how much chunk detail the `search` tool returns, and the [Repository Docs example](../examples/repository-docs/) for a runnable configured-indexing setup.
+
 ## Resource Frontmatter Format
 
-Each resource file **must** start with YAML frontmatter containing required metadata:
+Legacy `mcp-resources/` discovery (used when `index` is absent from `mcp-metadata.yaml`) requires each resource file to start with YAML frontmatter containing required metadata:
 
 ```yaml
 ---
@@ -129,13 +240,15 @@ Keywords provide a way to improve search relevance. When a search query matches 
 
 ### How It Works
 
-The search service uses a disjunction query across three fields:
+The search service uses a disjunction query across five fields:
 
-| Field      | Boost | Description                              |
-| ---------- | ----- | ---------------------------------------- |
-| `name`     | 2.0x  | Resource title (configurable)            |
-| `content`  | 1.0x  | Markdown body content (configurable)     |
-| `keywords` | 3.0x  | Frontmatter keywords (configurable)      |
+| Field         | Boost | Description                                              |
+| ------------- | ----- | --------------------------------------------------------- |
+| `source_title`| 2.0x  | Resource/document title (configurable)                    |
+| `heading_path`| 2.5x  | The chunk's Markdown heading ancestry                      |
+| `path_labels` | 1.25x | Labels derived from the file path — see [Path Labels](#path-labels) |
+| `content`     | 1.0x  | Markdown chunk content (configurable)                      |
+| `keywords`    | 3.0x  | Frontmatter keywords (configurable)                        |
 
 ### Advanced Search Features
 
@@ -172,7 +285,7 @@ Content about software development...
 ```
 
 Searching for `"golang"` will rank **Resource B** higher because:
-1. Resource B matches "golang" in its keywords field (boosted 2x)
+1. Resource B matches "golang" in its keywords field (boosted 3x)
 2. Resource A has no keyword match
 
 ### Best Practices for Keywords
@@ -209,6 +322,8 @@ The URI scheme can be customized via the `--uri-scheme` flag or `ACDC_MCP_URI_SC
 | `mcp-resources/api/endpoints.md`    | `myorg://api/endpoints`    |
 
 See [Configuration Reference](configuration.md) for details.
+
+The same scheme applies to [configured chunk indexing](#configured-chunk-indexing-index), except the path is relative to `--content-dir` instead of `mcp-resources/` (e.g. `docs/setup/intro.md` → `acdc://docs/setup/intro`). Chunks within a document are addressed with a `#fragment` suffix on the document URI — see [Fragment Reads](#fragment-reads).
 
 ## Complete Example
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,7 @@ When the same setting is specified in multiple places, the following priority ap
 | `--search-keywords-boost` | — | `ACDC_MCP_SEARCH_KEYWORDS_BOOST` | Boost for keywords matches | `3.0` |
 | `--search-name-boost` | — | `ACDC_MCP_SEARCH_NAME_BOOST` | Boost for name matches | `2.0` |
 | `--search-content-boost` | — | `ACDC_MCP_SEARCH_CONTENT_BOOST` | Boost for content matches | `1.0` |
+| `--search-result-mode` | — | `ACDC_MCP_SEARCH_RESULT_MODE` | Search output detail: `references` (chunk citations only) or `content` (citations plus the full matched chunk body) | `references` |
 
 ## Authentication Settings
 
@@ -59,6 +60,13 @@ When the same setting is specified in multiple places, the following priority ap
 
 This produces resource URIs like `myorg://guides/getting-started` instead of the default `acdc://guides/getting-started`.
 
+**CLI flags (content result mode):**
+```bash
+./bin/acdc-mcp -c /path/to/content --search-result-mode content
+```
+
+By default (`references`), the `search` tool returns chunk citations — title, URI, breadcrumb, and a highlighted snippet — so agents follow up with a `read` call for the full chunk. Setting `--search-result-mode content` (or `ACDC_MCP_SEARCH_RESULT_MODE=content`) additionally inlines the full matched chunk body in the search response itself. See the [Authoring Resources Guide](authoring-resources.md#configured-chunk-indexing-index) for how content is split into chunks.
+
 **Environment variables:**
 ```bash
 ACDC_MCP_TRANSPORT=sse ACDC_MCP_CONTENT_DIR=/data ./bin/acdc-mcp
@@ -78,6 +86,7 @@ auth.basic.password=secret
 The server validates configuration at startup and will fail with a clear error if:
 
 - `--uri-scheme` is empty or doesn't match RFC 3986 (must start with a letter, then letters/digits/`+`/`-`/`.`)
+- `--search-result-mode` is set to anything other than `references` or `content`
 - `--auth-type=basic` is set without username/password
 - `--auth-type=apikey` is set without API keys
 - `--auth-type=none` is set with auth credentials (conflicting intent)

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # MCP ACDC Examples
 
-This directory contains examples for deploying and running the MCP ACDC server using Docker. These examples demonstrate two common patterns for loading content.
+This directory contains examples for deploying and running the MCP ACDC server. These examples demonstrate common patterns for loading content, using both Docker and configured chunk indexing over plain directories.
 
 ## 📁 Available Patterns
 
@@ -24,14 +24,24 @@ This example demonstrates how to use a pre-built content image (`sha1n/mcp-acdc-
 - **Pattern**: Init container with a remote content image.
 - **Guide**: [Remote Image Guide](docker-image-content/README.md)
 
+### 3. Repository Docs (Configured Chunk Indexing)
+**Location:** [`repository-docs/`](repository-docs/)
+
+This example indexes an existing repository's `docs/` directory directly via the `index` block in `mcp-metadata.yaml`, instead of curating a dedicated `mcp-resources/` tree. No Docker required — run `acdc-mcp` directly against the target repository.
+
+- **Pattern**: Configured chunk indexing (`index.include`/`index.exclude`) over an arbitrary directory.
+- **Guide**: [Repository Docs Guide](repository-docs/README.md)
+
 ---
 
 ## 📂 Sample Content
 
-Both examples use the sample content found in the [**`sample-content/`**](sample-content/) directory:
+The Docker examples (`docker-local-content/` and `docker-image-content/`) use the sample content found in the [**`sample-content/`**](sample-content/) directory:
 - `mcp-metadata.yaml`: Server identity, instructions, and tool-description overrides.
 - `mcp-resources/`: Markdown files (with frontmatter and keywords) that the agent can search and read.
 - `mcp-prompts/`: Parameterised prompt templates the agent can invoke.
+
+`repository-docs/` is self-contained and instead points at an existing repository's own `docs/` directory — see its guide for setup.
 
 ## 📖 Related Guides
 

--- a/examples/repository-docs/README.md
+++ b/examples/repository-docs/README.md
@@ -1,0 +1,32 @@
+# Repository Docs (Configured Chunk Indexing)
+
+This example shows the other way to point ACDC at content: instead of curating a dedicated `mcp-resources/` tree with required frontmatter, it indexes an **existing repository's `docs/` directory** directly, using the `index` block in `mcp-metadata.yaml`. Documents are split into heading-aware chunks for search — see the [Authoring Resources Guide](../../docs/authoring-resources.md#configured-chunk-indexing-index) for the full behavior.
+
+## What this example demonstrates
+
+- metadata index.include selects Markdown relative to --content-dir
+- index.exclude wins over include
+- frontmatter is optional for configured Markdown
+- references is the default result mode
+- content mode is selected with --search-result-mode=content
+- base URIs read full documents; search-returned fragments read chunks
+- existing mcp-resources behavior remains when index is absent
+- persistence and live watching are not part of this release
+
+## Usage
+
+1. Copy `mcp-metadata.yaml` from this directory to the root of the repository whose `docs/` you want to search (the same directory you'll pass as `--content-dir`). If that repository already has an `mcp-metadata.yaml`, merge the `index` block into it instead of overwriting the file.
+2. Adjust `index.include`/`index.exclude` if your documentation lives somewhere other than `docs/`.
+3. Run the server pointed at that repository:
+
+```bash
+acdc-mcp --content-dir /path/to/repository
+acdc-mcp --content-dir /path/to/repository --search-result-mode content
+```
+
+The first command returns chunk citations (title, URI, breadcrumb, and a snippet) that agents follow up on with the `read` tool. The second additionally inlines the full matched chunk body in the search response itself.
+
+## Notes
+
+- No frontmatter is required in the indexed Markdown; `name`/`description` fall back to the first H1 (`#`) heading and first paragraph when frontmatter is absent. A document whose first heading is `##` or deeper gets an empty name.
+- The server rebuilds its chunk catalog and search index fully at startup. There is no persistence across restarts and no live filesystem watching — restart the server to pick up documentation changes.

--- a/examples/repository-docs/mcp-metadata.yaml
+++ b/examples/repository-docs/mcp-metadata.yaml
@@ -1,0 +1,11 @@
+server:
+  name: Repository Documentation
+  version: 1.0.0
+  instructions: |
+    Search repository documentation before answering repository-specific questions.
+
+index:
+  include:
+    - docs/**/*.md
+  exclude:
+    - docs/generated/**

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -276,6 +276,20 @@ func TestLoadSettingsWithFlags_AllFlagTypes(t *testing.T) {
 	}
 }
 
+// TestLoadSettingsWithFlags_SearchResultModeDefaultsToReferences pins the
+// process-wide default result mode when --search-result-mode is registered
+// but left unset, exercising the same flag-unset fallback path CLI users hit
+// when they don't pass the flag (internal/app/cli.go registers it with an
+// empty-string default so viper falls through to this SetDefault).
+func TestLoadSettingsWithFlags_SearchResultModeDefaultsToReferences(t *testing.T) {
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.String("search-result-mode", "", "")
+
+	settings, err := LoadSettingsWithFlags(flags)
+	require.NoError(t, err)
+	require.Equal(t, SearchResultModeReferences, settings.Search.ResultMode)
+}
+
 // --- ValidateSettings Tests ---
 
 func TestValidateSettings_ValidNone(t *testing.T) {

--- a/internal/domain/metadata.go
+++ b/internal/domain/metadata.go
@@ -34,19 +34,19 @@ type McpMetadata struct {
 var DefaultToolMetadata = map[string]ToolMetadata{
 	"search": {
 		Name: "search",
-		Description: `Search across all development resources using full-text search. This tool searches resource names, descriptions, and content to help you find relevant standards, guidelines, and documentation.
+		Description: `Search across all indexed documentation using full-text search. This tool searches source titles, heading text, path segments, markdown content, and keywords to help you find relevant standards, guidelines, and documentation.
 
 WHEN TO USE: Use this as your first step before generating code or reviewing implementations. Search for relevant topics to discover which resources apply to your task.
 
-HOW IT WORKS: Searches are performed across resource names, descriptions, and full markdown content. Results include the resource name, URI, and a relevant text snippet showing where your query was found.`,
+HOW IT WORKS: Searches are performed across source titles, heading paths, file/directory path segments, markdown content, and keywords. Results are chunk citations: each includes the source title, a chunk URI (open it with the read tool), a heading breadcrumb, the matched line range, and a relevant snippet. When the server is configured for content result mode, each result also includes the full text of the matched chunk.`,
 	},
 	"read": {
 		Name: "read",
-		Description: `Read the full content of a specified resource. This tool allows you to retrieve the complete markdown content of any development resource using its URI.
+		Description: `Read the full content of a source document, or a single chunk within it. This tool allows you to retrieve markdown content using a URI returned by search or a resource listing.
 
-WHEN TO USE: Use after you have found a relevant resource URI (e.g., via the search tool or by listing resources) and need to read its full content to understand specific standards, guidelines, or instructions.
+WHEN TO USE: Use after you have found a relevant URI (e.g., via the search tool or by listing resources) and need to read its content to understand specific standards, guidelines, or instructions.
 
-HOW IT WORKS: Provide the URI of the resource you wish to read (e.g., 'acdc://guides/getting-started.md'). The tool returns the full markdown content of the resource with frontmatter removed.`,
+HOW IT WORKS: Provide a base URI (e.g., 'acdc://guides/getting-started') to read the whole document, or that same URI with a '#fragment' suffix (e.g., 'acdc://guides/getting-started#installation') to read a single chunk, exactly as returned by search. Resource URIs never include a file extension. The scheme defaults to 'acdc://' but may be configured differently by the server operator, so always use the scheme from the URI you were given.`,
 	},
 }
 

--- a/internal/domain/metadata_test.go
+++ b/internal/domain/metadata_test.go
@@ -1,6 +1,8 @@
 package domain
 
 import (
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -154,6 +156,41 @@ func TestGetToolMetadata(t *testing.T) {
 			t.Errorf("expected default search even with empty tools")
 		}
 	})
+}
+
+// exampleURIPattern matches single-quoted example URIs like 'acdc://guides/getting-started'
+// or 'acdc://guides/getting-started#installation' as used in the default tool descriptions.
+var exampleURIPattern = regexp.MustCompile(`'([a-zA-Z][a-zA-Z0-9+\-.]*://[^']*)'`)
+
+func TestDefaultToolMetadata_ReadDescriptionExampleURIsHaveNoFileExtension(t *testing.T) {
+	desc := DefaultToolMetadata["read"].Description
+
+	matches := exampleURIPattern.FindAllStringSubmatch(desc, -1)
+	require.NotEmpty(t, matches, "expected at least one example URI in the read tool description")
+
+	for _, match := range matches {
+		uri := match[1]
+		require.False(t, strings.HasSuffix(uri, ".md"), "example URI %q should not carry a .md extension - resource URIs never include the file extension", uri)
+		require.False(t, strings.HasSuffix(uri, ".markdown"), "example URI %q should not carry a .markdown extension - resource URIs never include the file extension", uri)
+	}
+}
+
+func TestDefaultToolMetadata_ReadDescriptionMentionsFragmentForm(t *testing.T) {
+	desc := DefaultToolMetadata["read"].Description
+
+	require.Contains(t, desc, "#", "expected the read tool description to mention the '#fragment' URI form for reading a single chunk")
+}
+
+func TestDefaultToolMetadata_SearchDescriptionDoesNotClaimDescriptionsAreSearched(t *testing.T) {
+	desc := DefaultToolMetadata["search"].Description
+
+	require.NotContains(t, strings.ToLower(desc), "descriptions", "descriptions are not an indexed search field - the search default description should not claim otherwise")
+}
+
+func TestDefaultToolMetadata_SearchDescriptionMentionsChunkResults(t *testing.T) {
+	desc := DefaultToolMetadata["search"].Description
+
+	require.Contains(t, strings.ToLower(desc), "chunk", "search results are chunk citations - the default description should describe them as such")
 }
 
 func TestToolsMap(t *testing.T) {


### PR DESCRIPTION
## Summary

Documents the configured chunk search feature for users and ships a runnable repository-docs example. Closes out the series: the behavior landed across the preceding PRs, but nothing user-facing described it yet.

Every documented claim was verified against the landed code and the integration tests rather than against the design notes — several first-draft claims turned out to contradict the implementation and were corrected.

## Changes

- **`index` configuration and result modes** — documents the `index.include`/`index.exclude` schema, `--search-result-mode` / `ACDC_MCP_SEARCH_RESULT_MODE` / `search.result_mode`, metadata derivation, path labels, and the strict configured-discovery failure modes.
- **Chunking is documented as mode-independent.** The first draft presented chunking, fragment URIs, and result diversity as consequences of adding an `index` block. They are not — legacy `mcp-resources/` content is chunked too, and `search` returns chunk URIs with fragments in both modes. This is the most likely point of confusion for existing deployments, so it is now stated up front in both `docs/authoring-resources.md` and `docs/SPECIFICATIONS.md`.
- **Corrected stale search documentation** — the boost table listed three fields (including a `name` field that no longer exists); the landed query spans five. The worked example's keywords boost said 2x against a landed default of 3.0.
- **`examples/repository-docs/`** — a minimal `mcp-metadata.yaml` plus README for pointing `--content-dir` at a repository. Verified live over stdio: excluded paths stay unindexed, `references` is the default mode, a returned fragment URI reads back a single chunk, the base URI reads the whole document, and `--search-result-mode=content` appends the body.

### One production change worth reviewing

`internal/domain/metadata.go` — the built-in `search` and `read` tool descriptions were stale and are the only specification the calling agent sees. `search` claimed to search resource descriptions (never an indexed field) and to return document-level snippets rather than chunk citations. `read` documented an example URI carrying a `.md` extension, which does not resolve because `sourceURI` strips extensions — that one predates this series. Both now describe the landed behavior, including the fragment URI form. Tool input schemas, tool names, and the config override mechanism are unchanged.
