### PR TITLE
refactor(config)!: rename --search-name-boost to --search-title-boost

### DIFF
--- a/docs/SPECIFICATIONS.md
+++ b/docs/SPECIFICATIONS.md
@@ -24,7 +24,7 @@ The server is configured via environment variables, command-line flags, or a `.e
 | `ACDC_MCP_PORT` | `--port`, `-p` | Port to listen on for SSE transport. | `8080` |
 | `ACDC_MCP_SEARCH_MAX_RESULTS` | `--search-max-results`, `-m` | Max results returned by the search tool. | `10` |
 | `ACDC_MCP_SEARCH_KEYWORDS_BOOST` | `--search-keywords-boost` | Boost factor for keyword matches. | `3.0` |
-| `ACDC_MCP_SEARCH_NAME_BOOST` | `--search-name-boost` | Boost factor for name matches. | `2.0` |
+| `ACDC_MCP_SEARCH_TITLE_BOOST` | `--search-title-boost` | Boost factor for document title (`source_title`) matches. | `2.0` |
 | `ACDC_MCP_SEARCH_CONTENT_BOOST` | `--search-content-boost` | Boost factor for content matches. | `1.0` |
 | `ACDC_MCP_SEARCH_RESULT_MODE` | `--search-result-mode` | Search output detail: `references` or `content`. | `references` |
 | `ACDC_MCP_AUTH_TYPE` | `--auth-type`, `-a` | Authentication mode for SSE: `none`, `basic`, `apikey`. | `none` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,7 +23,7 @@ When the same setting is specified in multiple places, the following priority ap
 | `--cross-ref` | — | `ACDC_MCP_CROSS_REF` | Transform relative markdown links between resources into resource URIs | `false` |
 | `--search-max-results` | `-m` | `ACDC_MCP_SEARCH_MAX_RESULTS` | Maximum search results | `10` |
 | `--search-keywords-boost` | — | `ACDC_MCP_SEARCH_KEYWORDS_BOOST` | Boost for keywords matches | `3.0` |
-| `--search-name-boost` | — | `ACDC_MCP_SEARCH_NAME_BOOST` | Boost for name matches | `2.0` |
+| `--search-title-boost` | — | `ACDC_MCP_SEARCH_TITLE_BOOST` | Boost for document title (`source_title`) matches | `2.0` |
 | `--search-content-boost` | — | `ACDC_MCP_SEARCH_CONTENT_BOOST` | Boost for content matches | `1.0` |
 | `--search-result-mode` | — | `ACDC_MCP_SEARCH_RESULT_MODE` | Search output detail: `references` (chunk citations only) or `content` (citations plus the full matched chunk body) | `references` |
 

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -10,7 +10,7 @@ func RegisterFlags(flags *pflag.FlagSet) {
 	flags.IntP("port", "p", 0, "Port for SSE transport (default: 8080)")
 	flags.IntP("search-max-results", "m", 0, "Maximum search results (default: 10)")
 	flags.Float64("search-keywords-boost", 0, "Boost for keywords matches (default: 3.0)")
-	flags.Float64("search-name-boost", 0, "Boost for name matches (default: 2.0)")
+	flags.Float64("search-title-boost", 0, "Boost for document title matches (default: 2.0)")
 	flags.Float64("search-content-boost", 0, "Boost for content matches (default: 1.0)")
 	flags.String("search-result-mode", "", "Search output mode: references or content (default: references)")
 	flags.StringP("uri-scheme", "s", "", "URI scheme for resources (default: acdc)")

--- a/internal/app/cli_test.go
+++ b/internal/app/cli_test.go
@@ -124,3 +124,22 @@ func TestCLI_FlagParsing_AuthAPIKeys(t *testing.T) {
 		t.Errorf("Unexpected keys: %v", keys)
 	}
 }
+
+func TestRegisterFlags_SearchTitleBoostReplacesNameBoost(t *testing.T) {
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	RegisterFlags(flags)
+
+	require.NotNil(t, flags.Lookup("search-title-boost"))
+	require.Nil(t, flags.Lookup("search-name-boost"))
+}
+
+func TestCLI_FlagParsing_SearchTitleBoost(t *testing.T) {
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	RegisterFlags(flags)
+	require.NoError(t, flags.Set("search-title-boost", "7.5"))
+
+	settings, err := config.LoadSettingsWithFlags(flags)
+
+	require.NoError(t, err)
+	require.Equal(t, 7.5, settings.Search.TitleBoost)
+}

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -23,7 +23,7 @@ func LogWithLogger(s *Settings, logger *slog.Logger) {
 	logger.InfoContext(ctx, "Config: search.max_results", "value", s.Search.MaxResults)
 	logger.InfoContext(ctx, "Config: search.in_memory", "value", s.Search.InMemory)
 	logger.InfoContext(ctx, "Config: search.keywords_boost", "value", s.Search.KeywordsBoost)
-	logger.InfoContext(ctx, "Config: search.name_boost", "value", s.Search.NameBoost)
+	logger.InfoContext(ctx, "Config: search.title_boost", "value", s.Search.TitleBoost)
 	logger.InfoContext(ctx, "Config: search.content_boost", "value", s.Search.ContentBoost)
 	logger.InfoContext(ctx, "Config: search.result_mode", "value", s.Search.ResultMode)
 
@@ -43,7 +43,7 @@ func SearchSettingsLogValue(s SearchSettings) slog.Value {
 		slog.Int("max_results", s.MaxResults),
 		slog.Bool("in_memory", s.InMemory),
 		slog.Float64("keywords_boost", s.KeywordsBoost),
-		slog.Float64("name_boost", s.NameBoost),
+		slog.Float64("title_boost", s.TitleBoost),
 		slog.Float64("content_boost", s.ContentBoost),
 		slog.String("result_mode", string(s.ResultMode)),
 	)

--- a/internal/config/logging_test.go
+++ b/internal/config/logging_test.go
@@ -23,7 +23,7 @@ func TestLog(t *testing.T) {
 					MaxResults:    10,
 					InMemory:      true,
 					KeywordsBoost: 1.0,
-					NameBoost:     1.0,
+					TitleBoost:    1.0,
 					ContentBoost:  1.0,
 					ResultMode:    SearchResultModeReferences,
 				},

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -27,7 +27,7 @@ type SearchSettings struct {
 	MaxResults    int              `mapstructure:"max_results"`
 	InMemory      bool             `mapstructure:"in_memory"`
 	KeywordsBoost float64          `mapstructure:"keywords_boost"`
-	NameBoost     float64          `mapstructure:"name_boost"`
+	TitleBoost    float64          `mapstructure:"title_boost"`
 	ContentBoost  float64          `mapstructure:"content_boost"`
 	ResultMode    SearchResultMode `mapstructure:"result_mode"`
 }
@@ -86,7 +86,7 @@ func LoadSettingsWithFlags(flags *pflag.FlagSet) (*Settings, error) {
 	v.SetDefault("uri_scheme", "acdc")
 	v.SetDefault("search.max_results", 10)
 	v.SetDefault("search.keywords_boost", 3.0)
-	v.SetDefault("search.name_boost", 2.0)
+	v.SetDefault("search.title_boost", 2.0)
 	v.SetDefault("search.content_boost", 1.0)
 	v.SetDefault("search.result_mode", SearchResultModeReferences)
 	v.SetDefault("cross_ref", false)
@@ -102,7 +102,7 @@ func LoadSettingsWithFlags(flags *pflag.FlagSet) (*Settings, error) {
 	// with hardcoded keys. Errors are intentionally discarded here.
 	_ = v.BindEnv("search.max_results", "ACDC_MCP_SEARCH_MAX_RESULTS")
 	_ = v.BindEnv("search.keywords_boost", "ACDC_MCP_SEARCH_KEYWORDS_BOOST")
-	_ = v.BindEnv("search.name_boost", "ACDC_MCP_SEARCH_NAME_BOOST")
+	_ = v.BindEnv("search.title_boost", "ACDC_MCP_SEARCH_TITLE_BOOST")
 	_ = v.BindEnv("search.content_boost", "ACDC_MCP_SEARCH_CONTENT_BOOST")
 	_ = v.BindEnv("search.result_mode", "ACDC_MCP_SEARCH_RESULT_MODE")
 
@@ -124,7 +124,7 @@ func LoadSettingsWithFlags(flags *pflag.FlagSet) (*Settings, error) {
 		_ = v.BindPFlag("cross_ref", flags.Lookup("cross-ref"))
 		_ = v.BindPFlag("search.max_results", flags.Lookup("search-max-results"))
 		_ = v.BindPFlag("search.keywords_boost", flags.Lookup("search-keywords-boost"))
-		_ = v.BindPFlag("search.name_boost", flags.Lookup("search-name-boost"))
+		_ = v.BindPFlag("search.title_boost", flags.Lookup("search-title-boost"))
 		_ = v.BindPFlag("search.content_boost", flags.Lookup("search-content-boost"))
 		_ = v.BindPFlag("search.result_mode", flags.Lookup("search-result-mode"))
 		_ = v.BindPFlag("auth.type", flags.Lookup("auth-type"))

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -33,8 +33,8 @@ func TestLoadSettings_Defaults(t *testing.T) {
 	if settings.Search.KeywordsBoost != 3.0 {
 		t.Errorf("Expected default keywords boost 3.0, got %f", settings.Search.KeywordsBoost)
 	}
-	if settings.Search.NameBoost != 2.0 {
-		t.Errorf("Expected default name boost 2.0, got %f", settings.Search.NameBoost)
+	if settings.Search.TitleBoost != 2.0 {
+		t.Errorf("Expected default title boost 2.0, got %f", settings.Search.TitleBoost)
 	}
 	if settings.Search.ContentBoost != 1.0 {
 		t.Errorf("Expected default content boost 1.0, got %f", settings.Search.ContentBoost)
@@ -217,7 +217,7 @@ func TestLoadSettingsWithFlags_AllFlagTypes(t *testing.T) {
 	flags.Int("port", 0, "")
 	flags.Int("search-max-results", 0, "")
 	flags.Float64("search-keywords-boost", 0, "")
-	flags.Float64("search-name-boost", 0, "")
+	flags.Float64("search-title-boost", 0, "")
 	flags.Float64("search-content-boost", 0, "")
 	flags.String("auth-type", "", "")
 	flags.String("auth-basic-username", "", "")
@@ -230,7 +230,7 @@ func TestLoadSettingsWithFlags_AllFlagTypes(t *testing.T) {
 	_ = flags.Set("port", "3000")
 	_ = flags.Set("search-max-results", "50")
 	_ = flags.Set("search-keywords-boost", "10.0")
-	_ = flags.Set("search-name-boost", "5.0")
+	_ = flags.Set("search-title-boost", "5.0")
 	_ = flags.Set("search-content-boost", "2.0")
 	_ = flags.Set("auth-type", "basic")
 	_ = flags.Set("auth-basic-username", "testuser")
@@ -259,8 +259,8 @@ func TestLoadSettingsWithFlags_AllFlagTypes(t *testing.T) {
 	if settings.Search.KeywordsBoost != 10.0 {
 		t.Errorf("Expected keywords boost 10.0, got %f", settings.Search.KeywordsBoost)
 	}
-	if settings.Search.NameBoost != 5.0 {
-		t.Errorf("Expected name boost 5.0, got %f", settings.Search.NameBoost)
+	if settings.Search.TitleBoost != 5.0 {
+		t.Errorf("Expected title boost 5.0, got %f", settings.Search.TitleBoost)
 	}
 	if settings.Search.ContentBoost != 2.0 {
 		t.Errorf("Expected content boost 2.0, got %f", settings.Search.ContentBoost)
@@ -685,4 +685,34 @@ func TestValidateSettings_InvalidSchemes(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLoadSettingsWithFlags_SearchTitleBoostFlag(t *testing.T) {
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.Float64("search-title-boost", 0, "")
+	require.NoError(t, flags.Set("search-title-boost", "5.0"))
+
+	settings, err := LoadSettingsWithFlags(flags)
+
+	require.NoError(t, err)
+	require.Equal(t, 5.0, settings.Search.TitleBoost)
+}
+
+func TestLoadSettings_SearchTitleBoostEnvVar(t *testing.T) {
+	t.Setenv("ACDC_MCP_SEARCH_TITLE_BOOST", "4.5")
+
+	settings, err := LoadSettings()
+
+	require.NoError(t, err)
+	require.Equal(t, 4.5, settings.Search.TitleBoost)
+}
+
+// The pre-rename env var is no longer a supported input.
+func TestLoadSettings_SearchTitleBoostIgnoresRetiredNameEnvVar(t *testing.T) {
+	t.Setenv("ACDC_MCP_SEARCH_NAME_BOOST", "9.0")
+
+	settings, err := LoadSettings()
+
+	require.NoError(t, err)
+	require.Equal(t, 2.0, settings.Search.TitleBoost)
 }

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -253,7 +253,7 @@ func (s *Service) Search(queryStr string, candidateLimit int) ([]SearchResult, e
 		q = bleve.NewDisjunctionQuery(
 			fieldQuery(queryStr, domain.FieldKeywords, s.settings.KeywordsBoost),
 			fieldQuery(queryStr, domain.FieldHeadingPath, headingBoost),
-			fieldQuery(queryStr, domain.FieldSourceTitle, s.settings.NameBoost),
+			fieldQuery(queryStr, domain.FieldSourceTitle, s.settings.TitleBoost),
 			fieldQuery(queryStr, domain.FieldPathLabels, pathBoost),
 			fieldQuery(queryStr, domain.FieldContent, s.settings.ContentBoost),
 		)

--- a/internal/search/service_test.go
+++ b/internal/search/service_test.go
@@ -66,7 +66,7 @@ func testSettings() config.SearchSettings {
 		InMemory:      true,
 		MaxResults:    10,
 		KeywordsBoost: 3,
-		NameBoost:     2,
+		TitleBoost:    2,
 		ContentBoost:  1,
 	}
 }


### PR DESCRIPTION
## Summary

`--search-name-boost` tunes the boost applied to the `source_title` field, but its name refers to a `name` field that no longer exists in the index — it was replaced during the chunk-indexing series. This renames the flag, env var, config key, and struct field to match the field they actually affect. Ranking behavior is unchanged.

## Changes

- `--search-name-boost` → `--search-title-boost`, `ACDC_MCP_SEARCH_NAME_BOOST` → `ACDC_MCP_SEARCH_TITLE_BOOST`, `search.name_boost` → `search.title_boost`, `SearchSettings.NameBoost` → `TitleBoost`.
- Flag help is now "Boost for document title matches"; both config tables name the indexed field explicitly (`source_title`) so the flag↔field link is documented rather than implicit — the drift this fixes went unnoticed precisely because it wasn't written down.

### Breaking change — chosen deliberately over a deprecation alias

- `--search-name-boost` now fails as an unknown flag (non-zero exit). Loud.
- `ACDC_MCP_SEARCH_NAME_BOOST` and `search.name_boost` are no longer read, and there is **no warning** — a deployment still setting either silently reverts to the `2.0` default. This is the sharper edge of the hard-rename option and belongs in the release notes.

`heading_path` (2.5) and `path_labels` (1.25) remain hardcoded while the other three boosts are configurable. Out of scope here, but it's an odd line to draw — `heading_path` is the second-strongest ranking signal and can't be tuned at all.