### PR TITLE
feat!: add zero-config repository mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ docker-compose up -d
 **Homebrew:**
 ```bash
 brew install sha1n/tap/acdc-mcp
+acdc-mcp
+```
+Or point it at a dedicated content repository:
+```bash
 acdc-mcp --content-dir ./content
 ```
 
@@ -66,6 +70,10 @@ See [Development Guide](docs/development.md) for build instructions.
 ## 🏃 Running
 
 ### Stdio Transport (default)
+```bash
+acdc-mcp
+```
+Or point it at a dedicated content repository:
 ```bash
 acdc-mcp --content-dir ./content
 ```
@@ -101,7 +109,7 @@ readinessProbe:
 
 | Flag | Short | Environment Variable | Default |
 |------|-------|---------------------|---------|
-| `--content-dir` | `-c` | `ACDC_MCP_CONTENT_DIR` | `./content` |
+| `--content-dir` | `-c` | `ACDC_MCP_CONTENT_DIR` | current working directory |
 | `--transport` | `-t` | `ACDC_MCP_TRANSPORT` | `stdio` |
 | `--port` | `-p` | `ACDC_MCP_PORT` | `8080` |
 | `--uri-scheme` | `-s` | `ACDC_MCP_URI_SCHEME` | `acdc` |
@@ -115,9 +123,18 @@ For full configuration options including authentication, see [Configuration Refe
 
 ## 🤖 Agent Configuration
 
+### Per-Repository (Zero-Config)
+
+Because `--content-dir` defaults to the working directory and `mcp-metadata.yaml` is optional, `acdc-mcp` can be registered once at **user** scope, with no `--content-dir` — for clients that launch stdio servers with the repository as the working directory, as Claude Code and Gemini CLI do, this means it indexes whichever repository the client is running in each time it launches the server:
+
+```bash
+claude mcp add --scope user --transport stdio acdc -- acdc-mcp
+gemini mcp add --scope user --transport stdio --trust acdc acdc-mcp
+```
+
 ### [Gemini CLI](https://github.com/google-gemini/gemini-cli)
 
-**Stdio:**
+**Stdio (fixed content directory):**
 ```bash
 gemini mcp add --scope user --transport stdio --trust acdc acdc-mcp -- --transport stdio --content-dir $ACDC_MCP_CONTENT_DIR
 ```
@@ -129,7 +146,7 @@ gemini mcp add --scope user --transport sse --trust acdc http://<host>:<port>/ss
 
 ### [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code)
 
-**Stdio:**
+**Stdio (fixed content directory):**
 ```bash
 claude mcp add --scope user --transport stdio acdc -- acdc-mcp --transport stdio --content-dir $ACDC_MCP_CONTENT_DIR
 ```
@@ -144,9 +161,13 @@ claude mcp add --scope user --transport sse acdc http://<host>:<port>/sse
 
 ## 📚 Content & Resources
 
-The server requires an `mcp-metadata.yaml` file in your content directory to define server identity. Tool metadata is optional and the server provides high-quality default descriptions for `search` and `read` tools.
+An `mcp-metadata.yaml` file in your content directory is optional. Point `acdc-mcp` at any repository with no manifest and it starts anyway, indexing `README.md` and `docs/**/*.md` with built-in server identity and instructions — no configuration required:
 
-By default, the server discovers markdown files under `mcp-resources/`. Adding an `index` block to `mcp-metadata.yaml` switches document discovery instead to any Markdown matched by glob patterns (e.g. `docs/**/*.md`), without needing frontmatter or a dedicated `mcp-resources/` layout. Either way, discovered documents are split into heading-aware chunks for search.
+```bash
+acdc-mcp --content-dir /path/to/repository
+```
+
+Add an `mcp-metadata.yaml` to override the defaults: customize server identity and instructions, and either add an `index` block to index any Markdown matched by glob patterns (e.g. `docs/**/*.md`, without needing frontmatter), or omit `index` to use the legacy `mcp-resources/` layout, which requires frontmatter on every file. Whichever mode selected the documents, they are split into heading-aware chunks for search.
 
 For details on authoring resource files, including frontmatter format and search keyword boosting, see the [Authoring Resources Guide](docs/authoring-resources.md).
 

--- a/docs/SPECIFICATIONS.md
+++ b/docs/SPECIFICATIONS.md
@@ -7,7 +7,7 @@ The ACDC (Agent Content Discovery Companion) MCP Server is designed to serve org
 ### Core Principles
 1.  **Centralized Content**: Operates on a local directory (typically a mounted volume) containing static Markdown resources.
 2.  **Zero-Config Client**: Clients discover capabilities dynamically via MCP tool definitions.
-3.  **Metadata-Driven**: Server identity and tool exposure are controlled by a `mcp-metadata.yaml` manifest in the content root.
+3.  **Metadata-Driven**: Server identity, tool exposure, and indexing use built-in defaults, optionally overridden by an `mcp-metadata.yaml` manifest in the content root.
 4.  **Transport Agnostic**: Supports both `stdio` (local process) and `sse` (HTTP) transports.
 
 ---
@@ -18,7 +18,7 @@ The server is configured via environment variables, command-line flags, or a `.e
 
 | Environment Variable | CLI Flag | Description | Default |
 | :--- | :--- | :--- | :--- |
-| `ACDC_MCP_CONTENT_DIR` | `--content-dir`, `-c` | Root directory containing `mcp-metadata.yaml` (see Content Repository Structure). | `./content` |
+| `ACDC_MCP_CONTENT_DIR` | `--content-dir`, `-c` | Root directory to serve; an `mcp-metadata.yaml` there is optional (see Content Repository Structure). | current working directory |
 | `ACDC_MCP_TRANSPORT` | `--transport`, `-t` | Communication transport: `stdio` or `sse`. | `stdio` |
 | `ACDC_MCP_HOST` | `--host`, `-H` | Host interface to bind for SSE transport. | `0.0.0.0` |
 | `ACDC_MCP_PORT` | `--port`, `-p` | Port to listen on for SSE transport. | `8080` |
@@ -37,16 +37,30 @@ The server is configured via environment variables, command-line flags, or a `.e
 
 ## Content Repository Structure
 
-The server expects `mcp-metadata.yaml` at the root of `ACDC_MCP_CONTENT_DIR`. Source documents are then discovered in one of two mutually exclusive modes, selected by the presence of an `index` block in `mcp-metadata.yaml`:
+`mcp-metadata.yaml` at the root of `ACDC_MCP_CONTENT_DIR` is optional. If it is absent, the server falls back to built-in zero-config defaults (see 0 below) rather than failing startup. If it is present, source documents are discovered in one of two mutually exclusive modes, selected by the presence of an `index` block in `mcp-metadata.yaml`:
 
 ```text
 / (Content Root)
-├── mcp-metadata.yaml       # Server identity, tool, and index configuration (Required)
+├── mcp-metadata.yaml       # Server identity, tool, and index configuration (Optional — see 0. Zero-Config Defaults)
 └── mcp-resources/          # Legacy discovery: used when `index` is absent
     ├── guide.md
     └── subfolder/
         └── details.md
 ```
+
+### 0. Zero-Config Defaults (`mcp-metadata.yaml` absent)
+
+-   **Activation**: Triggered only when `mcp-metadata.yaml` does not exist at the content root. A manifest that exists but cannot be read, fails to parse as YAML, or fails `Validate()` is still a fatal startup error — only a *missing* file falls back to defaults.
+-   **Default index**: Equivalent to a manifest with `index.include: ["README.md", "docs/**/*.md"]` (no `exclude`), which selects the same configured chunk indexing path described in 2b, with the same optional-frontmatter metadata derivation.
+-   **Error handling (lenient)**: Unlike an explicit `index` block, the defaulted index tolerates conditions that would otherwise fail startup: zero matched files, and a per-file read or parse failure, are logged as warnings and the file (or the whole selection) is skipped instead of failing the server. Configuration-shape errors — an invalid, absolute, or root-escaping glob pattern, a selected non-Markdown file, or a content root that cannot be resolved — remain fatal, exactly as in 2b.
+-   **Directory pruning**: `.git` is always skipped during traversal, in both this mode and 2b. Under this defaulted mode only, `node_modules`, `vendor`, `dist`, `build`, `target`, and `.venv` are also skipped, so a repository's dependency and build-output directories are never scanned for Markdown. The content root itself is never pruned, even if its name matches one of these.
+-   **Derived identity**: The server name is `"<base> Documentation"`, where `<base>` is the base name of the resolved `--content-dir` path (falling back to `"Repository"` if no meaningful base name can be derived, e.g. the root directory). The version is the build-injected binary version, or `0.0.0` when it is empty. Instructions are generated from a built-in template naming the repository:
+    ```text
+    Documentation for the <base> repository: guides, references, design documents, specs and plans kept under docs/, plus the top-level README.
+
+    Search here before answering questions about this repository's conventions, architecture, decisions, or planned work. Prefer these documents over assumptions drawn from source code alone.
+    ```
+-   **Startup log**: When defaults are used, the server logs `mcp-metadata.yaml not found, using built-in defaults` at info level, with the derived server name and default index patterns.
 
 ### 1. Metadata Manifest (`mcp-metadata.yaml`)
 
@@ -57,7 +71,7 @@ Defines the server's identity, optional tool overrides, and optional configured 
 server:
   name: <string>        # Display name of the MCP server
   version: <string>     # Semantic version string
-  instructions: <string> # System prompt / context instructions for the agent
+  instructions: <string> # Delivered to clients as the MCP server's `instructions` field
 
 tools:                  # Optional: Override default tool descriptions
   - name: search
@@ -98,7 +112,7 @@ Markdown content follows...
 
 ### 2b. Configured Chunk Indexing (`index` present)
 
--   **Discovery**: Files under the content root matching `index.include` (and not matching `index.exclude`) are indexed, using [doublestar](https://github.com/bmatcuk/doublestar) glob syntax where `**` matches zero or more path segments (`docs/**/*.md` matches both `docs/guide.md` and `docs/api/guide.md`). Patterns must be relative to the content root; absolute or root-escaping patterns fail startup. `exclude` always wins over `include`.
+-   **Discovery**: Files under the content root matching `index.include` (and not matching `index.exclude`) are indexed, using [doublestar](https://github.com/bmatcuk/doublestar) glob syntax where `**` matches zero or more path segments (`docs/**/*.md` matches both `docs/guide.md` and `docs/api/guide.md`). Patterns must be relative to the content root; absolute or root-escaping patterns fail startup. `exclude` always wins over `include`. `.git` is always skipped during traversal (see also the zero-config-only pruning in 0 above).
 -   **URI Scheme**: Same construction as legacy discovery, relative to `--content-dir` instead of `mcp-resources/`.
 -   **File Format**: Must be `.md` or `.markdown`. YAML frontmatter is **optional**; when present it must still be valid.
 -   **Metadata derivation**: `name` falls back to the first `#` (H1) heading, `description` to the first paragraph, when frontmatter omits them. `description` is always truncated to 200 Unicode characters, whether it came from frontmatter or the fallback paragraph. `keywords` has no fallback.

--- a/docs/authoring-resources.md
+++ b/docs/authoring-resources.md
@@ -2,6 +2,12 @@
 
 This guide explains how to create and structure markdown resource files for the ACDC MCP server.
 
+## Zero-Config Defaults (No Manifest)
+
+`mcp-metadata.yaml` is optional. Point `--content-dir` at any repository that has no manifest and the server starts anyway, indexing `README.md` and `docs/**/*.md` with a built-in server name, version, and instructions naming the repository. Because the manifest is missing (not merely lacking an `index` block), this reuses the same discovery mechanism as [Configured Chunk Indexing](#configured-chunk-indexing-index) — frontmatter is optional — but tolerates conditions that would otherwise fail startup: an empty selection or a file that cannot be read or parsed is logged as a warning and skipped rather than failing the server. See [Content Repository Structure](SPECIFICATIONS.md#content-repository-structure) in the specification for the exact activation rule, default patterns, and derived identity.
+
+Add an `mcp-metadata.yaml` file to override any of this: give the server a custom name, version, and instructions, restrict or expand which files are indexed, or opt back into the stricter legacy layout described below. The rest of this guide assumes a manifest is present.
+
 ## File Location
 
 By default (when `mcp-metadata.yaml` has no `index` block — see [Configured Chunk Indexing](#configured-chunk-indexing-index)), place all resource markdown files inside the `mcp-resources/` subdirectory of your content directory:
@@ -19,7 +25,7 @@ content/
 
 ## Server Metadata (`mcp-metadata.yaml`)
 
-The `mcp-metadata.yaml` file in the root of your content directory defines server identity and instructions. This file is **required** for the server to start.
+The `mcp-metadata.yaml` file in the root of your content directory overrides the [built-in zero-config defaults](#zero-config-defaults-no-manifest): it defines server identity and instructions explicitly, and controls tool descriptions and indexing. The file is optional — omit it to run with defaults — but once present, the fields below are required within it, and an invalid or unreadable manifest fails startup.
 
 ### Structure
 
@@ -43,7 +49,7 @@ server:
 
 #### The `instructions` Field
 
-The `instructions` field is particularly important—it provides **system-level guidance** to AI agents on how to use this server effectively. Well-crafted instructions significantly improve agent behavior.
+The `instructions` field is particularly important—it is delivered to the client verbatim as the MCP server's `instructions`, giving AI agents **system-level guidance** on how to use this server effectively. Well-crafted instructions significantly improve agent behavior.
 
 **What to include:**
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,7 +15,7 @@ When the same setting is specified in multiple places, the following priority ap
 
 | CLI Flag | Short | Environment Variable | Description | Default |
 |----------|-------|---------------------|-------------|---------|
-| `--content-dir` | `-c` | `ACDC_MCP_CONTENT_DIR` | Path to content directory | `./content` |
+| `--content-dir` | `-c` | `ACDC_MCP_CONTENT_DIR` | Path to content directory. May point at a repository root with no `mcp-metadata.yaml` — see [Authoring Resources Guide](authoring-resources.md#zero-config-defaults-no-manifest). | current working directory |
 | `--transport` | `-t` | `ACDC_MCP_TRANSPORT` | Transport type: `stdio` or `sse` | `stdio` |
 | `--host` | `-H` | `ACDC_MCP_HOST` | Host for SSE server (SSE mode only) | `0.0.0.0` |
 | `--port` | `-p` | `ACDC_MCP_PORT` | Port for SSE server (SSE mode only) | `8080` |

--- a/examples/repository-docs/README.md
+++ b/examples/repository-docs/README.md
@@ -1,8 +1,24 @@
 # Repository Docs (Configured Chunk Indexing)
 
-This example shows the other way to point ACDC at content: instead of curating a dedicated `mcp-resources/` tree with required frontmatter, it indexes an **existing repository's `docs/` directory** directly, using the `index` block in `mcp-metadata.yaml`. Documents are split into heading-aware chunks for search — see the [Authoring Resources Guide](../../docs/authoring-resources.md#configured-chunk-indexing-index) for the full behavior.
+This example shows the other way to point ACDC at content: instead of curating a dedicated `mcp-resources/` tree with required frontmatter, it indexes an **existing repository's `docs/` directory** directly. Documents are split into heading-aware chunks for search — see the [Authoring Resources Guide](../../docs/authoring-resources.md#configured-chunk-indexing-index) for the full behavior.
 
-## What this example demonstrates
+Two variants are shown below: running with **no manifest at all** (zero-config defaults), and running with the `mcp-metadata.yaml` in this directory to customize identity or the indexed patterns.
+
+## No-Manifest Variant (Zero-Config)
+
+If the repository you're pointing at has no `mcp-metadata.yaml`, skip straight to running the server — no setup required:
+
+```bash
+acdc-mcp --content-dir /path/to/repository
+```
+
+This indexes `README.md` and `docs/**/*.md` under that repository, deriving the server name and instructions from the repository's directory name. Unlike the configured variant below, an empty selection or an unreadable/unparsable file is a startup warning rather than a fatal error — see [Zero-Config Defaults](../../docs/authoring-resources.md#zero-config-defaults-no-manifest).
+
+## Configured Variant (`mcp-metadata.yaml`)
+
+Add a manifest when you want a custom server name/instructions, or `index.include`/`index.exclude` patterns other than the `docs/**/*.md` default.
+
+### What this example demonstrates
 
 - metadata index.include selects Markdown relative to --content-dir
 - index.exclude wins over include
@@ -13,7 +29,7 @@ This example shows the other way to point ACDC at content: instead of curating a
 - existing mcp-resources behavior remains when index is absent
 - persistence and live watching are not part of this release
 
-## Usage
+### Usage
 
 1. Copy `mcp-metadata.yaml` from this directory to the root of the repository whose `docs/` you want to search (the same directory you'll pass as `--content-dir`). If that repository already has an `mcp-metadata.yaml`, merge the `index` block into it instead of overwriting the file.
 2. Adjust `index.include`/`index.exclude` if your documentation lives somewhere other than `docs/`.
@@ -26,7 +42,7 @@ acdc-mcp --content-dir /path/to/repository --search-result-mode content
 
 The first command returns chunk citations (title, URI, breadcrumb, and a snippet) that agents follow up on with the `read` tool. The second additionally inlines the full matched chunk body in the search response itself.
 
-## Notes
+## Notes (Both Variants)
 
 - No frontmatter is required in the indexed Markdown; `name`/`description` fall back to the first H1 (`#`) heading and first paragraph when frontmatter is absent. A document whose first heading is `##` or deeper gets an empty name.
 - The server rebuilds its chunk catalog and search index fully at startup. There is no persistence across restarts and no live filesystem watching — restart the server to pick up documentation changes.

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -4,7 +4,7 @@ import "github.com/spf13/pflag"
 
 // RegisterFlags registers all CLI flags on the given FlagSet
 func RegisterFlags(flags *pflag.FlagSet) {
-	flags.StringP("content-dir", "c", "", "Path to content directory (default: ./content)")
+	flags.StringP("content-dir", "c", "", "Path to content directory (default: current working directory)")
 	flags.StringP("transport", "t", "", "Transport type: stdio or sse (default: stdio)")
 	flags.StringP("host", "H", "", "Host for SSE transport (default: 0.0.0.0)")
 	flags.IntP("port", "p", 0, "Port for SSE transport (default: 8080)")

--- a/internal/app/factory.go
+++ b/internal/app/factory.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
@@ -13,11 +14,10 @@ import (
 	"github.com/sha1n/mcp-acdc-server/internal/prompts"
 	"github.com/sha1n/mcp-acdc-server/internal/resources"
 	"github.com/sha1n/mcp-acdc-server/internal/search"
-	"gopkg.in/yaml.v3"
 )
 
 type factoryDeps struct {
-	discover  func(context.Context, *content.ContentProvider, *domain.IndexMetadata, string) (resources.DiscoveryResult, error)
+	discover  func(context.Context, *content.ContentProvider, *domain.IndexMetadata, string, ...resources.DiscoverOption) (resources.DiscoveryResult, error)
 	newSearch func(config.SearchSettings) search.Searcher
 }
 
@@ -31,36 +31,32 @@ func defaultFactoryDeps() factoryDeps {
 }
 
 // CreateMCPServer initializes the core MCP server components.
-func CreateMCPServer(ctx context.Context, settings *config.Settings) (*mcpsdk.Server, func(), error) {
-	return createMCPServer(ctx, settings, defaultFactoryDeps())
+func CreateMCPServer(ctx context.Context, settings *config.Settings, version string) (*mcpsdk.Server, func(), error) {
+	return createMCPServer(ctx, settings, version, defaultFactoryDeps())
 }
 
-func createMCPServer(ctx context.Context, settings *config.Settings, deps factoryDeps) (*mcpsdk.Server, func(), error) {
+func createMCPServer(ctx context.Context, settings *config.Settings, version string, deps factoryDeps) (*mcpsdk.Server, func(), error) {
 	// Initialize content provider
 	cp := content.NewContentProvider(settings.ContentDir)
 
-	// Load metadata
-	metadataPath := cp.GetPath("mcp-metadata.yaml")
-
-	mdBytes, err := os.ReadFile(metadataPath)
+	resolved, err := resolveMetadata(cp, version)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to read metadata file: %w", err)
+		return nil, nil, err
 	}
+	metadata := resolved.metadata
 
-	var metadata domain.McpMetadata
-	if err := yaml.Unmarshal(mdBytes, &metadata); err != nil {
-		return nil, nil, fmt.Errorf("failed to parse metadata: %w", err)
-	}
-
-	if err := metadata.Validate(); err != nil {
-		return nil, nil, fmt.Errorf("metadata validation failed: %w", err)
+	var discoverOpts []resources.DiscoverOption
+	if resolved.defaulted {
+		discoverOpts = append(discoverOpts, resources.WithLenientIndex())
 	}
 
 	// Discover resources
-	discovery, err := deps.discover(ctx, cp, metadata.Index, settings.Scheme)
+	discovery, err := deps.discover(ctx, cp, metadata.Index, settings.Scheme, discoverOpts...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to discover resources: %w", err)
 	}
+
+	warnIfLegacyLayoutIgnored(cp, resolved.defaulted, discovery)
 
 	var resourceOpts []resources.Option
 	if settings.CrossRef {
@@ -94,4 +90,36 @@ func createMCPServer(ctx context.Context, settings *config.Settings, deps factor
 	mcpServer := mcp.CreateServer(metadata, resourceProvider, promptProvider, searchService, settings.Search)
 
 	return mcpServer, searchService.Close, nil
+}
+
+// warnIfLegacyLayoutIgnored flags the likely cause of a silently empty
+// zero-config server: a manifest-less content root laid out for legacy
+// mcp-resources discovery. Zero-config defaults always set a non-nil Index,
+// which routes discovery to the configured-index path (README.md and
+// docs/**) rather than the legacy mcp-resources scan, so an mcp-resources/
+// directory goes unindexed without any error. This is diagnostic only; it
+// does not change which discovery mode is selected or whether startup
+// succeeds.
+func warnIfLegacyLayoutIgnored(cp *content.ContentProvider, defaulted bool, discovery resources.DiscoveryResult) {
+	if !shouldWarnLegacyLayoutIgnored(cp, defaulted, discovery) {
+		return
+	}
+	slog.Warn("Found mcp-resources/ directory but no mcp-metadata.yaml manifest; "+
+		"zero-config mode indexes only README.md and docs/**, so mcp-resources/ is not indexed",
+		"resources_dir", cp.ResourcesDir,
+		"manifest_path", cp.GetPath(metadataFileName))
+}
+
+// shouldWarnLegacyLayoutIgnored reports whether defaulted metadata produced
+// zero discovered sources while an mcp-resources/ directory sits unindexed
+// at the content root.
+func shouldWarnLegacyLayoutIgnored(cp *content.ContentProvider, defaulted bool, discovery resources.DiscoveryResult) bool {
+	if !defaulted || len(discovery.Sources) > 0 {
+		return false
+	}
+	info, err := os.Stat(cp.ResourcesDir)
+	if err != nil || !info.IsDir() {
+		return false
+	}
+	return true
 }

--- a/internal/app/factory_test.go
+++ b/internal/app/factory_test.go
@@ -7,7 +7,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/sha1n/mcp-acdc-server/internal/config"
 	"github.com/sha1n/mcp-acdc-server/internal/content"
 	"github.com/sha1n/mcp-acdc-server/internal/domain"
@@ -36,6 +38,84 @@ func appTestSettings(contentDir string) *config.Settings {
 }
 
 type factoryContextKey struct{}
+
+// TestShouldWarnLegacyLayoutIgnored_ConditionMatrix pins the predicate that
+// decides whether the missing-manifest-over-legacy-layout diagnostic fires,
+// independent of the slog.Warn side effect. Each case documents one branch
+// of the three-way condition so a future change to any single branch (e.g.
+// inverting defaulted, loosening the source-count check, or dropping the
+// IsDir guard) fails here rather than silently mis-warning correctly
+// configured zero-config servers.
+func TestShouldWarnLegacyLayoutIgnored_ConditionMatrix(t *testing.T) {
+	oneSource := []domain.SourceDocument{{URI: "acdc://readme", Name: "readme"}}
+
+	tests := []struct {
+		name      string
+		defaulted bool
+		sources   []domain.SourceDocument
+		setupDir  func(t *testing.T, contentDir string)
+		wantWarn  bool
+	}{
+		{
+			name:      "defaulted, zero sources, mcp-resources dir exists",
+			defaulted: true,
+			sources:   nil,
+			setupDir: func(t *testing.T, contentDir string) {
+				require.NoError(t, os.MkdirAll(filepath.Join(contentDir, "mcp-resources"), 0o755))
+			},
+			wantWarn: true,
+		},
+		{
+			name:      "not defaulted (explicit manifest), zero sources, mcp-resources dir exists",
+			defaulted: false,
+			sources:   nil,
+			setupDir: func(t *testing.T, contentDir string) {
+				require.NoError(t, os.MkdirAll(filepath.Join(contentDir, "mcp-resources"), 0o755))
+			},
+			wantWarn: false,
+		},
+		{
+			name:      "defaulted, at least one source, mcp-resources dir exists",
+			defaulted: true,
+			sources:   oneSource,
+			setupDir: func(t *testing.T, contentDir string) {
+				require.NoError(t, os.MkdirAll(filepath.Join(contentDir, "mcp-resources"), 0o755))
+			},
+			wantWarn: false,
+		},
+		{
+			name:      "defaulted, zero sources, no mcp-resources at all",
+			defaulted: true,
+			sources:   nil,
+			setupDir: func(t *testing.T, contentDir string) {
+				// no mcp-resources directory created
+			},
+			wantWarn: false,
+		},
+		{
+			name:      "defaulted, zero sources, mcp-resources exists but is a regular file",
+			defaulted: true,
+			sources:   nil,
+			setupDir: func(t *testing.T, contentDir string) {
+				require.NoError(t, os.WriteFile(filepath.Join(contentDir, "mcp-resources"), []byte("not a directory"), 0o644))
+			},
+			wantWarn: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			contentDir := t.TempDir()
+			tt.setupDir(t, contentDir)
+			cp := content.NewContentProvider(contentDir)
+			discovery := resources.DiscoveryResult{Sources: tt.sources}
+
+			got := shouldWarnLegacyLayoutIgnored(cp, tt.defaulted, discovery)
+
+			require.Equal(t, tt.wantWarn, got)
+		})
+	}
+}
 
 func TestCreateMCPServer_Success(t *testing.T) {
 	tempDir := t.TempDir()
@@ -69,7 +149,7 @@ tools: []
 		},
 	}
 
-	server, cleanup, err := CreateMCPServer(context.Background(), settings)
+	server, cleanup, err := CreateMCPServer(context.Background(), settings, "test")
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}
@@ -80,7 +160,12 @@ tools: []
 	}
 }
 
-func TestCreateMCPServer_MissingMetadata(t *testing.T) {
+// TestCreateMCPServer_MissingManifestNoDefaultDocsSucceedsLeniently covers the
+// zero-config path: with no mcp-metadata.yaml and neither README.md nor docs/,
+// the built-in defaults apply and the empty match is tolerated rather than
+// failing startup. This supersedes the pre-zero-config behavior where an
+// absent manifest was a hard configuration error.
+func TestCreateMCPServer_MissingManifestNoDefaultDocsSucceedsLeniently(t *testing.T) {
 	tempDir := t.TempDir()
 	contentDir := filepath.Join(tempDir, "content")
 	_ = os.MkdirAll(contentDir, 0755)
@@ -93,13 +178,78 @@ func TestCreateMCPServer_MissingMetadata(t *testing.T) {
 		},
 	}
 
-	_, _, err := CreateMCPServer(context.Background(), settings)
-	if err == nil {
-		t.Fatal("Expected error when metadata is missing")
+	server, cleanup, err := CreateMCPServer(context.Background(), settings, "test")
+	if err != nil {
+		t.Fatalf("Expected success under the zero-config default, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "failed to read metadata file") {
-		t.Errorf("Unexpected error message: %v", err)
+	defer cleanup()
+
+	if server == nil {
+		t.Fatal("Server is nil")
 	}
+}
+
+// TestCreateMCPServer_MissingManifestWithDefaultDocsSucceeds covers the
+// zero-config path where the content root has README.md and docs/**/*.md,
+// matching the built-in default include patterns.
+func TestCreateMCPServer_MissingManifestWithDefaultDocsSucceeds(t *testing.T) {
+	contentDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(contentDir, "README.md"), []byte("# Hello\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(contentDir, "docs"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(contentDir, "docs", "a.md"), []byte("# Doc A\n"), 0o644))
+
+	server, cleanup, err := CreateMCPServer(context.Background(), appTestSettings(contentDir), "test")
+	require.NoError(t, err)
+	defer cleanup()
+	require.NotNil(t, server)
+}
+
+// TestCreateMCPServer_MissingManifestOverLegacyLayoutSucceeds covers a
+// content root laid out for legacy discovery (mcp-resources/**.md) but
+// missing mcp-metadata.yaml. Zero-config defaults always set a non-nil Index,
+// so discovery never reaches the legacy mcp-resources scan; startup must
+// still succeed, and the diagnostic warning this path is expected to emit
+// must not itself break server construction. The resulting zero indexed
+// source count is verified separately by
+// TestZeroConfig_LegacyResourcesLayoutIsNotDiscovered in
+// tests/integration/zero_config_test.go.
+func TestCreateMCPServer_MissingManifestOverLegacyLayoutSucceeds(t *testing.T) {
+	contentDir := t.TempDir()
+	resourcesDir := filepath.Join(contentDir, "mcp-resources")
+	require.NoError(t, os.MkdirAll(resourcesDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(resourcesDir, "guide.md"),
+		[]byte("---\nname: Guide\ndescription: A guide.\n---\ncontent"), 0o644))
+
+	server, cleanup, err := CreateMCPServer(context.Background(), appTestSettings(contentDir), "test")
+	require.NoError(t, err)
+	defer cleanup()
+	require.NotNil(t, server)
+}
+
+// TestCreateMCPServer_DefaultedMetadataCarriesInjectedVersion verifies the
+// build-injected version reaches the metadata used to build the server: with
+// no manifest, Server.Version has no other source than the version parameter.
+func TestCreateMCPServer_DefaultedMetadataCarriesInjectedVersion(t *testing.T) {
+	contentDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(contentDir, "README.md"), []byte("# Hello\n"), 0o644))
+
+	server, cleanup, err := CreateMCPServer(context.Background(), appTestSettings(contentDir), "9.9.9")
+	require.NoError(t, err)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	serverTransport, clientTransport := mcpsdk.NewInMemoryTransports()
+	_, err = server.Connect(ctx, serverTransport, nil)
+	require.NoError(t, err)
+
+	client := mcpsdk.NewClient(&mcpsdk.Implementation{Name: "test-client", Version: "1.0.0"}, nil)
+	session, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+	defer func() { _ = session.Close() }()
+
+	require.Equal(t, "9.9.9", session.InitializeResult().ServerInfo.Version)
 }
 
 func TestCreateMCPServer_InvalidMetadataYAML(t *testing.T) {
@@ -118,7 +268,7 @@ func TestCreateMCPServer_InvalidMetadataYAML(t *testing.T) {
 		},
 	}
 
-	_, _, err := CreateMCPServer(context.Background(), settings)
+	_, _, err := CreateMCPServer(context.Background(), settings, "test")
 	if err == nil {
 		t.Fatal("Expected error for invalid YAML")
 	}
@@ -149,7 +299,7 @@ server:
 		},
 	}
 
-	_, _, err := CreateMCPServer(context.Background(), settings)
+	_, _, err := CreateMCPServer(context.Background(), settings, "test")
 	if err == nil {
 		t.Fatal("Expected error for invalid metadata")
 	}
@@ -186,7 +336,7 @@ tools: []
 	}
 
 	// Invalid resources are skipped, not failed
-	server, cleanup, err := CreateMCPServer(context.Background(), settings)
+	server, cleanup, err := CreateMCPServer(context.Background(), settings, "test")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -217,7 +367,7 @@ func TestCreateMCPServer_ResourceWithKeywords(t *testing.T) {
 		Search:     config.SearchSettings{InMemory: true, MaxResults: 10},
 	}
 
-	server, cleanup, err := CreateMCPServer(context.Background(), settings)
+	server, cleanup, err := CreateMCPServer(context.Background(), settings, "test")
 	if err != nil {
 		t.Fatalf("Failed: %v", err)
 	}
@@ -253,7 +403,7 @@ tools: []
 	}
 
 	// Should succeed with no resources
-	server, cleanup, err := CreateMCPServer(context.Background(), settings)
+	server, cleanup, err := CreateMCPServer(context.Background(), settings, "test")
 	if err != nil {
 		t.Fatalf("Failed to create server with no resources: %v", err)
 	}
@@ -274,7 +424,7 @@ index:
   include: ["docs/**/*.md"]
 `)
 
-	_, cleanup, err := CreateMCPServer(context.Background(), appTestSettings(contentDir))
+	_, cleanup, err := CreateMCPServer(context.Background(), appTestSettings(contentDir), "test")
 
 	require.ErrorContains(t, err, "configured index matched no files")
 	require.Nil(t, cleanup)
@@ -288,14 +438,14 @@ func TestCreateMCPServer_IndexFailureStopsConstruction(t *testing.T) {
 `)
 	indexer := &fakeSearcher{indexErr: errors.New("index failed")}
 	deps := defaultFactoryDeps()
-	deps.discover = func(context.Context, *content.ContentProvider, *domain.IndexMetadata, string) (resources.DiscoveryResult, error) {
+	deps.discover = func(context.Context, *content.ContentProvider, *domain.IndexMetadata, string, ...resources.DiscoverOption) (resources.DiscoveryResult, error) {
 		return resources.DiscoveryResult{}, nil
 	}
 	deps.newSearch = func(config.SearchSettings) search.Searcher {
 		return indexer
 	}
 
-	server, cleanup, err := createMCPServer(context.Background(), appTestSettings(contentDir), deps)
+	server, cleanup, err := createMCPServer(context.Background(), appTestSettings(contentDir), "test", deps)
 
 	require.ErrorContains(t, err, "index chunks: index failed")
 	require.Nil(t, server)
@@ -312,7 +462,7 @@ func TestCreateMCPServer_PassesCallerContextToDiscovery(t *testing.T) {
 	ctx := context.WithValue(context.Background(), factoryContextKey{}, "request-context")
 	deps := defaultFactoryDeps()
 	var discoveryCtx context.Context
-	deps.discover = func(gotCtx context.Context, _ *content.ContentProvider, _ *domain.IndexMetadata, _ string) (resources.DiscoveryResult, error) {
+	deps.discover = func(gotCtx context.Context, _ *content.ContentProvider, _ *domain.IndexMetadata, _ string, _ ...resources.DiscoverOption) (resources.DiscoveryResult, error) {
 		discoveryCtx = gotCtx
 		return resources.DiscoveryResult{}, nil
 	}
@@ -320,7 +470,7 @@ func TestCreateMCPServer_PassesCallerContextToDiscovery(t *testing.T) {
 		return &fakeSearcher{drain: true}
 	}
 
-	server, cleanup, err := createMCPServer(ctx, appTestSettings(contentDir), deps)
+	server, cleanup, err := createMCPServer(ctx, appTestSettings(contentDir), "test", deps)
 
 	require.NoError(t, err)
 	require.NotNil(t, server)
@@ -341,7 +491,7 @@ index:
 	require.NoError(t, os.MkdirAll(filepath.Join(contentDir, "docs"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(contentDir, "docs", "data.txt"), []byte("not markdown"), 0o644))
 
-	_, _, err := CreateMCPServer(context.Background(), &config.Settings{ContentDir: contentDir, Scheme: "acdc", Search: config.SearchSettings{InMemory: true}})
+	_, _, err := CreateMCPServer(context.Background(), &config.Settings{ContentDir: contentDir, Scheme: "acdc", Search: config.SearchSettings{InMemory: true}}, "test")
 	require.ErrorContains(t, err, "failed to discover resources")
 	require.ErrorContains(t, err, "configured index selected non-Markdown file")
 }
@@ -359,7 +509,7 @@ index:
 	require.NoError(t, os.WriteFile(filepath.Join(contentDir, "docs", "guide.md"), []byte("# Guide"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(contentDir, "docs", "guide.markdown"), []byte("# Guide duplicate"), 0o644))
 
-	_, _, err := CreateMCPServer(context.Background(), &config.Settings{ContentDir: contentDir, Scheme: "acdc", Search: config.SearchSettings{InMemory: true}})
+	_, _, err := CreateMCPServer(context.Background(), &config.Settings{ContentDir: contentDir, Scheme: "acdc", Search: config.SearchSettings{InMemory: true}}, "test")
 	require.ErrorContains(t, err, "failed to create resource provider")
 	require.ErrorContains(t, err, "duplicate source URI: acdc://docs/guide")
 }
@@ -378,7 +528,7 @@ tools:
 	_ = os.WriteFile(filepath.Join(contentDir, "mcp-metadata.yaml"), []byte(metadataContent), 0644)
 
 	settings := &config.Settings{ContentDir: contentDir}
-	_, _, err := CreateMCPServer(context.Background(), settings)
+	_, _, err := CreateMCPServer(context.Background(), settings, "test")
 	if err == nil || !strings.Contains(err.Error(), "metadata validation failed") {
 		t.Errorf("Expected metadata validation error, got: %v", err)
 	}
@@ -398,7 +548,7 @@ tools:
 	_ = os.WriteFile(filepath.Join(contentDir, "mcp-metadata.yaml"), []byte(metadataContent), 0644)
 
 	settings := &config.Settings{ContentDir: contentDir}
-	_, _, err := CreateMCPServer(context.Background(), settings)
+	_, _, err := CreateMCPServer(context.Background(), settings, "test")
 	if err == nil || !strings.Contains(err.Error(), "metadata validation failed") {
 		t.Errorf("Expected metadata validation error, got: %v", err)
 	}
@@ -418,7 +568,7 @@ tools:
 	_ = os.WriteFile(filepath.Join(contentDir, "mcp-metadata.yaml"), []byte(metadataContent), 0644)
 
 	settings := &config.Settings{ContentDir: contentDir}
-	_, _, err := CreateMCPServer(context.Background(), settings)
+	_, _, err := CreateMCPServer(context.Background(), settings, "test")
 	if err == nil || !strings.Contains(err.Error(), "duplicate tool name") {
 		t.Errorf("Expected duplicate tool name error, got: %v", err)
 	}
@@ -445,7 +595,7 @@ func TestCreateMCPServer_PromptDiscoveryError(t *testing.T) {
 		Search:     config.SearchSettings{InMemory: true},
 	}
 
-	_, _, err := CreateMCPServer(context.Background(), settings)
+	_, _, err := CreateMCPServer(context.Background(), settings, "test")
 	if err == nil {
 		t.Fatal("Expected error for prompt discovery failure")
 	}
@@ -480,7 +630,7 @@ func TestCreateMCPServer_CrossRefTransformation(t *testing.T) {
 		Search:     config.SearchSettings{InMemory: true, MaxResults: 10},
 	}
 
-	server, cleanup, err := CreateMCPServer(context.Background(), settings)
+	server, cleanup, err := CreateMCPServer(context.Background(), settings, "test")
 	if err != nil {
 		t.Fatalf("Failed to create server: %v", err)
 	}

--- a/internal/app/metadata.go
+++ b/internal/app/metadata.go
@@ -1,0 +1,94 @@
+package app
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/sha1n/mcp-acdc-server/internal/content"
+	"github.com/sha1n/mcp-acdc-server/internal/domain"
+	"gopkg.in/yaml.v3"
+)
+
+// defaultVersion is substituted when the build-injected version is empty.
+const defaultVersion = "0.0.0"
+
+// defaultRepoBaseName is substituted when a content directory's base name cannot be derived.
+const defaultRepoBaseName = "Repository"
+
+// metadataFileName is the manifest file name resolved from a content root.
+const metadataFileName = "mcp-metadata.yaml"
+
+// resolvedMetadata carries the effective server metadata and how it was obtained.
+type resolvedMetadata struct {
+	metadata  domain.McpMetadata
+	defaulted bool
+}
+
+// resolveMetadata loads mcp-metadata.yaml from the content root, falling back to
+// built-in defaults when the manifest is absent. A manifest that exists but cannot
+// be read (permissions, is-a-directory, etc.) is treated as misconfiguration and
+// returned as an error rather than silently defaulted.
+//
+// The content directory itself is validated first: a missing mcp-metadata.yaml
+// under a nonexistent or non-directory --content-dir also satisfies
+// fs.ErrNotExist, which would otherwise be misread as "no manifest" and
+// silently defaulted, only to fail one step later during content root
+// resolution with no mention of the actual misconfiguration.
+func resolveMetadata(cp *content.ContentProvider, version string) (resolvedMetadata, error) {
+	if info, statErr := os.Stat(cp.ContentDir); statErr != nil || !info.IsDir() {
+		return resolvedMetadata{}, fmt.Errorf("failed to resolve content directory %s: not found or not a directory", cp.ContentDir)
+	}
+
+	metadataPath := cp.GetPath(metadataFileName)
+
+	mdBytes, err := os.ReadFile(metadataPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			metadata := domain.DefaultMetadata(repoBaseName(cp.ContentDir), resolveVersion(version))
+			slog.Info("mcp-metadata.yaml not found, using built-in defaults",
+				"server_name", metadata.Server.Name,
+				"index_include", metadata.Index.Include,
+			)
+			return resolvedMetadata{metadata: metadata, defaulted: true}, nil
+		}
+		return resolvedMetadata{}, fmt.Errorf("failed to read metadata file: %w", err)
+	}
+
+	var metadata domain.McpMetadata
+	if err := yaml.Unmarshal(mdBytes, &metadata); err != nil {
+		return resolvedMetadata{}, fmt.Errorf("failed to parse metadata: %w", err)
+	}
+
+	if err := metadata.Validate(); err != nil {
+		return resolvedMetadata{}, fmt.Errorf("metadata validation failed: %w", err)
+	}
+
+	return resolvedMetadata{metadata: metadata, defaulted: false}, nil
+}
+
+// repoBaseName derives a display-friendly repository name from the content directory,
+// falling back to a generic name when no meaningful base name can be derived.
+func repoBaseName(contentDir string) string {
+	abs, err := filepath.Abs(contentDir)
+	if err != nil {
+		abs = contentDir
+	}
+
+	base := filepath.Base(abs)
+	if base == "" || base == "." || base == ".." || base == string(filepath.Separator) {
+		return defaultRepoBaseName
+	}
+	return base
+}
+
+// resolveVersion returns the build-injected version, or a placeholder when it is empty.
+func resolveVersion(version string) string {
+	if version == "" {
+		return defaultVersion
+	}
+	return version
+}

--- a/internal/app/metadata_test.go
+++ b/internal/app/metadata_test.go
@@ -1,0 +1,170 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sha1n/mcp-acdc-server/internal/content"
+	"github.com/sha1n/mcp-acdc-server/internal/domain"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveMetadata_MissingManifestFallsBackToDefaults(t *testing.T) {
+	contentDir := filepath.Join(t.TempDir(), "my-repo")
+	require.NoError(t, os.MkdirAll(contentDir, 0o755))
+	cp := content.NewContentProvider(contentDir)
+
+	resolved, err := resolveMetadata(cp, "1.2.3")
+
+	require.NoError(t, err)
+	require.True(t, resolved.defaulted)
+	require.Equal(t, domain.DefaultMetadata("my-repo", "1.2.3"), resolved.metadata)
+}
+
+func TestResolveMetadata_ValidManifestReturnedVerbatim(t *testing.T) {
+	contentDir := t.TempDir()
+	manifest := `
+server:
+  name: test
+  version: "1.0"
+  instructions: inst
+tools:
+  - name: search
+    description: custom search
+`
+	require.NoError(t, os.WriteFile(filepath.Join(contentDir, "mcp-metadata.yaml"), []byte(manifest), 0o644))
+	cp := content.NewContentProvider(contentDir)
+
+	resolved, err := resolveMetadata(cp, "9.9.9")
+
+	require.NoError(t, err)
+	require.False(t, resolved.defaulted)
+	require.Equal(t, "test", resolved.metadata.Server.Name)
+	require.Equal(t, "1.0", resolved.metadata.Server.Version)
+	require.Equal(t, "inst", resolved.metadata.Server.Instructions)
+	require.Equal(t, []domain.ToolMetadata{{Name: "search", Description: "custom search"}}, resolved.metadata.Tools)
+}
+
+func TestResolveMetadata_MalformedYAMLReturnsError(t *testing.T) {
+	contentDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(contentDir, "mcp-metadata.yaml"), []byte("not: valid: yaml: {{"), 0o644))
+	cp := content.NewContentProvider(contentDir)
+
+	_, err := resolveMetadata(cp, "1.0.0")
+
+	require.ErrorContains(t, err, "failed to parse metadata")
+}
+
+func TestResolveMetadata_ValidationFailureReturnsError(t *testing.T) {
+	contentDir := t.TempDir()
+	manifest := `
+server:
+  name: ""
+  version: ""
+  instructions: ""
+`
+	require.NoError(t, os.WriteFile(filepath.Join(contentDir, "mcp-metadata.yaml"), []byte(manifest), 0o644))
+	cp := content.NewContentProvider(contentDir)
+
+	_, err := resolveMetadata(cp, "1.0.0")
+
+	require.ErrorContains(t, err, "metadata validation failed")
+}
+
+func TestResolveMetadata_UnreadableManifestReturnsError(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses permission bits")
+	}
+	contentDir := t.TempDir()
+	manifestPath := filepath.Join(contentDir, "mcp-metadata.yaml")
+	require.NoError(t, os.WriteFile(manifestPath, []byte("server: {name: test, version: '1', instructions: i}"), 0o644))
+	require.NoError(t, os.Chmod(manifestPath, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(manifestPath, 0o644) })
+	cp := content.NewContentProvider(contentDir)
+
+	_, err := resolveMetadata(cp, "1.0.0")
+
+	require.ErrorContains(t, err, "failed to read metadata file")
+}
+
+// TestResolveMetadata_ManifestIsDirectoryReturnsError exercises the
+// unreadable-manifest path with a failure mode that reproduces on every uid
+// and platform (EISDIR), unlike the permission-bit test above which is
+// skipped under root.
+func TestResolveMetadata_ManifestIsDirectoryReturnsError(t *testing.T) {
+	contentDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(contentDir, "mcp-metadata.yaml"), 0o755))
+	cp := content.NewContentProvider(contentDir)
+
+	_, err := resolveMetadata(cp, "1.0.0")
+
+	require.ErrorContains(t, err, "failed to read metadata file")
+}
+
+// TestResolveMetadata_NonexistentContentDirReturnsError pins the diagnostic
+// for a typo'd --content-dir: os.ReadFile("<typo>/mcp-metadata.yaml") also
+// satisfies fs.ErrNotExist, so without an explicit content-dir check the
+// server would log a misleading "using built-in defaults" for a directory
+// that was never resolved, then fail one step later on content root
+// resolution.
+func TestResolveMetadata_NonexistentContentDirReturnsError(t *testing.T) {
+	contentDir := filepath.Join(t.TempDir(), "does-not-exist")
+	cp := content.NewContentProvider(contentDir)
+
+	_, err := resolveMetadata(cp, "1.0.0")
+
+	require.ErrorContains(t, err, "content directory")
+	require.ErrorContains(t, err, contentDir)
+}
+
+func TestResolveMetadata_ContentDirIsFileReturnsError(t *testing.T) {
+	parent := t.TempDir()
+	contentDir := filepath.Join(parent, "not-a-directory")
+	require.NoError(t, os.WriteFile(contentDir, []byte("not a directory"), 0o644))
+	cp := content.NewContentProvider(contentDir)
+
+	_, err := resolveMetadata(cp, "1.0.0")
+
+	require.ErrorContains(t, err, "content directory")
+	require.ErrorContains(t, err, contentDir)
+}
+
+func TestRepoBaseName(t *testing.T) {
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		contentDir string
+		want       string
+	}{
+		{name: "nested path", contentDir: "/foo/bar/my-repo", want: "my-repo"},
+		{name: "trailing slash", contentDir: "/foo/bar/my-repo/", want: "my-repo"},
+		{name: "dot resolves to working directory name", contentDir: ".", want: filepath.Base(wd)},
+		{name: "root has no meaningful base name", contentDir: "/", want: "Repository"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, repoBaseName(tt.contentDir))
+		})
+	}
+}
+
+func TestResolveVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{name: "empty falls back to placeholder", version: "", want: "0.0.0"},
+		{name: "non-empty passes through", version: "1.2.3", want: "1.2.3"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, resolveVersion(tt.version))
+		})
+	}
+}

--- a/internal/app/runner.go
+++ b/internal/app/runner.go
@@ -16,7 +16,7 @@ type RunParams struct {
 	LoadSettings      func(*pflag.FlagSet) (*config.Settings, error)
 	ValidSettings     func(*config.Settings) error
 	StartSSEServer    func(*mcp.Server, *config.Settings) error
-	CreateServer      func(context.Context, *config.Settings) (*mcp.Server, func(), error)
+	CreateServer      func(context.Context, *config.Settings, string) (*mcp.Server, func(), error)
 	CustomIOTransport mcp.Transport // Optional: for testing with custom IO
 }
 
@@ -50,7 +50,7 @@ func RunWithDeps(ctx context.Context, params RunParams, flags *pflag.FlagSet, ve
 	slog.Info("Starting MCP Acdc server", "version", version)
 	config.Log(settings)
 
-	mcpServer, cleanup, err := params.CreateServer(ctx, settings)
+	mcpServer, cleanup, err := params.CreateServer(ctx, settings, version)
 	if err != nil {
 		return err
 	}

--- a/internal/app/runner_test.go
+++ b/internal/app/runner_test.go
@@ -53,7 +53,7 @@ func TestRunWithDeps_ErrorCases(t *testing.T) {
 					return &config.Settings{Transport: "sse"}, nil
 				},
 				ValidSettings: noopValidate,
-				CreateServer: func(context.Context, *config.Settings) (*mcp.Server, func(), error) {
+				CreateServer: func(context.Context, *config.Settings, string) (*mcp.Server, func(), error) {
 					return nil, nil, errors.New("create server error")
 				},
 			},
@@ -66,7 +66,7 @@ func TestRunWithDeps_ErrorCases(t *testing.T) {
 					return &config.Settings{Transport: "sse"}, nil
 				},
 				ValidSettings: noopValidate,
-				CreateServer: func(context.Context, *config.Settings) (*mcp.Server, func(), error) {
+				CreateServer: func(context.Context, *config.Settings, string) (*mcp.Server, func(), error) {
 					return nil, nil, nil
 				},
 				StartSSEServer: func(*mcp.Server, *config.Settings) error {
@@ -97,7 +97,7 @@ func TestRunWithDeps_Cleanup(t *testing.T) {
 			return &config.Settings{Transport: "sse"}, nil
 		},
 		ValidSettings: noopValidate,
-		CreateServer: func(context.Context, *config.Settings) (*mcp.Server, func(), error) {
+		CreateServer: func(context.Context, *config.Settings, string) (*mcp.Server, func(), error) {
 			return nil, func() { cleanupCalled = true }, nil
 		},
 		StartSSEServer: func(*mcp.Server, *config.Settings) error {
@@ -139,7 +139,7 @@ func TestRunWithDeps_StdioWithDefaultTransport(t *testing.T) {
 			return &config.Settings{Transport: "stdio"}, nil
 		},
 		ValidSettings: noopValidate,
-		CreateServer: func(context.Context, *config.Settings) (*mcp.Server, func(), error) {
+		CreateServer: func(context.Context, *config.Settings, string) (*mcp.Server, func(), error) {
 			// Create a minimal server
 			impl := &mcp.Implementation{Name: "test", Version: "1.0"}
 			server := mcp.NewServer(impl, nil)
@@ -176,7 +176,7 @@ func TestRunWithDeps_StdioWithCustomTransport(t *testing.T) {
 			return &config.Settings{Transport: "stdio"}, nil
 		},
 		ValidSettings: noopValidate,
-		CreateServer: func(context.Context, *config.Settings) (*mcp.Server, func(), error) {
+		CreateServer: func(context.Context, *config.Settings, string) (*mcp.Server, func(), error) {
 			impl := &mcp.Implementation{Name: "test", Version: "1.0"}
 			server := mcp.NewServer(impl, nil)
 			return server, nil, nil
@@ -204,7 +204,7 @@ func TestRunWithDeps_PassesExactCallerContextToCreateServer(t *testing.T) {
 			return &config.Settings{Transport: "sse"}, nil
 		},
 		ValidSettings: noopValidate,
-		CreateServer: func(gotCtx context.Context, _ *config.Settings) (*mcp.Server, func(), error) {
+		CreateServer: func(gotCtx context.Context, _ *config.Settings, _ string) (*mcp.Server, func(), error) {
 			createServerCtx = gotCtx
 			return nil, nil, nil
 		},
@@ -218,6 +218,30 @@ func TestRunWithDeps_PassesExactCallerContextToCreateServer(t *testing.T) {
 	}
 	if createServerCtx != ctx {
 		t.Fatal("CreateServer did not receive the exact caller context")
+	}
+}
+
+func TestRunWithDeps_PassesVersionToCreateServer(t *testing.T) {
+	var gotVersion string
+	params := RunParams{
+		LoadSettings: func(*pflag.FlagSet) (*config.Settings, error) {
+			return &config.Settings{Transport: "sse"}, nil
+		},
+		ValidSettings: noopValidate,
+		CreateServer: func(_ context.Context, _ *config.Settings, version string) (*mcp.Server, func(), error) {
+			gotVersion = version
+			return nil, nil, nil
+		},
+		StartSSEServer: func(*mcp.Server, *config.Settings) error { return nil },
+	}
+
+	err := RunWithDeps(context.Background(), params, nil, "9.9.9")
+
+	if err != nil {
+		t.Fatalf("RunWithDeps returned error: %v", err)
+	}
+	if gotVersion != "9.9.9" {
+		t.Fatalf("CreateServer did not receive the build-injected version, got %q", gotVersion)
 	}
 }
 

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -3,7 +3,6 @@ package config
 import (
 	"errors"
 	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -77,9 +76,8 @@ func LoadSettingsWithFlags(flags *pflag.FlagSet) (*Settings, error) {
 
 	// Default values
 	cwd, _ := os.Getwd()
-	defaultContentDir := filepath.Join(cwd, "content")
 
-	v.SetDefault("content_dir", defaultContentDir)
+	v.SetDefault("content_dir", cwd)
 	v.SetDefault("transport", "stdio")
 	v.SetDefault("host", "0.0.0.0")
 	v.SetDefault("port", 8080)

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -208,6 +208,49 @@ func TestLoadSettingsWithFlags_NilFlags(t *testing.T) {
 	}
 }
 
+// TestLoadSettings_ContentDirDefaultsToWorkingDirectory pins the zero-config
+// default: with no flag and no env var, content_dir is the process working
+// directory itself, not a "content" subdirectory beneath it.
+func TestLoadSettings_ContentDirDefaultsToWorkingDirectory(t *testing.T) {
+	// Note: Can't use t.Setenv to clear, so restore manually.
+	prevContentDir, hadContentDir := os.LookupEnv("ACDC_MCP_CONTENT_DIR")
+	_ = os.Unsetenv("ACDC_MCP_CONTENT_DIR")
+	t.Cleanup(func() {
+		if hadContentDir {
+			_ = os.Setenv("ACDC_MCP_CONTENT_DIR", prevContentDir)
+		}
+	})
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+
+	settings, err := LoadSettings()
+	require.NoError(t, err)
+	require.Equal(t, wd, settings.ContentDir)
+}
+
+// TestLoadSettingsWithFlags_ContentDirFlagOverridesDefault verifies an
+// explicit --content-dir flag still wins over the working-directory default.
+func TestLoadSettingsWithFlags_ContentDirFlagOverridesDefault(t *testing.T) {
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.String("content-dir", "", "")
+	require.NoError(t, flags.Set("content-dir", "/custom/path"))
+
+	settings, err := LoadSettingsWithFlags(flags)
+	require.NoError(t, err)
+	require.Equal(t, "/custom/path", settings.ContentDir)
+}
+
+// TestLoadSettings_ContentDirEnvVarOverridesDefault verifies
+// ACDC_MCP_CONTENT_DIR still wins over the working-directory default.
+func TestLoadSettings_ContentDirEnvVarOverridesDefault(t *testing.T) {
+	t.Setenv("ACDC_MCP_CONTENT_DIR", "/env/path")
+
+	settings, err := LoadSettings()
+	require.NoError(t, err)
+	require.Equal(t, "/env/path", settings.ContentDir)
+}
+
 // TestLoadSettingsWithFlags_AllFlagTypes verifies all flag types work
 func TestLoadSettingsWithFlags_AllFlagTypes(t *testing.T) {
 	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)

--- a/internal/domain/metadata.go
+++ b/internal/domain/metadata.go
@@ -50,6 +50,28 @@ HOW IT WORKS: Provide a base URI (e.g., 'acdc://guides/getting-started') to read
 	},
 }
 
+// DefaultIndexInclude selects the documentation layout assumed when no manifest is present.
+var DefaultIndexInclude = []string{"README.md", "docs/**/*.md"}
+
+// defaultInstructionsFormat is the server instructions used when no manifest is present.
+// %s is substituted with the raw repository name.
+const defaultInstructionsFormat = `Documentation for the %s repository: guides, references, design documents, specs and plans kept under docs/, plus the top-level README.
+
+Search here before answering questions about this repository's conventions, architecture, decisions, or planned work. Prefer these documents over assumptions drawn from source code alone.`
+
+// DefaultMetadata builds the metadata used when the content root has no mcp-metadata.yaml.
+// repoName identifies the indexed repository in the server's display name and instructions.
+func DefaultMetadata(repoName, version string) McpMetadata {
+	return McpMetadata{
+		Server: ServerMetadata{
+			Name:         repoName + " Documentation",
+			Version:      version,
+			Instructions: fmt.Sprintf(defaultInstructionsFormat, repoName),
+		},
+		Index: &IndexMetadata{Include: append([]string(nil), DefaultIndexInclude...)},
+	}
+}
+
 // GetToolMetadata returns metadata for the specified tool name, using overrides if provided
 // in the config, otherwise falling back to defaults.
 func (m *McpMetadata) GetToolMetadata(name string) ToolMetadata {

--- a/internal/domain/metadata_test.go
+++ b/internal/domain/metadata_test.go
@@ -193,6 +193,46 @@ func TestDefaultToolMetadata_SearchDescriptionMentionsChunkResults(t *testing.T)
 	require.Contains(t, strings.ToLower(desc), "chunk", "search results are chunk citations - the default description should describe them as such")
 }
 
+func TestDefaultMetadata_PassesValidate(t *testing.T) {
+	meta := DefaultMetadata("my-repo", "1.2.3")
+
+	require.NoError(t, meta.Validate())
+}
+
+func TestDefaultMetadata_IndexIncludeOrder(t *testing.T) {
+	meta := DefaultMetadata("my-repo", "1.2.3")
+
+	require.NotNil(t, meta.Index)
+	require.Equal(t, []string{"README.md", "docs/**/*.md"}, meta.Index.Include)
+}
+
+func TestDefaultMetadata_ToolsFallBackToDefaults(t *testing.T) {
+	meta := DefaultMetadata("my-repo", "1.2.3")
+
+	require.Empty(t, meta.Tools)
+	require.Equal(t, DefaultToolMetadata["search"].Description, meta.GetToolMetadata("search").Description)
+	require.Equal(t, DefaultToolMetadata["read"].Description, meta.GetToolMetadata("read").Description)
+}
+
+func TestDefaultMetadata_NameAndInstructionsContainRepoName(t *testing.T) {
+	meta := DefaultMetadata("my-repo", "1.2.3")
+
+	require.Equal(t, "my-repo Documentation", meta.Server.Name)
+	require.Contains(t, meta.Server.Instructions, "my-repo")
+}
+
+func TestDefaultMetadata_MutatingIndexIncludeDoesNotAffectPackageDefaultOrSecondCall(t *testing.T) {
+	originalDefault := append([]string(nil), DefaultIndexInclude...)
+
+	first := DefaultMetadata("my-repo", "1.2.3")
+	first.Index.Include[0] = "MUTATED.md"
+
+	require.Equal(t, originalDefault, DefaultIndexInclude, "mutating the returned Index.Include must not corrupt the package default")
+
+	second := DefaultMetadata("my-repo", "1.2.3")
+	require.Equal(t, []string{"README.md", "docs/**/*.md"}, second.Index.Include, "mutating a previous result must not affect a later call")
+}
+
 func TestToolsMap(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		meta := McpMetadata{

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -30,8 +30,7 @@ func CreateServer(
 	s := mcp.NewServer(&mcp.Implementation{
 		Name:    metadata.Server.Name,
 		Version: metadata.Server.Version,
-	}, nil)
-	// Note: Instructions are stored in metadata but not directly supported by official SDK
+	}, &mcp.ServerOptions{Instructions: metadata.Server.Instructions})
 
 	// Register Resources
 	for _, res := range resourceProvider.ListResources() {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -3,12 +3,15 @@ package mcp
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/sha1n/mcp-acdc-server/internal/config"
 	"github.com/sha1n/mcp-acdc-server/internal/domain"
 	"github.com/sha1n/mcp-acdc-server/internal/prompts"
 	"github.com/sha1n/mcp-acdc-server/internal/resources"
 	"github.com/sha1n/mcp-acdc-server/internal/search"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateServer(t *testing.T) {
@@ -37,6 +40,84 @@ func TestCreateServer(t *testing.T) {
 	if server == nil {
 		t.Fatal("Server should not be nil")
 	}
+}
+
+// TestCreateServer_InstructionsReachClient verifies that server.instructions
+// from the metadata is actually delivered to a connected client during MCP
+// initialization, not just stored on the Go struct.
+func TestCreateServer_InstructionsReachClient(t *testing.T) {
+	const wantInstructions = "Search the docs before answering questions about this repository."
+
+	metadata := domain.McpMetadata{
+		Server: domain.ServerMetadata{
+			Name:         "test-server",
+			Version:      "1.0.0",
+			Instructions: wantInstructions,
+		},
+		Tools: []domain.ToolMetadata{
+			{Name: "search", Description: "Search tool"},
+			{Name: "read", Description: "Read tool"},
+		},
+	}
+
+	resourceProvider, err := resources.NewResourceProvider([]resources.ResourceDefinition{}, nil)
+	require.NoError(t, err)
+	promptProvider := prompts.NewPromptProvider([]prompts.PromptDefinition{}, nil)
+
+	server := CreateServer(metadata, resourceProvider, promptProvider, &mockSearcher{}, config.SearchSettings{MaxResults: 10, ResultMode: config.SearchResultModeReferences})
+	require.NotNil(t, server)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	_, err = server.Connect(ctx, serverTransport, nil)
+	require.NoError(t, err)
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "1.0.0"}, nil)
+	session, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+	defer func() { _ = session.Close() }()
+
+	require.Equal(t, wantInstructions, session.InitializeResult().Instructions)
+}
+
+// TestCreateServer_EmptyInstructionsDoesNotBreakCreation ensures an empty
+// instructions string (bypassing domain.Validate, which normally requires
+// it) does not prevent server creation or client initialization.
+func TestCreateServer_EmptyInstructionsDoesNotBreakCreation(t *testing.T) {
+	metadata := domain.McpMetadata{
+		Server: domain.ServerMetadata{
+			Name:         "test-server",
+			Version:      "1.0.0",
+			Instructions: "",
+		},
+		Tools: []domain.ToolMetadata{
+			{Name: "search", Description: "Search tool"},
+			{Name: "read", Description: "Read tool"},
+		},
+	}
+
+	resourceProvider, err := resources.NewResourceProvider([]resources.ResourceDefinition{}, nil)
+	require.NoError(t, err)
+	promptProvider := prompts.NewPromptProvider([]prompts.PromptDefinition{}, nil)
+
+	server := CreateServer(metadata, resourceProvider, promptProvider, &mockSearcher{}, config.SearchSettings{MaxResults: 10, ResultMode: config.SearchResultModeReferences})
+	require.NotNil(t, server)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	_, err = server.Connect(ctx, serverTransport, nil)
+	require.NoError(t, err)
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "1.0.0"}, nil)
+	session, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+	defer func() { _ = session.Close() }()
+
+	require.Empty(t, session.InitializeResult().Instructions)
 }
 
 type mockSearcher struct{}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -18,7 +18,7 @@ type SearchToolArgument struct {
 
 // ReadToolArgument represents arguments for read tool
 type ReadToolArgument struct {
-	URI string `json:"uri" jsonschema_description:"The acdc:// URI of the resource to fetch"`
+	URI string `json:"uri" jsonschema_description:"The resource URI, exactly as returned by search or a resource listing (e.g. acdc://guides/setup#install)"`
 }
 
 // RegisterSearchTool registers the search tool with the server

--- a/internal/resources/discovery.go
+++ b/internal/resources/discovery.go
@@ -40,16 +40,70 @@ func defaultDiscoveryOps() discoveryOps {
 	}
 }
 
-// Discover loads configured Markdown sources, or legacy mcp-resources when
-// index is nil.
-func Discover(ctx context.Context, cp *content.ContentProvider, index *domain.IndexMetadata, scheme string) (DiscoveryResult, error) {
-	return discoverWithOps(ctx, cp, index, scheme, defaultDiscoveryOps())
+// discoverPolicy controls how the configured-index path tolerates repository
+// content. It never affects validation of the invocation itself (patterns,
+// content root, selected file containment or type), only how missing or
+// unreadable/unparsable repository files are handled.
+type discoverPolicy struct {
+	lenient bool
 }
 
-func discoverWithOps(ctx context.Context, cp *content.ContentProvider, index *domain.IndexMetadata, scheme string, ops discoveryOps) (DiscoveryResult, error) {
+// DiscoverOption configures discovery behavior.
+type DiscoverOption func(*discoverPolicy)
+
+// WithLenientIndex tolerates an empty selection and skips files that cannot be read
+// or parsed, instead of failing startup. Used when the index configuration is
+// defaulted rather than declared by an operator. It has no effect in legacy
+// mcp-resources mode (index == nil), which resolves before any policy is applied.
+func WithLenientIndex() DiscoverOption {
+	return func(p *discoverPolicy) { p.lenient = true }
+}
+
+func resolvePolicy(opts []DiscoverOption) discoverPolicy {
+	var policy discoverPolicy
+	for _, opt := range opts {
+		opt(&policy)
+	}
+	return policy
+}
+
+// directories that never hold indexable documentation.
+var alwaysPrunedDirs = map[string]bool{
+	".git": true,
+}
+
+// build/dependency artifact directories pruned only under the lenient
+// policy, so an explicit manifest keeps selecting exactly what it selects
+// today.
+var lenientPrunedDirs = map[string]bool{
+	"node_modules": true,
+	"vendor":       true,
+	"dist":         true,
+	"build":        true,
+	"target":       true,
+	".venv":        true,
+}
+
+func shouldPruneDir(name string, lenient bool) bool {
+	if alwaysPrunedDirs[name] {
+		return true
+	}
+	return lenient && lenientPrunedDirs[name]
+}
+
+// Discover loads configured Markdown sources, or legacy mcp-resources when
+// index is nil. By default it applies today's strict behavior: an empty
+// selection or an unreadable/unparsable configured file fails discovery.
+// Pass WithLenientIndex to tolerate repository content issues instead.
+func Discover(ctx context.Context, cp *content.ContentProvider, index *domain.IndexMetadata, scheme string, opts ...DiscoverOption) (DiscoveryResult, error) {
+	return discoverWithOps(ctx, cp, index, scheme, defaultDiscoveryOps(), opts...)
+}
+
+func discoverWithOps(ctx context.Context, cp *content.ContentProvider, index *domain.IndexMetadata, scheme string, ops discoveryOps, opts ...DiscoverOption) (DiscoveryResult, error) {
 	if index == nil {
 		return discoverLegacy(ctx, cp, scheme, ops)
 	}
+	policy := resolvePolicy(opts)
 
 	patterns, err := validatePatterns(index.Include)
 	if err != nil {
@@ -73,7 +127,13 @@ func discoverWithOps(ctx context.Context, cp *content.ContentProvider, index *do
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if entry.Type()&fs.ModeSymlink != 0 || entry.IsDir() {
+		if entry.IsDir() {
+			if filePath != root && shouldPruneDir(entry.Name(), policy.lenient) {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if entry.Type()&fs.ModeSymlink != 0 {
 			return nil
 		}
 
@@ -108,11 +168,15 @@ func discoverWithOps(ctx context.Context, cp *content.ContentProvider, index *do
 		return DiscoveryResult{}, err
 	}
 	if len(selected) == 0 {
+		if policy.lenient {
+			slog.Warn("Configured index matched no files", "root", root)
+			return DiscoveryResult{}, nil
+		}
 		return DiscoveryResult{}, fmt.Errorf("configured index matched no files")
 	}
 
 	sort.Strings(selected)
-	return buildCatalog(ctx, root, selected, scheme, ops)
+	return buildCatalog(ctx, root, selected, scheme, ops, policy)
 }
 
 // DiscoverResources returns legacy mcp-resources definitions for callers that
@@ -197,7 +261,7 @@ func discoverLegacy(ctx context.Context, cp *content.ContentProvider, scheme str
 	return result, nil
 }
 
-func buildCatalog(ctx context.Context, root string, files []string, scheme string, ops discoveryOps) (DiscoveryResult, error) {
+func buildCatalog(ctx context.Context, root string, files []string, scheme string, ops discoveryOps, policy discoverPolicy) (DiscoveryResult, error) {
 	result := DiscoveryResult{}
 	for _, filePath := range files {
 		if err := ctx.Err(); err != nil {
@@ -208,10 +272,18 @@ func buildCatalog(ctx context.Context, root string, files []string, scheme strin
 		}
 		raw, err := ops.readFile(filePath)
 		if err != nil {
+			if policy.lenient {
+				slog.Warn("Skipping unreadable configured file", "file", filepath.Base(filePath), "error", err)
+				continue
+			}
 			return DiscoveryResult{}, fmt.Errorf("read configured file %s: %w", filePath, err)
 		}
 		parsed, err := content.ParseMarkdown(raw, content.FrontmatterOptional)
 		if err != nil {
+			if policy.lenient {
+				slog.Warn("Skipping invalid configured file", "file", filepath.Base(filePath), "error", err)
+				continue
+			}
 			return DiscoveryResult{}, fmt.Errorf("parse configured file %s: %w", filePath, err)
 		}
 		relativePath, err := ops.relativePath(root, filePath)

--- a/internal/resources/discovery_ops_test.go
+++ b/internal/resources/discovery_ops_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io/fs"
+	"strings"
 	"testing"
 	"time"
 
@@ -175,6 +176,45 @@ func TestDiscoverWithOps_ConfiguredCancellationBeforeCatalogRead(t *testing.T) {
 
 	_, err := discoverWithOps(ctx, content.NewContentProvider(root), &domain.IndexMetadata{Include: []string{"docs/*.md"}}, "acdc", ops)
 	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestDiscoverWithOps_ConfiguredReadFailureLeniency(t *testing.T) {
+	root := "/catalog"
+	readableFile := root + "/docs/good.md"
+	unreadableFile := root + "/docs/bad.md"
+	readErr := errors.New("cannot read selected file")
+
+	buildOps := func() discoveryOps {
+		ops := successfulDiscoveryOps(root)
+		ops.walkDir = func(_ string, walk fs.WalkDirFunc) error {
+			if err := walk(unreadableFile, regularEntry("bad.md"), nil); err != nil {
+				return err
+			}
+			return walk(readableFile, regularEntry("good.md"), nil)
+		}
+		ops.relativePath = func(_, path string) (string, error) {
+			return strings.TrimPrefix(path, root+"/"), nil
+		}
+		ops.readFile = func(path string) ([]byte, error) {
+			if path == unreadableFile {
+				return nil, readErr
+			}
+			return []byte("# Good\n\nBody.\n"), nil
+		}
+		return ops
+	}
+	index := &domain.IndexMetadata{Include: []string{"docs/*.md"}}
+
+	t.Run("lenient skips the unreadable file and indexes its readable sibling", func(t *testing.T) {
+		result, err := discoverWithOps(context.Background(), content.NewContentProvider(root), index, "acdc", buildOps(), WithLenientIndex())
+		require.NoError(t, err)
+		require.Equal(t, []string{"acdc://docs/good"}, sourceURIs(result.Sources))
+	})
+
+	t.Run("strict fails discovery on the unreadable file", func(t *testing.T) {
+		_, err := discoverWithOps(context.Background(), content.NewContentProvider(root), index, "acdc", buildOps())
+		require.ErrorIs(t, err, readErr)
+	})
 }
 
 func TestDiscoverWithOps_LegacySkipsUnreadableAndNonregularEntries(t *testing.T) {

--- a/internal/resources/discovery_test.go
+++ b/internal/resources/discovery_test.go
@@ -147,6 +147,21 @@ func TestDiscover_LegacyMissingDirectoryAndCancellation(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
+func TestDiscover_LegacyIgnoresLenientOption(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "mcp-resources/valid.md", "---\nname: Valid\ndescription: Valid description\n---\n# Valid\n\nBody.\n")
+	writeFile(t, root, "mcp-resources/no-frontmatter.md", "# No Frontmatter\n\nBody.\n")
+
+	strict, err := Discover(context.Background(), content.NewContentProvider(root), nil, "acdc")
+	require.NoError(t, err)
+	require.Equal(t, []string{"acdc://valid"}, sourceURIs(strict.Sources))
+
+	lenient, err := Discover(context.Background(), content.NewContentProvider(root), nil, "acdc", WithLenientIndex())
+	require.NoError(t, err)
+
+	require.Equal(t, strict, lenient)
+}
+
 func TestDiscoverResources_FailsForUnresolvableLegacyRoot(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("creating symlinks requires additional permissions on Windows")
@@ -157,6 +172,106 @@ func TestDiscoverResources_FailsForUnresolvableLegacyRoot(t *testing.T) {
 
 	_, err := DiscoverResources(content.NewContentProvider(root), "acdc")
 	require.ErrorContains(t, err, "resolve resources root")
+}
+
+func TestDiscover_LenientZeroMatchesReturnsEmptyResult(t *testing.T) {
+	root := t.TempDir()
+
+	result, err := Discover(context.Background(), content.NewContentProvider(root), &domain.IndexMetadata{
+		Include: []string{"docs/**/*.md"},
+	}, "acdc", WithLenientIndex())
+	require.NoError(t, err)
+	require.Empty(t, result.Sources)
+	require.Empty(t, result.Chunks)
+}
+
+func TestDiscover_LenientSkipsUnparsableFilesButIndexesSiblings(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "docs/good.md", "# Good\n\nBody.\n")
+	writeFile(t, root, "docs/bad.md", "---\nname: [\n---\n# Bad\n")
+
+	result, err := Discover(context.Background(), content.NewContentProvider(root), &domain.IndexMetadata{
+		Include: []string{"docs/*.md"},
+	}, "acdc", WithLenientIndex())
+	require.NoError(t, err)
+	require.Equal(t, []string{"acdc://docs/good"}, sourceURIs(result.Sources))
+
+	_, err = Discover(context.Background(), content.NewContentProvider(root), &domain.IndexMetadata{
+		Include: []string{"docs/*.md"},
+	}, "acdc")
+	require.ErrorContains(t, err, "invalid YAML in frontmatter")
+}
+
+func TestDiscover_LenientStillRejectsRootEscapingPatterns(t *testing.T) {
+	root := t.TempDir()
+
+	_, err := Discover(context.Background(), content.NewContentProvider(root), &domain.IndexMetadata{
+		Include: []string{"../docs/*.md"},
+	}, "acdc", WithLenientIndex())
+	require.ErrorContains(t, err, "index pattern escapes content root")
+}
+
+func TestDiscover_PrunesGitDirectoryUnderBothPolicies(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, ".git/x.md", "# Git\n")
+	writeFile(t, root, "docs/guide.md", "# Guide\n")
+
+	for _, opts := range [][]DiscoverOption{nil, {WithLenientIndex()}} {
+		result, err := Discover(context.Background(), content.NewContentProvider(root), &domain.IndexMetadata{
+			Include: []string{"**/*.md"},
+		}, "acdc", opts...)
+		require.NoError(t, err)
+		require.Equal(t, []string{"acdc://docs/guide"}, sourceURIs(result.Sources))
+	}
+}
+
+func TestDiscover_PrunesBuildArtifactDirectoriesOnlyWhenLenient(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "node_modules/x.md", "# Vendored\n")
+	writeFile(t, root, "docs/guide.md", "# Guide\n")
+
+	strict, err := Discover(context.Background(), content.NewContentProvider(root), &domain.IndexMetadata{
+		Include: []string{"**/*.md"},
+	}, "acdc")
+	require.NoError(t, err)
+	require.Equal(t, []string{"acdc://docs/guide", "acdc://node_modules/x"}, sourceURIs(strict.Sources))
+
+	lenient, err := Discover(context.Background(), content.NewContentProvider(root), &domain.IndexMetadata{
+		Include: []string{"**/*.md"},
+	}, "acdc", WithLenientIndex())
+	require.NoError(t, err)
+	require.Equal(t, []string{"acdc://docs/guide"}, sourceURIs(lenient.Sources))
+}
+
+func TestDiscover_PrunesNestedBuildArtifactDirectoriesOnlyWhenLenient(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "docs/build/generated.md", "# Generated\n")
+	writeFile(t, root, "docs/guide.md", "# Guide\n")
+
+	strict, err := Discover(context.Background(), content.NewContentProvider(root), &domain.IndexMetadata{
+		Include: []string{"**/*.md"},
+	}, "acdc")
+	require.NoError(t, err)
+	require.Equal(t, []string{"acdc://docs/build/generated", "acdc://docs/guide"}, sourceURIs(strict.Sources))
+
+	lenient, err := Discover(context.Background(), content.NewContentProvider(root), &domain.IndexMetadata{
+		Include: []string{"**/*.md"},
+	}, "acdc", WithLenientIndex())
+	require.NoError(t, err)
+	require.Equal(t, []string{"acdc://docs/guide"}, sourceURIs(lenient.Sources))
+}
+
+func TestDiscover_DoesNotPruneContentRootItself(t *testing.T) {
+	root := t.TempDir()
+	buildRoot := filepath.Join(root, "build")
+	require.NoError(t, os.MkdirAll(filepath.Join(buildRoot, "docs"), 0o755))
+	writeFile(t, buildRoot, "docs/guide.md", "# Guide\n")
+
+	result, err := Discover(context.Background(), content.NewContentProvider(buildRoot), &domain.IndexMetadata{
+		Include: []string{"docs/**/*.md"},
+	}, "acdc", WithLenientIndex())
+	require.NoError(t, err)
+	require.Equal(t, []string{"acdc://docs/guide"}, sourceURIs(result.Sources))
 }
 
 func writeFile(t *testing.T, root, name, body string) string {

--- a/tests/integration/testkit/client.go
+++ b/tests/integration/testkit/client.go
@@ -31,6 +31,23 @@ func NewStdioTestClient(t testing.TB, contentOpts *ContentDirOptions) *TestClien
 		resultMode = contentOpts.ResultMode
 		crossRef = contentOpts.CrossRef
 	}
+	return newStdioTestClientForDir(t, contentDir, resultMode, crossRef)
+}
+
+// NewStdioTestClientForDir connects a test client to an ACDC server rooted at an
+// already-prepared content directory, via stdio transport. Unlike NewStdioTestClient,
+// it does not call CreateTestContentDir, so the caller controls the directory's base
+// name and whether mcp-metadata.yaml is present. Used by zero-config tests, where the
+// content root's base name drives the derived server name and no manifest must exist.
+func NewStdioTestClientForDir(t testing.TB, contentDir string) *TestClient {
+	t.Helper()
+
+	return newStdioTestClientForDir(t, contentDir, "", false)
+}
+
+func newStdioTestClientForDir(t testing.TB, contentDir, resultMode string, crossRef bool) *TestClient {
+	t.Helper()
+
 	flags := NewTestFlags(t, contentDir, &FlagOptions{
 		Transport:  "stdio",
 		ResultMode: resultMode,

--- a/tests/integration/zero_config_test.go
+++ b/tests/integration/zero_config_test.go
@@ -1,0 +1,141 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sha1n/mcp-acdc-server/tests/integration/testkit"
+	"github.com/stretchr/testify/require"
+)
+
+// defaultInstructionsFormat mirrors internal/domain/metadata.go's unexported
+// defaultInstructionsFormat verbatim. It is duplicated here, rather than derived
+// from the production default, so this test independently pins the exact wording a
+// zero-config client receives instead of merely echoing whatever the production
+// constant currently says.
+const defaultInstructionsFormat = `Documentation for the %s repository: guides, references, design documents, specs and plans kept under docs/, plus the top-level README.
+
+Search here before answering questions about this repository's conventions, architecture, decisions, or planned work. Prefer these documents over assumptions drawn from source code alone.`
+
+// TestZeroConfig_RepoWithDocs drives a real server, over the in-process stdio
+// transport, rooted at a temp directory with no mcp-metadata.yaml but with the
+// default zero-config layout (README.md plus docs/**/*.md). It proves the seam
+// from defaults through discovery, chunking, indexing, and the MCP surface: the
+// derived server identity, chunk-scoped search, bare and fragment reads, and the
+// resource listing.
+func TestZeroConfig_RepoWithDocs(t *testing.T) {
+	contentDir := t.TempDir()
+	writeFile(t, contentDir, "README.md", "# Acme Sample Repo\n\n"+
+		"## Overview\n\nThis repository hosts the Acme sample project used for documentation testing.\n\n"+
+		"## Getting Started\n\nClone the repository and run make install to get started.\n")
+	writeFile(t, contentDir, "docs/a.md", "# Guide A\n\n"+
+		"## Setup\n\nInstall dependencies before running Guide A procedures.\n\n"+
+		"## Usage\n\nRun the guide A workflow after setup completes.\n")
+	writeFile(t, contentDir, "docs/nested/b.md", "# Nested Guide B\n\n"+
+		"## Configuration\n\nThe zephyrwing setting controls nested-guide caching behavior.\n\n"+
+		"## Troubleshooting\n\nRestart the service if nested guide B does not start.\n")
+	// These three files must NOT be indexed, each for a different reason, so
+	// resources/list below proves the default patterns and lenient prune list
+	// haven't silently widened.
+	writeFile(t, contentDir, "CONTRIBUTING.md", "# Contributing\n\n"+
+		"## Pull Requests\n\nOpen a pull request against main and describe your change.\n")
+	writeFile(t, contentDir, "src/notes.md", "# Developer Notes\n\n"+
+		"## Scratch\n\nInternal notes that live alongside source, not documentation.\n")
+	writeFile(t, contentDir, "docs/build/generated.md", "# Generated Output\n\n"+
+		"## Build Artifacts\n\nContent written by a build step, not authored documentation.\n")
+
+	client := testkit.NewStdioTestClientForDir(t, contentDir)
+	defer client.Close()
+	ctx := context.Background()
+
+	repoBaseName := filepath.Base(contentDir)
+
+	// The server starts and derives its identity from the content root's base name,
+	// per the built-in zero-config defaults.
+	initResult := client.InitializeResult()
+	require.NotNil(t, initResult)
+	require.Equal(t, repoBaseName+" Documentation", initResult.ServerInfo.Name)
+	require.Equal(t, fmt.Sprintf(defaultInstructionsFormat, repoBaseName), initResult.Instructions)
+
+	// A term unique to docs/nested/b.md returns a chunk URI from that file.
+	searchText := callTextTool(t, ctx, client, "search", map[string]any{"query": "zephyrwing"})
+	require.Contains(t, searchText, "docs/nested/b.md")
+
+	chunkURI := extractFirstMarkdownURI(t, searchText)
+	require.Contains(t, chunkURI, "docs/nested/b#")
+
+	// The fragment URI from search resolves to the matched section's content.
+	chunkText := callTextTool(t, ctx, client, "read", map[string]any{"uri": chunkURI})
+	require.Contains(t, chunkText, "zephyrwing setting controls nested-guide caching behavior")
+
+	// The bare document URI resolves to the whole document, including sections the
+	// chunk read above did not return.
+	docText := callTextTool(t, ctx, client, "read", map[string]any{"uri": "acdc://docs/nested/b"})
+	require.Contains(t, docText, "# Nested Guide B")
+	require.Contains(t, docText, "## Troubleshooting")
+
+	// resources/list surfaces exactly the three default-included documents. The
+	// exact-set match also proves CONTRIBUTING.md, src/notes.md, and
+	// docs/build/generated.md are excluded: a widened include pattern or a
+	// missing prune entry would add one of them to this set and fail the match.
+	resourcesResult, err := client.ListResources(ctx)
+	require.NoError(t, err)
+	uris := make([]string, 0, len(resourcesResult.Resources))
+	for _, r := range resourcesResult.Resources {
+		uris = append(uris, r.URI)
+	}
+	require.ElementsMatch(t, []string{"acdc://README", "acdc://docs/a", "acdc://docs/nested/b"}, uris)
+}
+
+// TestZeroConfig_RepoWithNoDocs verifies that a repository with no manifest and no
+// README.md or docs/ still starts successfully, and that searching it returns the
+// ordinary no-results message rather than an error.
+func TestZeroConfig_RepoWithNoDocs(t *testing.T) {
+	contentDir := t.TempDir()
+
+	client := testkit.NewStdioTestClientForDir(t, contentDir)
+	defer client.Close()
+	ctx := context.Background()
+
+	require.NotNil(t, client.InitializeResult())
+
+	searchText := callTextTool(t, ctx, client, "search", map[string]any{"query": "anything"})
+	require.Equal(t, "No results found for 'anything'", searchText)
+}
+
+// TestZeroConfig_LegacyResourcesLayoutIsNotDiscovered verifies that a content
+// root laid out for legacy discovery (mcp-resources/**.md) but missing
+// mcp-metadata.yaml does not fall back to legacy discovery. Zero-config
+// defaults always set a non-nil Index, which routes discovery to the
+// configured-index path (README.md and docs/**) instead of scanning
+// mcp-resources. The fixture file carries valid frontmatter, so it would have
+// been discovered under legacy mode - proving the file is discoverable in
+// principle, and still isn't found.
+func TestZeroConfig_LegacyResourcesLayoutIsNotDiscovered(t *testing.T) {
+	contentDir := t.TempDir()
+	writeFile(t, contentDir, "mcp-resources/guide.md", "---\nname: Guide\ndescription: A guide.\n---\n"+
+		"# Guide\n\nContent for the guide.\n")
+
+	client := testkit.NewStdioTestClientForDir(t, contentDir)
+	defer client.Close()
+	ctx := context.Background()
+
+	require.NotNil(t, client.InitializeResult())
+
+	resourcesResult, err := client.ListResources(ctx)
+	require.NoError(t, err)
+	require.Empty(t, resourcesResult.Resources)
+
+	searchText := callTextTool(t, ctx, client, "search", map[string]any{"query": "guide"})
+	require.Equal(t, "No results found for 'guide'", searchText)
+}
+
+func writeFile(t *testing.T, root, relativePath, content string) {
+	t.Helper()
+	fullPath := filepath.Join(root, filepath.FromSlash(relativePath))
+	require.NoError(t, os.MkdirAll(filepath.Dir(fullPath), 0o755))
+	require.NoError(t, os.WriteFile(fullPath, []byte(content), 0o644))
+}


### PR DESCRIPTION
## Summary

`acdc-mcp` previously refused to start unless the content directory held an `mcp-metadata.yaml` declaring `server.name`, `server.version`, and `server.instructions` — making per-repository setup a manual step. A *missing* manifest now falls back to built-in defaults, so the server can be registered once at user scope and index whichever repository the client launches it in:

```bash
claude mcp add --scope user --transport stdio acdc -- acdc-mcp
```

Defaults index `README.md` + `docs/**/*.md`, deriving the server name from the content directory's base name and the version from the build stamp. Tool descriptions already had good built-in defaults; this reuses them.

## Changes

- **Missing manifest → defaults.** Only `fs.ErrNotExist` triggers the fallback. A manifest that exists but is malformed, invalid, or unreadable is still a fatal startup error — the branch's core safety property, covered by both a permissions test and a uid-independent `EISDIR` test.

- **BREAKING: `--content-dir` now defaults to the working directory**, not `<cwd>/content` (`305728e`, `!` + `BREAKING CHANGE:` footer). Invocations relying on the implicit `./content` will index the working directory instead. Docker is unaffected — `Dockerfile` and both compose examples set `ACDC_MCP_CONTENT_DIR` explicitly.

- **Behavior change: `server.instructions` now reaches clients.** It was required by `Validate()` and then silently dropped — `CreateServer` passed `nil` server options, and the comment claiming the SDK didn't support it was stale. Existing manifest users will start seeing instructions text they already authored.

- **Strict vs lenient discovery.** With defaults, zero matched files and per-file read/parse failures are warnings — a doc-less repository must still yield a working server, not a crashed one. With an explicit manifest they stay fatal: the operator declared intent. Configuration errors (bad or root-escaping globs, unresolvable root, non-Markdown selections) stay fatal in both. Strict is the zero value of `discoverPolicy`, so every pre-existing call site keeps today's behavior by construction.

- **Directory pruning.** `.git` in both modes; `node_modules`, `vendor`, `dist`, `build`, `target`, `.venv` only under the lenient/default policy, so an explicit manifest still selects exactly what it selects today. The content root itself is never pruned.

- **Fail fast on a bad `--content-dir`.** A typo previously logged "using built-in defaults" for a directory that doesn't exist, then failed one step later with a confusing `resolve content root` error.

## Review notes

- Scope is unchanged: URI scheme stays `acdc://` in both modes, and there are no tool-specific default excludes.
- The commits are individually buildable and `go vet`-clean, so the branch bisects.


## Diagnosing a missing manifest over a legacy layout

Because zero-config defaults always set a non-nil `index`, a content root with **no** manifest never reaches legacy `mcp-resources/` discovery. So a legacy-laid-out repository whose manifest goes missing — deleted, mistyped `--content-dir`, wrong volume mount — now starts successfully and indexes nothing, where it previously failed loudly. That behavior is deliberate (no manifest always means zero-config defaults, regardless of layout), but a silent empty server is hard to diagnose, so `createMCPServer` now warns when the manifest was absent, discovery found nothing, and an `mcp-resources/` directory exists. It is diagnostic only: mode selection, indexing, and startup success are unchanged.

**Known limitation:** the warning requires *zero* discovered sources. A repository holding both `docs/**` and an `mcp-resources/` tree still loses its legacy catalog silently. The zero-source case matches the likeliest real occurrence — a dedicated content repository has no `README.md` or `docs/` — but the mixed layout is where a future bug report will come from.

## Follow-up (deliberately out of scope)

`filepath.WalkDir` descends the whole content root and applies include globs per-file, so traversal is O(repo) even though selection is O(docs). Combined with the user-scope registration above and no index caching, that cost is paid on every launch. Pruning directories no include pattern can match would fix it, but conservative pattern analysis is real logic — silently missing docs is worse than being slow — so it belongs in its own PR. Tracked as #79.

Also split out: #80 (testkit stdio start-failure reporting) and #81 (env-var restore hygiene in settings tests).

