### PR TITLE
perf(resources): prune directories no include pattern can match

### DIFF
--- a/internal/resources/descent.go
+++ b/internal/resources/descent.go
@@ -1,0 +1,60 @@
+package resources
+
+import (
+	"path"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
+)
+
+// descentFilter bounds traversal to the directories an include pattern could
+// match a file beneath, so indexing a repository costs O(selected subtrees)
+// rather than O(repository).
+//
+// Each pattern contributes the literal directory prefix that precedes its first
+// meta character. What such a prefix cannot describe -- a wildcard or brace in
+// the first segment, a globstar -- degrades to a full descent, so the filter
+// never hides a matchable file. A base that leaves the content root contributes
+// nothing, which is equally correct: those patterns match no path relative to
+// the root either.
+//
+// It is derived from include patterns only. An exclude subtracts from the match
+// set without licensing a skipped subtree.
+type descentFilter struct {
+	unbounded bool
+	bases     []string
+}
+
+func newDescentFilter(includes []string) descentFilter {
+	var filter descentFilter
+	for _, pattern := range includes {
+		base, remainder := doublestar.SplitPattern(pattern)
+		if base = path.Clean(base); base != "." {
+			filter.bases = append(filter.bases, base)
+			continue
+		}
+		// No literal prefix: the pattern either matches only at the root, or its
+		// first segment is a wildcard that can reach any directory. Only a
+		// separator or a globstar lets a remainder cross into a subdirectory.
+		if strings.Contains(remainder, "/") || strings.Contains(remainder, "**") {
+			filter.unbounded = true
+		}
+	}
+	return filter
+}
+
+// allows reports whether relativeDir -- a slash path relative to the content
+// root -- is inside some pattern's base, or an ancestor on the way to one.
+func (filter descentFilter) allows(relativeDir string) bool {
+	if filter.unbounded || relativeDir == "." {
+		return true
+	}
+	for _, base := range filter.bases {
+		if relativeDir == base ||
+			strings.HasPrefix(relativeDir, base+"/") ||
+			strings.HasPrefix(base, relativeDir+"/") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/resources/descent_test.go
+++ b/internal/resources/descent_test.go
@@ -1,0 +1,106 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDescentFilter_AllowsOnlyDirectoriesAnIncludePatternCanReach(t *testing.T) {
+	tests := []struct {
+		name     string
+		includes []string
+		allowed  []string
+		denied   []string
+	}{
+		{
+			name:     "root anchored file pattern reaches no directory",
+			includes: []string{"README.md"},
+			denied:   []string{"docs", "src", "docs/api"},
+		},
+		{
+			name:     "a single star does not cross a separator",
+			includes: []string{"*.md"},
+			denied:   []string{"docs", "docs/api"},
+		},
+		{
+			name:     "a literal base admits its own subtree",
+			includes: []string{"docs/**/*.md"},
+			allowed:  []string{"docs", "docs/api", "docs/api/v1"},
+			denied:   []string{"src", "documents"},
+		},
+		{
+			name:     "a nested base admits its ancestors and its subtree",
+			includes: []string{"a/b/*.md"},
+			allowed:  []string{"a", "a/b", "a/b/c"},
+			denied:   []string{"a/c", "b", "ab"},
+		},
+		{
+			name:     "a leading globstar admits everything",
+			includes: []string{"**/*.md"},
+			allowed:  []string{"docs", "src/deep/deeper"},
+		},
+		{
+			name:     "a bare globstar admits everything",
+			includes: []string{"**"},
+			allowed:  []string{"docs", "src/deep"},
+		},
+		{
+			name:     "a wildcard first segment admits everything",
+			includes: []string{"d*cs/**"},
+			allowed:  []string{"docs", "src", "src/deep"},
+		},
+		{
+			name:     "a brace in the first segment admits everything",
+			includes: []string{"{docs,adr}/**/*.md"},
+			allowed:  []string{"docs", "adr", "src"},
+		},
+		{
+			name:     "relative segments resolve before the base is taken",
+			includes: []string{"./docs/**/*.md"},
+			allowed:  []string{"docs", "docs/api"},
+			denied:   []string{"src"},
+		},
+		{
+			name:     "a base that resolves back to the root falls back to the remainder",
+			includes: []string{"a/../**/*.md"},
+			allowed:  []string{"a", "src/deep"},
+		},
+		{
+			name:     "escaped meta characters stay literal",
+			includes: []string{`do\*cs/**`},
+			allowed:  []string{"do*cs", "do*cs/api"},
+			denied:   []string{"docs"},
+		},
+		{
+			name:     "a base outside the content root admits nothing",
+			includes: []string{"../outside/*.md"},
+			denied:   []string{"outside", "docs"},
+		},
+		{
+			name:     "several patterns admit their union",
+			includes: []string{"README.md", "docs/**/*.md", "adr/*.md"},
+			allowed:  []string{"docs", "docs/api", "adr"},
+			denied:   []string{"src", "adr-drafts"},
+		},
+		{
+			name:     "no include patterns admit nothing",
+			includes: nil,
+			denied:   []string{"docs"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filter := newDescentFilter(tt.includes)
+
+			require.True(t, filter.allows("."), "the content root is never pruned")
+			for _, dir := range tt.allowed {
+				require.True(t, filter.allows(dir), "expected %q to be descended", dir)
+			}
+			for _, dir := range tt.denied {
+				require.False(t, filter.allows(dir), "expected %q to be pruned", dir)
+			}
+		})
+	}
+}

--- a/internal/resources/discovery.go
+++ b/internal/resources/discovery.go
@@ -119,6 +119,8 @@ func discoverWithOps(ctx context.Context, cp *content.ContentProvider, index *do
 		return DiscoveryResult{}, fmt.Errorf("resolve content root: %w", err)
 	}
 
+	descent := newDescentFilter(patterns)
+
 	var selected []string
 	err = ops.walkDir(root, func(filePath string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
@@ -128,7 +130,17 @@ func discoverWithOps(ctx context.Context, cp *content.ContentProvider, index *do
 			return err
 		}
 		if entry.IsDir() {
-			if filePath != root && shouldPruneDir(entry.Name(), policy.lenient) {
+			if filePath == root {
+				return nil
+			}
+			if shouldPruneDir(entry.Name(), policy.lenient) {
+				return fs.SkipDir
+			}
+			relativeDir, err := ops.relativePath(root, filePath)
+			if err != nil {
+				return err
+			}
+			if !descent.allows(filepath.ToSlash(relativeDir)) {
 				return fs.SkipDir
 			}
 			return nil

--- a/internal/resources/discovery_ops_test.go
+++ b/internal/resources/discovery_ops_test.go
@@ -75,6 +75,13 @@ func TestDiscoverWithOps_ConfiguredFilesystemFailures(t *testing.T) {
 			},
 		},
 		{
+			name: "directory relative path error", wantErr: relativeErr,
+			configure: func(ops *discoveryOps) {
+				ops.walkDir = walkOne(root+"/docs", directoryEntry("docs"))
+				ops.relativePath = func(_, _ string) (string, error) { return "", relativeErr }
+			},
+		},
+		{
 			name: "read error", wantErr: readErr,
 			configure: func(ops *discoveryOps) {
 				ops.walkDir = walkOne(file, regularEntry("guide.md"))
@@ -277,6 +284,10 @@ func walkOne(file string, entry fs.DirEntry) func(string, fs.WalkDirFunc) error 
 
 func regularEntry(name string) testDirEntry {
 	return testDirEntry{name: name}
+}
+
+func directoryEntry(name string) testDirEntry {
+	return testDirEntry{name: name, mode: fs.ModeDir}
 }
 
 type testDirEntry struct {

--- a/internal/resources/discovery_test.go
+++ b/internal/resources/discovery_test.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -272,6 +273,200 @@ func TestDiscover_DoesNotPruneContentRootItself(t *testing.T) {
 	}, "acdc", WithLenientIndex())
 	require.NoError(t, err)
 	require.Equal(t, []string{"acdc://docs/guide"}, sourceURIs(result.Sources))
+}
+
+func TestDiscover_DescendsOnlyDirectoriesIncludePatternsCanReach(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "README.md", "# Readme\n")
+	writeFile(t, root, "docs/guide.md", "# Guide\n")
+	writeFile(t, root, "docs/api/auth.md", "# Auth\n")
+	writeFile(t, root, "src/main.md", "# Main\n")
+	writeFile(t, root, "node_modules/pkg/readme.md", "# Vendored\n")
+
+	everything := []string{".", "docs", "docs/api", "node_modules", "node_modules/pkg", "src"}
+	tests := []struct {
+		name          string
+		include       []string
+		wantDescended []string
+		wantSources   []string
+	}{
+		{
+			name:          "a literal base bounds traversal to its own subtree",
+			include:       []string{"docs/**/*.md"},
+			wantDescended: []string{".", "docs", "docs/api"},
+			wantSources:   []string{"acdc://docs/api/auth", "acdc://docs/guide"},
+		},
+		{
+			name:          "a root anchored pattern descends nothing",
+			include:       []string{"README.md"},
+			wantDescended: []string{"."},
+			wantSources:   []string{"acdc://README"},
+		},
+		{
+			name:          "a globstar descends everything",
+			include:       []string{"**/*.md"},
+			wantDescended: everything,
+			wantSources: []string{
+				"acdc://README", "acdc://docs/api/auth", "acdc://docs/guide",
+				"acdc://node_modules/pkg/readme", "acdc://src/main",
+			},
+		},
+		{
+			name:          "a wildcard first segment descends everything it cannot rule out",
+			include:       []string{"d*cs/**"},
+			wantDescended: everything,
+			wantSources:   []string{"acdc://docs/api/auth", "acdc://docs/guide"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var descended []string
+			result, err := discoverWithOps(context.Background(), content.NewContentProvider(root), &domain.IndexMetadata{
+				Include: tt.include,
+			}, "acdc", recordingDiscoveryOps(&descended))
+			require.NoError(t, err)
+			require.Equal(t, tt.wantDescended, descended)
+			require.Equal(t, tt.wantSources, sourceURIs(result.Sources))
+		})
+	}
+}
+
+func TestDiscover_DescendsTheAncestorsOfANestedPatternBase(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "a/b/guide.md", "# Guide\n")
+	writeFile(t, root, "a/c/other.md", "# Other\n")
+
+	var descended []string
+	result, err := discoverWithOps(context.Background(), content.NewContentProvider(root), &domain.IndexMetadata{
+		Include: []string{"a/b/*.md"},
+	}, "acdc", recordingDiscoveryOps(&descended))
+	require.NoError(t, err)
+	require.Equal(t, []string{".", "a", "a/b"}, descended)
+	require.Equal(t, []string{"acdc://a/b/guide"}, sourceURIs(result.Sources))
+}
+
+func TestDiscover_PrunesArtifactDirectoriesInsidePatternAdmittedSubtrees(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "docs/guide.md", "# Guide\n")
+	writeFile(t, root, "docs/build/generated.md", "# Generated\n")
+
+	var descended []string
+	result, err := discoverWithOps(context.Background(), content.NewContentProvider(root), &domain.IndexMetadata{
+		Include: []string{"docs/**/*.md"},
+	}, "acdc", recordingDiscoveryOps(&descended), WithLenientIndex())
+	require.NoError(t, err)
+	require.Equal(t, []string{".", "docs"}, descended)
+	require.Equal(t, []string{"acdc://docs/guide"}, sourceURIs(result.Sources))
+}
+
+// Bounding traversal must never change what is selected.
+func TestDiscover_BoundedTraversalPreservesSelection(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "README.md", "# Readme\n")
+	writeFile(t, root, "docs/guide.md", "# Guide\n")
+	writeFile(t, root, "docs/api/auth.md", "# Auth\n")
+	writeFile(t, root, "docs/generated/skip.md", "# Skip\n")
+	writeFile(t, root, "adr/0001-record.md", "# Record\n")
+	writeFile(t, root, "src/internal/notes.md", "# Notes\n")
+	writeFile(t, root, "node_modules/pkg/readme.md", "# Vendored\n")
+
+	tests := []struct {
+		name    string
+		include []string
+		exclude []string
+		opts    []DiscoverOption
+		want    []string
+	}{
+		{
+			name:    "zero-config defaults",
+			include: []string{"README.md", "docs/**/*.md"},
+			exclude: []string{"docs/generated/**"},
+			want:    []string{"acdc://README", "acdc://docs/api/auth", "acdc://docs/guide"},
+		},
+		{
+			name:    "everything under a strict policy",
+			include: []string{"**/*.md"},
+			want: []string{
+				"acdc://README", "acdc://adr/0001-record", "acdc://docs/api/auth",
+				"acdc://docs/generated/skip", "acdc://docs/guide",
+				"acdc://node_modules/pkg/readme", "acdc://src/internal/notes",
+			},
+		},
+		{
+			name:    "everything under a lenient policy",
+			include: []string{"**/*.md"},
+			opts:    []DiscoverOption{WithLenientIndex()},
+			want: []string{
+				"acdc://README", "acdc://adr/0001-record", "acdc://docs/api/auth",
+				"acdc://docs/generated/skip", "acdc://docs/guide", "acdc://src/internal/notes",
+			},
+		},
+		{
+			name:    "a bare globstar",
+			include: []string{"**"},
+			want: []string{
+				"acdc://README", "acdc://adr/0001-record", "acdc://docs/api/auth",
+				"acdc://docs/generated/skip", "acdc://docs/guide",
+				"acdc://node_modules/pkg/readme", "acdc://src/internal/notes",
+			},
+		},
+		{
+			name:    "braced alternatives",
+			include: []string{"{docs,adr}/**/*.md"},
+			want: []string{
+				"acdc://adr/0001-record", "acdc://docs/api/auth",
+				"acdc://docs/generated/skip", "acdc://docs/guide",
+			},
+		},
+		{
+			name:    "several disjoint bases",
+			include: []string{"src/**/*.md", "adr/*.md"},
+			want:    []string{"acdc://adr/0001-record", "acdc://src/internal/notes"},
+		},
+		{
+			name:    "a nested base reached through its ancestors",
+			include: []string{"docs/api/*.md"},
+			want:    []string{"acdc://docs/api/auth"},
+		},
+		{
+			name:    "root level files only",
+			include: []string{"*.md"},
+			want:    []string{"acdc://README"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := Discover(context.Background(), content.NewContentProvider(root), &domain.IndexMetadata{
+				Include: tt.include,
+				Exclude: tt.exclude,
+			}, "acdc", tt.opts...)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, sourceURIs(result.Sources))
+		})
+	}
+}
+
+// recordingDiscoveryOps walks the real filesystem while recording the directories
+// the walk actually descended into, as slash paths relative to the content root.
+func recordingDiscoveryOps(descended *[]string) discoveryOps {
+	ops := defaultDiscoveryOps()
+	ops.walkDir = func(root string, walk fs.WalkDirFunc) error {
+		return filepath.WalkDir(root, func(filePath string, entry fs.DirEntry, walkErr error) error {
+			err := walk(filePath, entry, walkErr)
+			if walkErr != nil || err != nil || !entry.IsDir() {
+				return err
+			}
+			relativePath, relativeErr := filepath.Rel(root, filePath)
+			if relativeErr != nil {
+				return relativeErr
+			}
+			*descended = append(*descended, filepath.ToSlash(relativePath))
+			return nil
+		})
+	}
+	return ops
 }
 
 func writeFile(t *testing.T, root, name, body string) string {


### PR DESCRIPTION
Closes #79.

## Summary

Configured-index discovery walked the entire content root regardless of what the
include patterns could ever select. With the zero-config defaults from #78,
*selection* is `docs/` plus one root file but *traversal* is the whole repository.
The server is meant to be registered once at user scope and there is no index
caching, so that cost is paid on **every launch in every repository** — and a
client started in `$HOME` walks the home directory.

Traversal is now bounded to the subtrees an include pattern can actually reach.
Selection is unchanged.

## Changes

`descentFilter` (new `internal/resources/descent.go`) derives, per include pattern,
the literal directory prefix preceding its first meta character — via
`doublestar.SplitPattern`, rather than hand-rolled glob prefix semantics. A
directory is descended iff it is one of those bases, inside one, or an ancestor on
the way to one.

| pattern | base | descends |
|---|---|---|
| `README.md` | `.` | nothing |
| `*.md` | `.` | nothing (`*` does not cross `/`) |
| `docs/**/*.md` | `docs` | `docs` + subtree |
| `a/b/*.md` | `a/b` | `a`, then `a/b` + subtree |
| `**/*.md`, `**`, `d*cs/**`, `{docs,adr}/**/*.md` | `.` | everything |

Anything a literal prefix cannot describe degrades to a **full descent** — the
intended failure direction. Two rules carry the correctness argument:

- **Ancestors are descended.** Reaching `a/b` requires descending `a`. A rule
  admitting only exact prefixes of the base would silently skip nested doc roots.
- **Excludes never prune.** An exclude subtracts from the match set; it does not
  license skipping traversal. `docs/**/draft-*.md` does not mean `docs/` can be
  skipped. Exclude-driven pruning is a separate, riskier optimization, out of scope.

Two non-obvious details, each found by probing `doublestar` rather than reasoning
about it — both are places a plausible implementation loses documents silently:

1. The base is `path.Clean`ed **before** the `"."` test. `a/../**/*.md` splits to
   base `a/..`; cleaning afterwards would treat it as a literal base and
   under-descend.
2. A remainder containing `**` forces a full descent even with no `/`.
   `Match("**", "a/b.md")` is `true`, so "no separator ⇒ cannot cross a directory"
   is not safe for a bare globstar.

Pattern-based pruning is a property of the patterns, not the policy, so it applies
under **both** strict and lenient — unlike `lenientPrunedDirs`. Existing base-name
pruning, the root exemption, symlink skipping and containment checks are untouched.

## Risk and verification

The failure mode this optimization can introduce is silent: documents that stop
being indexed with no error. Two independent checks pin selection equivalence.

- A table pinning the selected URI set across 7 pattern/policy combinations. Since
  it pins already-correct behavior it has no natural RED, so per repo convention the
  predicate was sabotaged — dropping the ancestor clause, and treating a `**`
  remainder as bounded — each failure confirmed and fully reverted. The first
  sabotage initially escaped the guard, so nested-base and bare-globstar cases were
  added until both were caught.
- End to end over stdio: `resources/list` output compared between a binary built at
  `master` and this branch, identical in all three modes — zero-config defaults (7
  resources), legacy `mcp-resources` (`examples/sample-content`, 4), and this repo's
  own manifest (6).

No existing assertion was changed; `discovery_ops_test.go` gains one case covering
the new directory-branch `relativePath` failure.

Traversal cost, on a synthetic 10,107-file repository whose docs are 7 files:

| | startup |
|---|---|
| master | 0.23s |
| this branch | 0.05s |