### PR TITLE
test(search): add a golden-query harness for ranking quality

### DIFF
--- a/internal/search/golden_test.go
+++ b/internal/search/golden_test.go
@@ -1,0 +1,349 @@
+package search
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/sha1n/mcp-acdc-server/internal/config"
+	"github.com/sha1n/mcp-acdc-server/internal/content"
+	"github.com/sha1n/mcp-acdc-server/internal/domain"
+	"github.com/sha1n/mcp-acdc-server/internal/resources"
+	"github.com/stretchr/testify/require"
+)
+
+// Corpora under testdata. zeroConfigCorpus carries no frontmatter, reproducing
+// what the server indexes in repository mode; curatedCorpus carries the
+// frontmatter an authored catalog supplies.
+const (
+	zeroConfigCorpus = "testdata/corpus"
+	curatedCorpus    = "testdata/curated"
+)
+
+// goldenCandidates is deliberately larger than any asserted rank, so a document
+// that drops out of the top ranks is reported rather than silently truncated.
+const goldenCandidates = 25
+
+// goldenQuery pins one ranking judgement. Expectations address documents by
+// source URI or by chunk URI; both forms are matched against every result.
+//
+// Assertions are on rank position only. Bleve scores move with library
+// upgrades and with corpus size, so a score assertion pins the library rather
+// than the ranking model.
+type goldenQuery struct {
+	name    string
+	corpora []string
+	query   string
+	// rationale states why the pinned ranking is the right answer.
+	rationale string
+	// top, when set, must be the URI at rank 1.
+	top string
+	// within maps a URI to the rank it must reach or better.
+	within map[string]int
+	// ranks maps a URI to the exact rank it must occupy. Used to pin a measured
+	// ranking that is not the desired one, so improving it fails the case
+	// instead of passing silently.
+	ranks map[string]int
+	// absent lists URIs that must not appear among the candidates at all.
+	absent []string
+	// finding, when non-empty, marks a case whose expectations pin what the
+	// current model *does* rather than what it should do. Retuning belongs to
+	// the issue named here, not to this harness.
+	finding string
+}
+
+// goldenService indexes the given corpora through the production discovery and
+// chunking path, so the harness measures the scorer against the documents it
+// actually sees rather than against hand-built chunks.
+func goldenService(t *testing.T, corpora ...string) *Service {
+	t.Helper()
+	return goldenServiceWith(t, testSettings(), corpora...)
+}
+
+func goldenServiceWith(t *testing.T, settings config.SearchSettings, corpora ...string) *Service {
+	t.Helper()
+
+	index := &domain.IndexMetadata{Include: []string{"**/*.md"}}
+	var chunks []domain.Chunk
+	for _, corpus := range corpora {
+		result, err := resources.Discover(context.Background(), content.NewContentProvider(corpus), index, "acdc")
+		require.NoError(t, err, "discover %s", corpus)
+		require.NotEmpty(t, result.Chunks, "corpus %s produced no chunks", corpus)
+		chunks = append(chunks, result.Chunks...)
+	}
+
+	service := NewService(settings)
+	t.Cleanup(service.Close)
+	indexChunks(t, service, chunks)
+	return service
+}
+
+// rankOf returns the best 1-based rank at which uri appears, or 0 when absent.
+func rankOf(results []SearchResult, uri string) int {
+	for rank, result := range results {
+		if result.ChunkURI == uri || result.SourceURI == uri {
+			return rank + 1
+		}
+	}
+	return 0
+}
+
+// reportRanking logs the leading results for a query. Visible under
+// `go test -run TestGolden -v`, this table is the measurement the harness
+// exists to produce; the assertions are its regression gate.
+func reportRanking(t *testing.T, query string, results []SearchResult) {
+	t.Helper()
+	t.Logf("query %q — %d candidates", query, len(results))
+	for rank, result := range results {
+		if rank == 5 {
+			break
+		}
+		t.Logf("  %d · %.4f · %s · %s", rank+1, result.Score, result.ChunkURI, strings.Join(result.HeadingPath, " > "))
+	}
+}
+
+func (q goldenQuery) run(t *testing.T) {
+	t.Helper()
+
+	service := goldenService(t, q.corpora...)
+	results, err := service.Search(q.query, goldenCandidates)
+	require.NoError(t, err)
+	reportRanking(t, q.query, results)
+
+	if q.finding != "" {
+		t.Logf("FINDING (%s): %s", q.finding, q.rationale)
+	}
+
+	if q.top != "" {
+		require.NotEmpty(t, results, "no results for %q", q.query)
+		require.Equal(t, 1, rankOf(results, q.top), "%s\nexpected %s at rank 1, got %s", q.rationale, q.top, results[0].ChunkURI)
+	}
+	for uri, limit := range q.within {
+		rank := rankOf(results, uri)
+		require.NotZero(t, rank, "%s\nexpected %s within rank %d, absent from %d candidates", q.rationale, uri, limit, len(results))
+		require.LessOrEqual(t, rank, limit, "%s\nexpected %s within rank %d, got rank %d", q.rationale, uri, limit, rank)
+	}
+	for uri, expected := range q.ranks {
+		require.Equal(t, expected, rankOf(results, uri), "%s\nexpected %s at rank %d", q.rationale, uri, expected)
+	}
+	for _, uri := range q.absent {
+		require.Zero(t, rankOf(results, uri), "%s\nexpected %s to be absent", q.rationale, uri)
+	}
+}
+
+func TestGolden_ZeroConfigRanking(t *testing.T) {
+	corpus := []string{zeroConfigCorpus}
+	queries := []goldenQuery{
+		{
+			name:    "dedicated page beats the README summary",
+			corpora: corpus,
+			query:   "authentication",
+			rationale: "docs/authentication.md is the page about the topic and wins, as it should. " +
+				"Measured: its six chunks then take ranks 1-6 outright, and the README summary — the only other document with a claim to the query — lands at 7. " +
+				"Ranking is per chunk with no per-source diversification, so one document can occupy an entire result page and hide every alternative from a client that reads the top five.",
+			top:     "acdc://docs/authentication",
+			ranks:   map[string]int{"acdc://README": 7},
+			finding: "no per-source diversification",
+		},
+		{
+			name:      "defining section beats sibling sections of the same page",
+			corpora:   corpus,
+			query:     "bearer token",
+			rationale: "The section that defines bearer tokens answers the query; rotation and revocation only use the term.",
+			top:       "acdc://docs/authentication#bearer-tokens",
+		},
+		{
+			name:      "nested heading retrieves the section, not the page",
+			corpora:   corpus,
+			query:     "readiness probe",
+			rationale: "Chunk granularity is the point: the answer is the third-level Readiness section, not the whole Kubernetes page.",
+			top:       "acdc://docs/deployment/kubernetes#readiness",
+		},
+		{
+			name:    "path carries a signal the body does not",
+			corpora: corpus,
+			query:   "rate limiting",
+			rationale: "docs/rate-limiting/quotas.md never writes 'rate' or 'limiting' in its body or headings, so only path_labels can retrieve it. " +
+				"It must still beat the troubleshooting section that mentions an append rate in passing: path_labels (1.25) over content (1.0).",
+			top:    "acdc://docs/rate-limiting/quotas",
+			within: map[string]int{"acdc://docs/troubleshooting#queries-are-slow": 6},
+		},
+		{
+			name:    "a heading beats repetition in a body",
+			corpora: corpus,
+			query:   "checksums",
+			rationale: "The internals page has a Checksums heading and names the term once; the CLI reference names it three times under a heading about a subcommand. " +
+				"heading_path (2.5) over content (1.0): what a section is titled says more than how often a term recurs inside one.",
+			top:    "acdc://docs/internals/indexing#checksums",
+			within: map[string]int{"acdc://docs/reference/cli#ledger-verify": 3},
+		},
+		{
+			name:      "title outranks a heading on a recurring term",
+			corpora:   corpus,
+			query:     "configuration",
+			rationale: "The term recurs in four documents. The page titled Configuration should win over the README section and the passing mentions.",
+			top:       "acdc://docs/configuration",
+			within:    map[string]int{"acdc://README": 6},
+		},
+		{
+			name:      "symptom heading beats an explanatory mention",
+			corpora:   corpus,
+			query:     "401",
+			rationale: "Troubleshooting has a heading for the symptom; authentication.md only mentions the status code while explaining validation.",
+			top:       "acdc://docs/troubleshooting#requests-fail-with-401",
+		},
+		{
+			name:      "an unrelated sibling page does not leak in",
+			corpora:   corpus,
+			query:     "helm chart",
+			rationale: "Precision probe: the Docker page shares a parent directory with Kubernetes but says nothing about Helm.",
+			top:       "acdc://docs/deployment/kubernetes#helm-chart",
+			absent:    []string{"acdc://docs/deployment/docker"},
+		},
+		{
+			name:    "fuzziness admits an unrelated document",
+			corpora: corpus,
+			query:   "readiness",
+			rationale: "README has no bearing on readiness probes, and the corpus contains one obviously correct answer. " +
+				"Measured: every README chunk matches, taking ranks 2-5, because the path label 'readme' stems to a term within edit distance 1 of the query. " +
+				"Fuzziness is applied to every field with no prefix_length, so a document is retrieved on a term it does not contain.",
+			top:     "acdc://docs/deployment/kubernetes#readiness",
+			ranks:   map[string]int{"acdc://README": 2},
+			finding: "#85 — fuzziness=1 with no prefix_length",
+		},
+	}
+
+	for _, query := range queries {
+		t.Run(query.name, query.run)
+	}
+}
+
+func TestGolden_CuratedRanking(t *testing.T) {
+	mixed := []string{zeroConfigCorpus, curatedCorpus}
+	queries := []goldenQuery{
+		{
+			name:    "keywords retrieve a document whose body lacks the term",
+			corpora: mixed,
+			query:   "compaction",
+			rationale: "Retention policy names compaction only in frontmatter keywords; the indexing page carries it as a heading and in its body. " +
+				"The boost table says keywords (3.0) outranks heading_path (2.5), so the curated document was expected to win. " +
+				"Measured: the indexing page wins outright and every retention chunk trails it. A larger boost does not decide a match — " +
+				"the indexing chunk scores on two fields at once, and per-field IDF favours it because the term appears in one heading_path but in the keywords of all three retention chunks. " +
+				"TestSearch_ChunkFieldBoosts proves the boosts are ordered; it holds all else equal, and on a real corpus all else is not equal.",
+			top:     "acdc://docs/internals/indexing#segment-compaction",
+			ranks:   map[string]int{"acdc://docs/retention": 2},
+			finding: "#84 — boost order is not the effective ranking",
+		},
+		{
+			name:    "a keyword beats a passing mention in a body",
+			corpora: mixed,
+			query:   "dashboards",
+			rationale: "Observability declares dashboards as a keyword and never writes the word; troubleshooting mentions one dashboard in passing. " +
+				"keywords (3.0) over content (1.0) is the curated catalog's whole value proposition, and this is the pair that isolates it.",
+			top:    "acdc://docs/observability",
+			within: map[string]int{"acdc://docs/troubleshooting#queries-are-slow": 4},
+		},
+		{
+			name:      "a curated title still competes on its own terms",
+			corpora:   mixed,
+			query:     "metrics endpoint",
+			rationale: "Frontmatter must not make a curated document win queries it has no claim to; here it has one, through both keywords and a heading.",
+			top:       "acdc://docs/observability#metrics-endpoint",
+		},
+	}
+
+	for _, query := range queries {
+		t.Run(query.name, query.run)
+	}
+}
+
+// TestGolden_KeywordsAreInertInZeroConfigMode pins the structural finding that
+// motivates this harness: keywords carry the highest boost in the model (3.0,
+// above heading_path at 2.5) and come only from YAML frontmatter, which
+// repository documentation does not have. In the mode the server now defaults
+// to, the strongest signal has no documents to match.
+func TestGolden_KeywordsAreInertInZeroConfigMode(t *testing.T) {
+	index := &domain.IndexMetadata{Include: []string{"**/*.md"}}
+	result, err := resources.Discover(context.Background(), content.NewContentProvider(zeroConfigCorpus), index, "acdc")
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Chunks)
+
+	var withKeywords []string
+	for _, chunk := range result.Chunks {
+		if len(chunk.Keywords) > 0 {
+			withKeywords = append(withKeywords, chunk.ChunkURI)
+		}
+	}
+	require.Empty(t, withKeywords, "keywords boost %v has no reachable documents without frontmatter", testSettings().KeywordsBoost)
+
+	curated, err := resources.Discover(context.Background(), content.NewContentProvider(curatedCorpus), index, "acdc")
+	require.NoError(t, err)
+	keywordChunks := 0
+	for _, chunk := range curated.Chunks {
+		if len(chunk.Keywords) > 0 {
+			keywordChunks++
+		}
+	}
+	require.NotZero(t, keywordChunks, "curated corpus must exercise the keywords field")
+	t.Logf("keywords populated: 0/%d zero-config chunks, %d/%d curated chunks",
+		len(result.Chunks), keywordChunks, len(curated.Chunks))
+}
+
+// TestGolden_TitleNeverFiresAloneInZeroConfigMode pins the second structural
+// finding. Without frontmatter a source title is the document's first level-one
+// heading, which the chunker also puts at the head of every heading path. So
+// source_title (2.0) never matches a chunk that heading_path (2.5) has not
+// already matched: two of the model's five fields carry no signal of their own
+// in the mode the server now defaults to.
+func TestGolden_TitleNeverFiresAloneInZeroConfigMode(t *testing.T) {
+	index := &domain.IndexMetadata{Include: []string{"**/*.md"}}
+	result, err := resources.Discover(context.Background(), content.NewContentProvider(zeroConfigCorpus), index, "acdc")
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Chunks)
+
+	for _, chunk := range result.Chunks {
+		require.NotEmpty(t, chunk.HeadingPath, "chunk %s has no heading path", chunk.ChunkURI)
+		require.Equal(t, chunk.SourceTitle, chunk.HeadingPath[0], "chunk %s: title is not the head of its heading path", chunk.ChunkURI)
+	}
+}
+
+// TestGolden_ContentBoostCannotOutweighAHeadingMatch measures how much authority
+// a boost constant actually carries, which is what #84 has to know before
+// exposing any of them as configuration.
+//
+// The query isolates one field against another: the internals page carries
+// "checksums" as a heading and never in its body, the CLI reference carries it
+// three times in a body and in no heading. Raising the content boost narrows the
+// gap and then stops — the two scores converge without crossing, so no value of
+// content_boost makes the body match win. Bleve normalizes each clause of the
+// disjunction against the query's own weights, which bounds what a single
+// clause's boost can buy; field length normalization then keeps the short
+// heading_path field ahead of a long body.
+//
+// A boost is therefore not a ranking override. Separately measured against the
+// golden cases: content_boost must reach ~10x its default before any of them
+// change at all, and settles by ~30x. Retuning the ranking model means changing
+// analyzers, field norms, or query structure — the boosts alone cannot express
+// every outcome an operator might configure them to want.
+func TestGolden_ContentBoostCannotOutweighAHeadingMatch(t *testing.T) {
+	const (
+		query       = "checksums"
+		headingOnly = "acdc://docs/internals/indexing#checksums"
+		bodyOnly    = "acdc://docs/reference/cli#ledger-verify"
+	)
+
+	for _, boost := range []float64{1, 3, 1000} {
+		t.Run(fmt.Sprintf("content_boost_%g", boost), func(t *testing.T) {
+			settings := testSettings()
+			settings.ContentBoost = boost
+			service := goldenServiceWith(t, settings, zeroConfigCorpus)
+
+			results, err := service.Search(query, goldenCandidates)
+			require.NoError(t, err)
+			reportRanking(t, query, results)
+			require.Equal(t, 1, rankOf(results, headingOnly), "heading match must lead at content_boost %g", boost)
+			require.Equal(t, 2, rankOf(results, bodyOnly), "body match must trail it at content_boost %g", boost)
+		})
+	}
+}

--- a/internal/search/testdata/README.md
+++ b/internal/search/testdata/README.md
@@ -1,0 +1,31 @@
+# Golden query corpus
+
+Fixtures for `golden_test.go`. They are ordinary Markdown so that the realism
+that makes them useful stays reviewable; Go string literals would not.
+
+`corpus/` reproduces repository documentation: **no frontmatter anywhere**,
+headings of uneven depth, terminology recurring across files, and a README whose
+sections restate what a `docs/` page covers at length.
+
+`curated/` reproduces an authored catalog: frontmatter with `name`,
+`description`, and `keywords`.
+
+## Load-bearing properties
+
+Several golden cases isolate one scoring field against another. Editing the
+prose is fine; these specific properties are not decoration, and breaking one
+turns a measurement into a tautology that still passes:
+
+- `corpus/` must never gain frontmatter. `keywords` being unreachable there is
+  the finding the harness exists to pin.
+- `docs/rate-limiting/quotas.md` must not write "rate" or "limiting" in its body
+  or headings. Only its path can retrieve it.
+- `docs/internals/indexing.md` carries "checksums" as a heading and never in its
+  body; `docs/reference/cli.md` carries it only in a body, three times. The pair
+  isolates `heading_path` against `content`.
+- `curated/docs/observability.md` declares `dashboards` as a keyword and never
+  writes the word; `corpus/docs/troubleshooting.md` mentions one dashboard in
+  passing. The pair isolates `keywords` against `content`.
+
+Adding documents is safe. Removing or renaming one of the above needs the
+matching golden case updated in the same change.

--- a/internal/search/testdata/corpus/README.md
+++ b/internal/search/testdata/corpus/README.md
@@ -1,0 +1,25 @@
+# Ledger
+
+Ledger is an append-only event store with an HTTP API. It keeps a durable log of
+domain events and serves range queries over that log.
+
+## Installation
+
+Download a release binary, or build from source with `make build`. The binary is
+self-contained and needs no runtime dependencies.
+
+## Authentication
+
+Every request must carry a bearer token. Tokens are issued by the control plane
+and scoped to a single tenant. The authentication guide covers token rotation
+and the full scope vocabulary.
+
+## Configuration
+
+Ledger reads `ledger.yaml` from the working directory. Environment variables
+prefixed with `LEDGER_` override values from the file.
+
+## Support
+
+Open an issue if something breaks. Include the server version and the output of
+`ledger verify`.

--- a/internal/search/testdata/corpus/docs/authentication.md
+++ b/internal/search/testdata/corpus/docs/authentication.md
@@ -1,0 +1,36 @@
+# Authentication
+
+Ledger authenticates every request with a bearer token issued by the control
+plane. A token carries a tenant identifier and a set of scopes.
+
+## Bearer tokens
+
+A bearer token is an opaque string. Send it in the `Authorization` header of
+every request:
+
+```
+Authorization: Bearer <token>
+```
+
+Tokens are validated against the control plane on first use and cached for the
+remainder of their lifetime. A token that fails validation yields `401`.
+
+## Token rotation
+
+Rotate a token without downtime by issuing the replacement before revoking the
+predecessor. Both tokens authenticate while the old one remains valid.
+
+### Overlapping validity windows
+
+The control plane accepts an overlap of up to seven days. During the overlap
+both tokens resolve to the same tenant, so a caller can migrate at its own pace.
+
+### Revoking a predecessor
+
+Revocation takes effect within one cache lifetime. Callers still presenting the
+revoked token begin to see `401` responses.
+
+## Scopes
+
+A scope names one capability: `events:append`, `events:read`, or `admin`. A
+token without the matching scope is rejected with `403`, not `401`.

--- a/internal/search/testdata/corpus/docs/configuration.md
+++ b/internal/search/testdata/corpus/docs/configuration.md
@@ -1,0 +1,19 @@
+# Configuration
+
+Ledger takes settings from a YAML file, from environment variables, and from
+command line flags. Every setting is available through all three.
+
+## The ledger.yaml file
+
+The server reads `ledger.yaml` from its working directory unless `--config`
+names another path. Unknown keys are rejected at startup rather than ignored.
+
+## Environment variables
+
+Every setting has an environment variable spelled `LEDGER_` followed by the
+upper-case setting name. Nested settings join their segments with an underscore.
+
+## Precedence
+
+Flags beat environment variables, which beat the YAML file, which beats the
+built-in defaults. Precedence is resolved once at startup and never re-read.

--- a/internal/search/testdata/corpus/docs/deployment/docker.md
+++ b/internal/search/testdata/corpus/docs/deployment/docker.md
@@ -1,0 +1,15 @@
+# Running Ledger in Docker
+
+The published image is a distroless base with the server binary and nothing
+else. There is no shell inside it.
+
+## Image tags
+
+Every release publishes an immutable tag. The floating `latest` tag follows the
+newest release and is meant for experiments, not for production.
+
+## Volumes
+
+Mount a volume at the data directory. The container process runs unprivileged,
+so the mounted volume must be writable by that user or the server exits before
+it binds a port.

--- a/internal/search/testdata/corpus/docs/deployment/kubernetes.md
+++ b/internal/search/testdata/corpus/docs/deployment/kubernetes.md
@@ -1,0 +1,31 @@
+# Running Ledger on Kubernetes
+
+The Helm chart is the supported path. It renders a StatefulSet, a headless
+Service, and a PersistentVolumeClaim per replica.
+
+## Helm chart
+
+Add the repository and install the chart into a namespace of your choosing.
+Chart values mirror `ledger.yaml` one for one, so anything expressible in the
+configuration file is expressible in values.
+
+## Probes
+
+The chart wires two HTTP probes. Both are cheap and neither touches storage.
+
+### Readiness
+
+The readiness endpoint reports whether the replica has acquired its data
+directory lock and replayed its tail. A replica that is still replaying answers
+`503`, which keeps it out of the Service until replay finishes.
+
+### Liveness
+
+The liveness endpoint answers as long as the process can schedule work. It
+deliberately ignores replay progress, so a slow replay never restarts a healthy
+replica.
+
+## Rolling updates
+
+Roll one replica at a time and wait for readiness between steps. The chart sets
+this policy by default.

--- a/internal/search/testdata/corpus/docs/guides/getting-started.md
+++ b/internal/search/testdata/corpus/docs/guides/getting-started.md
@@ -1,0 +1,12 @@
+# Getting started
+
+This guide walks from an empty directory to a server that answers queries.
+
+Install the binary, write a minimal `ledger.yaml` naming a data directory, then
+run `ledger serve`. The server refuses to start until it can create and lock the
+data directory, so a permission problem surfaces immediately rather than on the
+first write.
+
+Ask the control plane for a token with the `events:append` scope and append an
+event. Read it back with a range query covering the current day. Once that round
+trip works, everything else in these documents is a refinement of it.

--- a/internal/search/testdata/corpus/docs/internals/indexing.md
+++ b/internal/search/testdata/corpus/docs/internals/indexing.md
@@ -1,0 +1,20 @@
+# How indexing works
+
+Nothing here is a public contract. It changes between releases.
+
+## Segments
+
+An append lands in the open segment. When the open segment reaches its size
+bound it is sealed, and a fresh one takes its place. Sealed segments are
+immutable.
+
+## Segment compaction
+
+A background merger rewrites adjacent sealed segments into one. Compaction
+reclaims space held by superseded events and shortens the read path for range
+queries that span a long stretch of the log.
+
+## Checksums
+
+Every segment carries a digest over its payload. `ledger verify` recomputes each
+digest; the reader validates them lazily as it touches pages.

--- a/internal/search/testdata/corpus/docs/rate-limiting/quotas.md
+++ b/internal/search/testdata/corpus/docs/rate-limiting/quotas.md
@@ -1,0 +1,14 @@
+# Request throttling
+
+Ledger sheds load before it degrades. Each tenant gets a token budget that
+refills continuously, and a burst allowance on top of it.
+
+## Budgets
+
+A budget is expressed in requests per second per tenant. Exhausting the budget
+yields `429` with a `Retry-After` header naming the wait in whole seconds.
+
+## Bursts
+
+The burst allowance absorbs short spikes without touching the steady-state
+budget. It refills only while the tenant is below its steady-state consumption.

--- a/internal/search/testdata/corpus/docs/reference/cli.md
+++ b/internal/search/testdata/corpus/docs/reference/cli.md
@@ -1,0 +1,19 @@
+# Command line reference
+
+Every subcommand accepts `--config` and `--log-format`.
+
+## ledger serve
+
+Starts the HTTP server. Blocks until interrupted, then drains in-flight requests
+before closing the data directory.
+
+## ledger migrate
+
+Upgrades an on-disk data directory to the current segment format. Refuses to run
+against a directory another process holds open.
+
+## ledger verify
+
+Walks every segment and recomputes its checksum. A checksum mismatch is reported
+against the segment and the page holding it, and the walk continues, so one bad
+checksum does not hide the ones behind it. Exits non-zero if any mismatched.

--- a/internal/search/testdata/corpus/docs/troubleshooting.md
+++ b/internal/search/testdata/corpus/docs/troubleshooting.md
@@ -1,0 +1,24 @@
+# Troubleshooting
+
+Symptoms, in the order support sees them.
+
+## The server will not start
+
+Ledger refuses to start when `ledger.yaml` holds an unknown key. The startup
+error names the offending key and the line it appears on.
+
+## Requests fail with 401
+
+The bearer token is missing, malformed, or revoked. Confirm the token reaches
+the server in the `Authorization` header before suspecting the control plane.
+
+## Requests fail with 403
+
+The token authenticated, but its scopes do not cover the operation. This is a
+scope problem, not an authentication problem.
+
+## Queries are slow
+
+A range query that spans many segments reads each of them. Check whether the
+background merger has fallen behind, and whether the append rate has outgrown
+what a single replica can seal. The merger lag dashboard answers both.

--- a/internal/search/testdata/curated/docs/observability.md
+++ b/internal/search/testdata/curated/docs/observability.md
@@ -1,0 +1,23 @@
+---
+name: Observability
+description: Metrics, traces, and structured logs emitted by the server.
+keywords:
+  - metrics
+  - tracing
+  - dashboards
+---
+
+# Observability
+
+The server emits structured logs on stderr and exposes a metrics endpoint. Both
+are on by default and neither can be disabled at runtime.
+
+## Metrics endpoint
+
+The endpoint serves the Prometheus text format. Series are labelled by tenant,
+so cardinality grows with the tenant count rather than with traffic.
+
+## Traces
+
+Spans are emitted over OTLP when an endpoint is configured. The server
+propagates incoming trace context and never samples it away.

--- a/internal/search/testdata/curated/docs/retention.md
+++ b/internal/search/testdata/curated/docs/retention.md
@@ -1,0 +1,23 @@
+---
+name: Retention policy
+description: How long Ledger keeps events, and what reclaims the space they held.
+keywords:
+  - retention
+  - compaction
+  - pruning
+---
+
+# Retention policy
+
+A tenant declares how long its events remain readable. Past that horizon the
+events stop answering range queries and become eligible for reclamation.
+
+## Horizons
+
+A horizon is a duration, not a timestamp. Shortening one takes effect on the
+next merger pass; lengthening one cannot resurrect events already reclaimed.
+
+## Reclamation
+
+The background merger drops unreachable events as it rewrites sealed segments.
+Space returns to the filesystem only when the rewritten segment is durable.


### PR DESCRIPTION
Closes #83.

Nothing measured **whether search returns the right documents in the right order**, so every boost in the model was an unvalidated guess. This adds a golden-query harness: an authored fixture corpus, 12 queries with rank-position expectations, and a per-query top-5 report.

**Measurement tool first, regression gate second — so it changes no production code.** Three queries measured a ranking that is not the desired one. Each is pinned *as it behaves today* with a `finding` note naming the issue that owns the retune, so #84 and #85 start from a baseline rather than from a test that was tuned to pass.

## Review notes

- **Corpus lives in `internal/search/testdata/` as Markdown**, deviating from the repo's `t.TempDir()` + `writeFile` convention. Deliberate: a corpus whose realism *is* the point has to be reviewable, and Go string literals make it neither. `corpus/` reproduces repository docs (no frontmatter, uneven heading depth, recurring terminology, a README section restating a `docs/` page, a file whose *path* carries a signal its body does not); `curated/` adds frontmatter so the keywords-vs-heading gap is measurable side by side.
- **Chunks are built through `resources.Discover` + the production chunker**, not by hand — chunking decides what a "result" even is. No import cycle: nothing under `internal/search` is imported by `internal/resources`.
- **Assertions are on rank position only, never `Score`.** Bleve scores move with library upgrades and corpus size.
- **Expectations are an explicit Go table, not a regenerable golden file.** A `-update` flag would launder a ranking regression into the baseline.
- `testdata/README.md` records which corpus properties are load-bearing. Several cases isolate one scoring field against another, and a casual prose edit could turn a measurement into a tautology that still passes.
- **Findings assert the measured ranking rather than `t.Skip`.** A skipped case measures nothing; these fail if the behavior improves, which is the right signal for whoever lands #84/#85.

## Findings

**1. Two of the model's five fields carry no signal in the mode the server now defaults to.** `keywords` (boost 3.0, the highest) comes only from frontmatter — **0 of 41** zero-config chunks have any, against 6 of 6 curated. And without frontmatter a source title *is* the document's first H1, which the chunker also puts at the head of every heading path, so a `source_title` (2.0) match is always already a `heading_path` (2.5) match. This makes the two boosts #84 exposes the only discriminating ones in repository mode.

**2. A boost is not a ranking override.** For a pair where one document matches only `heading_path` and the other only `content`, raising `content_boost` narrows the gap and then stops — the scores converge without crossing:

| content_boost | heading-only | body-only |
|---|---|---|
| 1 (default) | **0.5106** | 0.0433 |
| 3 | **0.5747** | 0.1166 |
| 1000 | **0.3759** | 0.2504 |
| 100000 | **0.3734** | 0.2505 |

No value wins. Bleve normalizes each disjunction clause against the query's own weights, bounding what one clause's boost can buy; field length normalization then keeps a short `heading_path` ahead of a long body. Separately, `content_boost` must reach **~10x** its default before *any* golden case changes. **#84 should not present these as linear knobs.**

**3. The documented boost order is not the effective ranking (#84).** `keywords` (3.0) is supposed to beat `heading_path` (2.5); measured on `compaction`, the reverse — the heading document scores on two fields at once and per-field IDF favours it. `TestSearch_ChunkFieldBoosts` proves the boosts are *ordered* under all-else-equal synthetic chunks; on a real corpus all else is not equal. Left untouched — it still pins what it claims to.

**4. Fuzziness retrieves documents on terms they do not contain (#85).** Query `readiness` on a corpus with one obviously correct answer: the right chunk leads, then **every README chunk takes ranks 2-5**, because the path label `readme` stems within edit distance 1. Worth noting when fixing: #85 scopes the evaluation to the `content` field, but the damage measured here came through `path_labels`.

**5. No per-source diversification — new, and no issue owns it.** Query `authentication`: the six chunks of one document take ranks 1-6 outright, pushing the only other document with a claim to the query to rank 7. A client reading the top five sees one document and no alternatives.

## Sabotage verification

A harness that passes under a scrambled model measures nothing, so the boosts in `testSettings()` were temporarily scrambled, then restored byte-identically:

| Scramble | Golden cases that fail |
|---|---|
| swap `keywords` (3) <-> `content` (1) | 1 |
| swap `title` (2) <-> `content` (1) | **0** |
| `content` x10 | 3 |

The middle row is finding 1 showing up as a measurement: `title_boost` is unobservable in zero-config mode because the signal is degenerate.

Reproduce the full ranking table with `go test ./internal/search/ -run TestGolden -v`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)