### PR TITLE
feat(app): refresh the catalog and index when repository documents change

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ For full configuration options including authentication, see [Configuration Refe
 
 ### Per-Repository (Zero-Config)
 
-Because `--content-dir` defaults to the working directory and `mcp-metadata.yaml` is optional, `acdc-mcp` can be registered once at **user** scope, with no `--content-dir` — for clients that launch stdio servers with the repository as the working directory, as Claude Code and Gemini CLI do, this means it indexes whichever repository the client is running in each time it launches the server:
+Because `--content-dir` defaults to the working directory and `mcp-metadata.yaml` is optional, `acdc-mcp` can be registered once at **user** scope, with no `--content-dir` — for clients that launch stdio servers with the repository as the working directory, as Claude Code and Gemini CLI do, this means it indexes whichever repository the client is running in each time it launches the server, and picks up edits made mid-session without needing a restart (see [Content Refresh](docs/SPECIFICATIONS.md#content-refresh)):
 
 ```bash
 claude mcp add --scope user --transport stdio acdc -- acdc-mcp
@@ -170,6 +170,10 @@ acdc-mcp --content-dir /path/to/repository
 Add an `mcp-metadata.yaml` to override the defaults: customize server identity and instructions, and either add an `index` block to index any Markdown matched by glob patterns (e.g. `docs/**/*.md`, without needing frontmatter), or omit `index` to use the legacy `mcp-resources/` layout, which requires frontmatter on every file. Whichever mode selected the documents, they are split into heading-aware chunks for search.
 
 For details on authoring resource files, including frontmatter format and search keyword boosting, see the [Authoring Resources Guide](docs/authoring-resources.md).
+
+### Content Refresh
+
+The catalog and search index don't just build once at startup: a `search` call, a `read` call, or a resource read re-checks the content root (debounced to at most once every 2 seconds) and rebuilds them in place when something actually changed, so an edit made mid-session is visible without restarting the server. `resources/list` doesn't trigger this check and can lag slightly until one of the other three runs. See [Content Refresh](docs/SPECIFICATIONS.md#content-refresh) in the specification for the full trigger, debounce, and error-handling behavior, and note that a rebuild briefly blocks concurrent `search` calls.
 
 ### Examples
 

--- a/docs/SPECIFICATIONS.md
+++ b/docs/SPECIFICATIONS.md
@@ -52,7 +52,7 @@ The server is configured via environment variables, command-line flags, or a `.e
 
 -   **Activation**: Triggered only when `mcp-metadata.yaml` does not exist at the content root. A manifest that exists but cannot be read, fails to parse as YAML, or fails `Validate()` is still a fatal startup error — only a *missing* file falls back to defaults.
 -   **Default index**: Equivalent to a manifest with `index.include: ["README.md", "docs/**/*.md"]` (no `exclude`), which selects the same configured chunk indexing path described in 2b, with the same optional-frontmatter metadata derivation.
--   **Error handling (lenient)**: Unlike an explicit `index` block, the defaulted index tolerates conditions that would otherwise fail startup: zero matched files, and a per-file read or parse failure, are logged as warnings and the file (or the whole selection) is skipped instead of failing the server. Configuration-shape errors — an invalid, absolute, or root-escaping glob pattern, a selected non-Markdown file, or a content root that cannot be resolved — remain fatal, exactly as in 2b.
+-   **Error handling (lenient)**: Unlike an explicit `index` block, the defaulted index tolerates conditions that would otherwise fail startup: zero matched files, and a per-file read, parse, or URI-construction failure, are logged as warnings and the file (or the whole selection) is skipped instead of failing the server. Configuration-shape errors — an invalid, absolute, or root-escaping glob pattern, a selected non-Markdown file, or a content root that cannot be resolved — remain fatal, exactly as in 2b.
 -   **Directory pruning**: `.git` is always skipped during traversal, in both this mode and 2b. Under this defaulted mode only, `node_modules`, `vendor`, `dist`, `build`, `target`, and `.venv` are also skipped, so a repository's dependency and build-output directories are never scanned for Markdown. The content root itself is never pruned, even if its name matches one of these.
 -   **Derived identity**: The server name is `"<base> Documentation"`, where `<base>` is the base name of the resolved `--content-dir` path (falling back to `"Repository"` if no meaningful base name can be derived, e.g. the root directory). The version is the build-injected binary version, or `0.0.0` when it is empty. Instructions are generated from a built-in template naming the repository:
     ```text
@@ -96,7 +96,7 @@ index:                  # Optional: switches discovery to configured chunk index
     -   The scheme must be RFC 3986 compliant (starts with a letter, followed by letters/digits/`+`/`-`/`.`).
     -   Windows backslashes are normalized to forward slashes.
 -   **File Format**: Must be Markdown with YAML Frontmatter.
--   **Error handling**: A file with invalid YAML, missing frontmatter, or missing `name`/`description` is skipped with a warning log; it does not fail startup.
+-   **Error handling**: A file with invalid YAML, missing frontmatter, missing `name`/`description`, or a relative path that cannot be constructed into a valid resource URI (e.g. containing an ASCII control character) is skipped with a warning log; it does not fail startup.
 
 **Frontmatter Requirements:**
 ```markdown
@@ -116,8 +116,8 @@ Markdown content follows...
 -   **URI Scheme**: Same construction as legacy discovery, relative to `--content-dir` instead of `mcp-resources/`.
 -   **File Format**: Must be `.md` or `.markdown`. YAML frontmatter is **optional**; when present it must still be valid.
 -   **Metadata derivation**: `name` falls back to the first `#` (H1) heading, `description` to the first paragraph, when frontmatter omits them. `description` is always truncated to 200 Unicode characters, whether it came from frontmatter or the fallback paragraph. `keywords` has no fallback.
--   **Error handling (strict)**: Any of the following fails server startup: `index.include` missing/empty, an invalid/absolute/root-escaping glob pattern, zero files matched, a matched file that is not Markdown, a matched file that cannot be read or parsed, or the content root itself cannot be resolved (e.g. a broken symlink).
--   **Not part of this release**: persistence across restarts and live filesystem watching. The chunk catalog and search index are rebuilt fully at each startup.
+-   **Error handling (strict)**: Any of the following fails server startup: `index.include` missing/empty, an invalid/absolute/root-escaping glob pattern, zero files matched, a matched file that is not Markdown, a matched file that cannot be read or parsed, a matched file whose URI cannot be constructed as a valid resource address (e.g. a relative path containing an ASCII control character), or the content root itself cannot be resolved (e.g. a broken symlink). The same conditions encountered on the mid-session refresh described in [Content Refresh](#content-refresh) are logged and skipped instead of fatal — a running server keeps serving its last-known-good catalog.
+-   **Not part of this release**: persistence across restarts. The chunk catalog and search index are rebuilt fully at startup, and rebuilt again mid-session whenever a refresh detects a content change — see [Content Refresh](#content-refresh).
 
 ### 3. Chunking and Fragment URIs (Both Modes)
 
@@ -195,6 +195,20 @@ In addition to tools, the server exposes source documents (not individual chunks
 
 ---
 
+## Content Refresh
+
+The content root is re-checked for changes at the start of every `search` call, every `read` call, and every resource read. `resources/list` does not trigger a check: the underlying SDK serves it directly, with no handler to route through revalidation, so its listing can lag behind the other three surfaces until one of them runs.
+
+A check is debounced to at most once every 2 seconds — a burst of requests inside that window is served from the previous result rather than re-walking the content root. The check itself is layered to keep the common case cheap: it first compares a digest of file paths, sizes, and modification times (no file contents are read) against the last check, and only when that digest changed does it re-discover and diff a content digest, and only when *that* digest also changed does it re-assemble the catalog, rebuild the Bleve search index, publish the new catalog, and reconcile registered resources — sending `notifications/resources/list_changed` to connected clients when the resource set actually changed. An untouched content root costs one cheap filesystem walk per debounce interval; the full rebuild only runs on an actual change.
+
+This applies identically to both discovery modes (legacy `mcp-resources/` and configured indexing) and to both transports — there is no way to scope refresh to one or disable it. Every error on this path (a failed walk, discovery, parse, or index rebuild) is logged and swallowed: the previously published catalog and index stay in place and the next debounce interval retries from scratch. This is deliberately different from the fatal startup errors listed elsewhere on this page — a malformed document must never take down a server that has already been serving successfully.
+
+A content-change rebuild holds the search index's write lock for its duration, so a concurrent `search` call briefly blocks until the rebuild finishes. For the zero-config, locally-indexed case this is on the order of milliseconds; for a large curated corpus served over SSE to many concurrent clients, it is a real (if brief) pause on every edit, with no configuration to opt out of it.
+
+Persistence across restarts is still not part of this release: nothing is written to disk, and the catalog/index are rebuilt from scratch every time the process starts, independent of the mid-session refresh described here.
+
+---
+
 ## Transports
 
 The server supports two transport modes, which are **mutually exclusive**. Only one transport can be active at a time.
@@ -221,7 +235,7 @@ Used for remote connections.
 ## Search Implementation Details
 
 *   **Engine**: Bleve (Go) full-text search engine.
-*   **Indexing**: Indexes document chunks (not whole documents). Occurs at server startup (in-memory or temporary directory) and is rebuilt in full on every restart — there is no persistence across restarts and no live filesystem watching in this release.
+*   **Indexing**: Indexes document chunks (not whole documents), in-memory or in a temporary directory — no persistence across restarts. Built in full at startup, and rebuilt in full again mid-session whenever a debounced refresh detects a content change; see [Content Refresh](#content-refresh) for the trigger, debounce interval, and concurrency cost.
 *   **Features**:
     *   **Fuzzy Search**: Matches terms with an edit distance of 1.
     *   **Stemming**: Uses the standard English analyzer for language-aware matching.

--- a/docs/authoring-resources.md
+++ b/docs/authoring-resources.md
@@ -204,7 +204,7 @@ When `index` is absent from `mcp-metadata.yaml`, discovery keeps scanning `mcp-r
 
 ### Not Yet Supported
 
-Persistence across restarts and live filesystem watching are not part of this release. The chunk catalog and search index are rebuilt fully at startup (in memory or a temporary directory); pick up content changes by restarting the server.
+Persistence across restarts is not part of this release: the chunk catalog and search index are rebuilt fully at startup, in memory or a temporary directory, with no watcher process behind it. Content changes are still picked up without a restart, though — a `search` call, a `read` call, or a resource read re-checks the content root (debounced to at most once every 2 seconds) and, only when something actually changed, re-assembles the catalog and rebuilds the index in place. See [Content Refresh](SPECIFICATIONS.md#content-refresh) for the trigger, the debounce, and how its error handling deliberately differs from the strict startup rules above.
 
 See [Configuration Reference](configuration.md) for the `--search-result-mode` flag that controls how much chunk detail the `search` tool returns, and the [Repository Docs example](../examples/repository-docs/) for a runnable configured-indexing setup.
 

--- a/examples/repository-docs/README.md
+++ b/examples/repository-docs/README.md
@@ -27,7 +27,7 @@ Add a manifest when you want a custom server name/instructions, or `index.includ
 - content mode is selected with --search-result-mode=content
 - base URIs read full documents; search-returned fragments read chunks
 - existing mcp-resources behavior remains when index is absent
-- persistence and live watching are not part of this release
+- persistence across restarts is not part of this release; mid-session content changes are still picked up via debounced refresh
 
 ### Usage
 
@@ -45,4 +45,4 @@ The first command returns chunk citations (title, URI, breadcrumb, and a snippet
 ## Notes (Both Variants)
 
 - No frontmatter is required in the indexed Markdown; `name`/`description` fall back to the first H1 (`#`) heading and first paragraph when frontmatter is absent. A document whose first heading is `##` or deeper gets an empty name.
-- The server rebuilds its chunk catalog and search index fully at startup. There is no persistence across restarts and no live filesystem watching — restart the server to pick up documentation changes.
+- The server rebuilds its chunk catalog and search index fully at startup; there is no persistence across restarts. You don't need to restart it to pick up documentation changes, though: a `search` call, a `read` call, or a resource read re-checks the content root (debounced to at most once every 2 seconds) and rebuilds the catalog and index in place when something changed. See [Content Refresh](../../docs/SPECIFICATIONS.md#content-refresh) for the details, including the brief pause a rebuild puts on concurrent searches.

--- a/internal/app/factory.go
+++ b/internal/app/factory.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"time"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/sha1n/mcp-acdc-server/internal/config"
@@ -50,6 +51,19 @@ func createMCPServer(ctx context.Context, settings *config.Settings, version str
 		discoverOpts = append(discoverOpts, resources.WithLenientIndex())
 	}
 
+	// Fingerprint before discovery so a file that changes between the two
+	// calls is seen as pending work by the first refresh check rather than
+	// silently folded into the seed digest. A fingerprint failure here is not
+	// fatal: a server that indexes fine must not refuse to start because a
+	// refresh gate could not be primed, so an empty digest is seeded instead
+	// and the first Revalidate call treats the content root as changed.
+	seedWalkDigest, err := resources.Fingerprint(ctx, cp, metadata.Index, discoverOpts...)
+	if err != nil {
+		slog.Warn("failed to fingerprint content root at startup; catalog refresh will re-discover on first check",
+			"error", err)
+		seedWalkDigest = ""
+	}
+
 	// Discover resources
 	discovery, err := deps.discover(ctx, cp, metadata.Index, settings.Scheme, discoverOpts...)
 	if err != nil {
@@ -58,13 +72,7 @@ func createMCPServer(ctx context.Context, settings *config.Settings, version str
 
 	warnIfLegacyLayoutIgnored(cp, resolved.defaulted, discovery)
 
-	var resourceOpts []resources.Option
-	if settings.CrossRef {
-		resourceOpts = append(resourceOpts, resources.WithTransformer(
-			resources.NewCrossRefTransformer(discovery.Sources, settings.Scheme),
-		))
-	}
-	resourceProvider, err := resources.NewResourceProvider(discovery.Sources, discovery.Chunks, resourceOpts...)
+	resourceProvider, err := assembleResourceProvider(discovery, settings.CrossRef, settings.Scheme)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create resource provider: %w", err)
 	}
@@ -86,10 +94,54 @@ func createMCPServer(ctx context.Context, settings *config.Settings, version str
 		return nil, nil, err
 	}
 
-	// Create MCP server
-	mcpServer := mcp.CreateServer(metadata, resourceProvider, promptProvider, searchService, settings.Search)
+	holder := resources.NewCatalogHolder(resourceProvider)
+
+	// The refresher closes over the metadata and discover options resolved
+	// once above, so a mid-session refresh applies the same zero-config
+	// leniency decision as startup rather than re-deciding it.
+	refresher := &catalogRefresher{
+		holder:   holder,
+		searcher: searchService,
+		fingerprint: func(ctx context.Context) (string, error) {
+			return resources.Fingerprint(ctx, cp, metadata.Index, discoverOpts...)
+		},
+		discover: func(ctx context.Context) (resources.DiscoveryResult, error) {
+			return deps.discover(ctx, cp, metadata.Index, settings.Scheme, discoverOpts...)
+		},
+		assemble: func(discovery resources.DiscoveryResult) (*resources.ResourceProvider, error) {
+			return assembleResourceProvider(discovery, settings.CrossRef, settings.Scheme)
+		},
+		now:           time.Now,
+		interval:      refreshInterval,
+		walkDigest:    seedWalkDigest,
+		contentDigest: computeContentDigest(discovery.Sources),
+	}
+	refresher.reindex = func(ctx context.Context, provider *resources.ResourceProvider) error {
+		return IndexResources(ctx, provider, refresher.searcher)
+	}
+
+	// Create MCP server. mcp.CreateServer needs the refresher to build the
+	// registrar it returns, so the registrar is bound onto the refresher only
+	// after this call — the narrow window Revalidate's nil-registrar guard
+	// covers.
+	mcpServer, registrar := mcp.CreateServer(metadata, holder, promptProvider, searchService, settings.Search, refresher)
+	refresher.bindRegistrar(registrar)
 
 	return mcpServer, searchService.Close, nil
+}
+
+// assembleResourceProvider builds the resource catalog from a discovery
+// result exactly the same way at startup and on every later refresh,
+// cross-ref transformer included, so a future change to provider options
+// cannot apply to only one of those call sites.
+func assembleResourceProvider(discovery resources.DiscoveryResult, crossRef bool, scheme string) (*resources.ResourceProvider, error) {
+	var opts []resources.Option
+	if crossRef {
+		opts = append(opts, resources.WithTransformer(
+			resources.NewCrossRefTransformer(discovery.Sources, scheme),
+		))
+	}
+	return resources.NewResourceProvider(discovery.Sources, discovery.Chunks, opts...)
 }
 
 // warnIfLegacyLayoutIgnored flags the likely cause of a silently empty

--- a/internal/app/factory_test.go
+++ b/internal/app/factory_test.go
@@ -479,6 +479,37 @@ func TestCreateMCPServer_PassesCallerContextToDiscovery(t *testing.T) {
 	cleanup()
 }
 
+// TestCreateMCPServer_FingerprintFailureAtStartupDoesNotStopConstruction pins
+// the deliberate startup design: a fingerprint failure only warns and seeds an
+// empty walk digest, it never fails construction. The manifest's include
+// pattern is invalid, which fails the real resources.Fingerprint call inside
+// createMCPServer; deps.discover is injected to succeed regardless of that
+// same metadata, isolating the fingerprint failure from the discovery failure
+// that identical invalid metadata would otherwise also produce.
+func TestCreateMCPServer_FingerprintFailureAtStartupDoesNotStopConstruction(t *testing.T) {
+	contentDir := writeMetadataOnly(t, `server:
+  name: test
+  version: "1"
+  instructions: test
+index:
+  include: ["/abs/pattern/**"]
+`)
+	deps := defaultFactoryDeps()
+	deps.discover = func(context.Context, *content.ContentProvider, *domain.IndexMetadata, string, ...resources.DiscoverOption) (resources.DiscoveryResult, error) {
+		return resources.DiscoveryResult{}, nil
+	}
+	deps.newSearch = func(config.SearchSettings) search.Searcher {
+		return &fakeSearcher{drain: true}
+	}
+
+	server, cleanup, err := createMCPServer(context.Background(), appTestSettings(contentDir), "test", deps)
+
+	require.NoError(t, err)
+	require.NotNil(t, server)
+	require.NotNil(t, cleanup)
+	cleanup()
+}
+
 func TestCreateMCPServer_FailsWhenConfiguredDiscoveryFails(t *testing.T) {
 	contentDir := t.TempDir()
 	metadata := `

--- a/internal/app/indexing_test.go
+++ b/internal/app/indexing_test.go
@@ -55,11 +55,7 @@ func (s *fakeSearcher) Index(_ context.Context, chunks <-chan domain.Chunk) erro
 }
 
 func (*fakeSearcher) Search(string, int) ([]search.SearchResult, error) { return nil, nil }
-func (*fakeSearcher) ReplaceSource(context.Context, string, []domain.Chunk) error {
-	return nil
-}
-func (*fakeSearcher) DeleteSource(context.Context, string) error { return nil }
-func (s *fakeSearcher) Close()                                   { s.closeCalls++ }
+func (s *fakeSearcher) Close()                                          { s.closeCalls++ }
 
 func TestIndexResources_Success(t *testing.T) {
 	streamer := &fakeChunkStreamer{chunks: []domain.Chunk{{ID: "one"}}}

--- a/internal/app/refresh.go
+++ b/internal/app/refresh.go
@@ -1,0 +1,155 @@
+package app
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/sha1n/mcp-acdc-server/internal/domain"
+	"github.com/sha1n/mcp-acdc-server/internal/mcp"
+	"github.com/sha1n/mcp-acdc-server/internal/resources"
+	"github.com/sha1n/mcp-acdc-server/internal/search"
+)
+
+// refreshInterval bounds how often a request may pay for a filesystem walk. It
+// collapses a burst of calls into one revalidation while keeping the staleness
+// window far below the latency of a person editing a document and then asking
+// about it.
+const refreshInterval = 2 * time.Second
+
+// catalogRefresher implements mcp.Revalidator by re-walking the content root
+// on a debounced schedule and republishing the catalog and search index only
+// when something the walk found actually changed. Its filesystem and indexing
+// collaborators are injected as function fields so tests can drive the
+// debounce and change-detection logic without a real content root.
+type catalogRefresher struct {
+	mu sync.Mutex
+
+	holder    *resources.CatalogHolder
+	searcher  search.Searcher
+	registrar *mcp.ResourceRegistrar
+
+	fingerprint func(context.Context) (string, error)
+	discover    func(context.Context) (resources.DiscoveryResult, error)
+	assemble    func(resources.DiscoveryResult) (*resources.ResourceProvider, error)
+	reindex     func(context.Context, *resources.ResourceProvider) error
+
+	now      func() time.Time
+	interval time.Duration
+
+	lastCheck     time.Time
+	walkDigest    string
+	contentDigest string
+}
+
+var _ mcp.Revalidator = (*catalogRefresher)(nil)
+
+// bindRegistrar binds the registrar built alongside this refresher.
+// mcp.CreateServer needs a Revalidator to construct the ResourceRegistrar it
+// returns, so registrar cannot be set at construction time; it is bound here,
+// under mu like every other field Revalidate reads, once CreateServer
+// returns it.
+func (r *catalogRefresher) bindRegistrar(registrar *mcp.ResourceRegistrar) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.registrar = registrar
+}
+
+// Revalidate re-walks the content root at most once per interval and
+// republishes the catalog and search index only when the walk finds a
+// genuine content change. It returns immediately while registrar is nil,
+// which covers only the narrow window during server construction: mcp.
+// CreateServer needs a Revalidator to build the registrar it returns, so the
+// registrar cannot be bound to this refresher until after that call, and no
+// request reaches the server before that binding completes.
+func (r *catalogRefresher) Revalidate(ctx context.Context) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.registrar == nil {
+		return
+	}
+
+	now := r.now()
+	if !r.lastCheck.IsZero() && now.Sub(r.lastCheck) < r.interval {
+		return
+	}
+	r.lastCheck = now
+
+	walkDigest, err := r.fingerprint(ctx)
+	if err != nil {
+		slog.Warn("Catalog refresh failed to fingerprint content root, retrying next interval", "error", err)
+		return
+	}
+	if walkDigest == r.walkDigest {
+		// Idle path: the file set's paths, sizes and mtimes are unchanged, so
+		// there is nothing to discover, index or republish.
+		return
+	}
+
+	// A mid-session discovery, assembly or indexing failure must never take
+	// down a live server: the previously published catalog and index stay in
+	// place, the stored digests are left untouched, and the next interval's
+	// walk retries from scratch.
+	discovery, err := r.discover(ctx)
+	if err != nil {
+		slog.Warn("Catalog refresh discovery failed, retrying next interval", "error", err)
+		return
+	}
+
+	newContentDigest := computeContentDigest(discovery.Sources)
+	if newContentDigest == r.contentDigest {
+		// Pure touch: the walk saw different paths, sizes or mtimes, but
+		// every source's content fingerprint is unchanged, so there is
+		// nothing to re-index or republish. The walk digest still advances
+		// so an unchanged repeat of this same touch is quiet next time.
+		r.walkDigest = walkDigest
+		return
+	}
+
+	provider, err := r.assemble(discovery)
+	if err != nil {
+		slog.Warn("Catalog refresh failed to assemble resource provider, retrying next interval", "error", err)
+		return
+	}
+	if err := r.reindex(ctx, provider); err != nil {
+		slog.Warn("Catalog refresh failed to reindex content, retrying next interval", "error", err)
+		return
+	}
+
+	// The index is replaced (inside reindex, above) before the catalog is
+	// published here, and the catalog is published before the registrar is
+	// synced against it. This ordering is not observable through search,
+	// read or resource-read: every one of those handlers calls Revalidate
+	// before touching the catalog or index, and Revalidate holds r.mu for
+	// its entire body, so a concurrent caller blocks here until this swap
+	// and sync have both completed rather than ever observing a call to
+	// one collaborator and not the other. Only resources/list can lag: the
+	// SDK serves it without a handler to hook, so it is the one surface
+	// that is not gated by Revalidate and can reflect an older listing
+	// until the next call that does trigger it.
+	r.holder.Swap(provider)
+	r.registrar.Sync(provider)
+
+	r.walkDigest = walkDigest
+	r.contentDigest = newContentDigest
+	slog.Info("Catalog refresh republished catalog", "sources", len(discovery.Sources))
+}
+
+// computeContentDigest digests the selected source set's content fingerprints
+// in discovery order: a SHA-256 over, per source, its URI, a NUL separator,
+// its Fingerprint, and a newline. Unlike Fingerprint (which detects that the
+// file set may have changed at all), this detects whether it actually did.
+func computeContentDigest(sources []domain.SourceDocument) string {
+	hasher := sha256.New()
+	for _, source := range sources {
+		// hash.Hash.Write never returns an error (per the io.Writer contract
+		// it documents), so the write's result is deliberately discarded.
+		_, _ = fmt.Fprintf(hasher, "%s\x00%s\n", source.URI, source.Fingerprint)
+	}
+	return hex.EncodeToString(hasher.Sum(nil))
+}

--- a/internal/app/refresh_test.go
+++ b/internal/app/refresh_test.go
@@ -1,0 +1,453 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	mcpserver "github.com/sha1n/mcp-acdc-server/internal/mcp"
+	"github.com/sha1n/mcp-acdc-server/internal/resources"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeClock gives tests control over the instant catalogRefresher.now reports,
+// without depending on wall-clock timing.
+type fakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{now: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+// noopTestRevalidator satisfies mcpserver.Revalidator without triggering any
+// refresh, for wiring a ResourceRegistrar the tests do not intend to drive
+// through its own Revalidate hook.
+type noopTestRevalidator struct{}
+
+func (noopTestRevalidator) Revalidate(context.Context) {}
+
+// newTestRegistrar builds a real ResourceRegistrar backed by an unconnected
+// in-process *mcp.Server: catalogRefresher.registrar is a concrete type, not
+// an interface, so observing whether Sync ran requires a genuine registrar
+// and, where a test needs to see the effect, a connected in-memory client. The
+// backing server is returned alongside the registrar so a test can query it.
+func newTestRegistrar(t *testing.T, catalog resources.Catalog) (*mcpserver.ResourceRegistrar, *mcpsdk.Server) {
+	t.Helper()
+	s := mcpsdk.NewServer(&mcpsdk.Implementation{Name: "test-server", Version: "1.0.0"}, nil)
+	registrar := mcpserver.NewResourceRegistrar(s, catalog, noopTestRevalidator{})
+	registrar.Sync(catalog)
+	return registrar, s
+}
+
+// listResourceURIs connects a fresh in-memory client to the server backing
+// registrar and returns the URIs currently registered, letting a test observe
+// whether a ResourceRegistrar.Sync call actually changed the served listing.
+// Both ends of the connection are closed before returning: the SDK's
+// changeAndNotify branches on whether s has any live sessions, so a server
+// session left open here would accumulate across calls within a test and
+// skew that behavior for callers made afterwards.
+func listResourceURIs(t *testing.T, s *mcpsdk.Server) []string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client := mcpsdk.NewClient(&mcpsdk.Implementation{Name: "test-client", Version: "1.0.0"}, nil)
+	serverTransport, clientTransport := mcpsdk.NewInMemoryTransports()
+	serverSession, err := s.Connect(ctx, serverTransport, nil)
+	require.NoError(t, err)
+	defer func() { _ = serverSession.Close() }()
+	session, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+	defer func() { _ = session.Close() }()
+
+	result, err := session.ListResources(ctx, nil)
+	require.NoError(t, err)
+
+	uris := make([]string, len(result.Resources))
+	for i, r := range result.Resources {
+		uris[i] = r.URI
+	}
+	return uris
+}
+
+func mustProvider(t *testing.T, sources []resources.ResourceDefinition) *resources.ResourceProvider {
+	t.Helper()
+	p, err := resources.NewResourceProvider(sources, nil)
+	require.NoError(t, err)
+	return p
+}
+
+// newTestRefresher builds a catalogRefresher with fakes that never fire
+// unless a test overrides them, backed by a real holder/registrar pair seeded
+// with initialProvider. The registrar's backing server is returned alongside
+// it so a test can verify Sync's effect via listResourceURIs.
+func newTestRefresher(t *testing.T, initialProvider *resources.ResourceProvider, clock *fakeClock) (*catalogRefresher, *mcpsdk.Server) {
+	t.Helper()
+	holder := resources.NewCatalogHolder(initialProvider)
+	registrar, server := newTestRegistrar(t, holder)
+
+	return &catalogRefresher{
+		holder:    holder,
+		registrar: registrar,
+		fingerprint: func(context.Context) (string, error) {
+			t.Fatal("fingerprint should not have been called")
+			return "", nil
+		},
+		discover: func(context.Context) (resources.DiscoveryResult, error) {
+			t.Fatal("discover should not have been called")
+			return resources.DiscoveryResult{}, nil
+		},
+		assemble: func(resources.DiscoveryResult) (*resources.ResourceProvider, error) {
+			t.Fatal("assemble should not have been called")
+			return nil, nil
+		},
+		reindex: func(context.Context, *resources.ResourceProvider) error {
+			t.Fatal("reindex should not have been called")
+			return nil
+		},
+		now:      clock.Now,
+		interval: refreshInterval,
+	}, server
+}
+
+func TestCatalogRefresher_Revalidate_RegistrarNil_ReturnsImmediately(t *testing.T) {
+	clock := newFakeClock()
+	r := &catalogRefresher{
+		now:      clock.Now,
+		interval: refreshInterval,
+		fingerprint: func(context.Context) (string, error) {
+			t.Fatal("fingerprint should not have been called while registrar is nil")
+			return "", nil
+		},
+	}
+
+	r.Revalidate(context.Background())
+	// No panic and no fingerprint call: the construction-window guard fired.
+}
+
+func TestCatalogRefresher_Revalidate_TwoCallsWithinInterval_FingerprintsOnce(t *testing.T) {
+	clock := newFakeClock()
+	initial := mustProvider(t, nil)
+	r, _ := newTestRefresher(t, initial, clock)
+	r.walkDigest = "digest-a" // matches the fingerprint below: the idle path, not discovery, follows
+
+	var fingerprintCalls atomic.Int32
+	r.fingerprint = func(context.Context) (string, error) {
+		fingerprintCalls.Add(1)
+		return "digest-a", nil
+	}
+
+	r.Revalidate(context.Background())
+	r.Revalidate(context.Background())
+
+	require.Equal(t, int32(1), fingerprintCalls.Load())
+}
+
+func TestCatalogRefresher_Revalidate_CallAfterInterval_FingerprintsAgain(t *testing.T) {
+	clock := newFakeClock()
+	initial := mustProvider(t, nil)
+	r, _ := newTestRefresher(t, initial, clock)
+	r.walkDigest = "digest-a" // matches the fingerprint below: the idle path, not discovery, follows
+
+	var fingerprintCalls atomic.Int32
+	r.fingerprint = func(context.Context) (string, error) {
+		fingerprintCalls.Add(1)
+		return "digest-a", nil
+	}
+
+	r.Revalidate(context.Background())
+	clock.Advance(refreshInterval)
+	r.Revalidate(context.Background())
+
+	require.Equal(t, int32(2), fingerprintCalls.Load())
+}
+
+func TestCatalogRefresher_Revalidate_UnchangedWalkDigest_SkipsDiscovery(t *testing.T) {
+	clock := newFakeClock()
+	initial := mustProvider(t, nil)
+	r, server := newTestRefresher(t, initial, clock)
+	r.walkDigest = "digest-a"
+
+	r.fingerprint = func(context.Context) (string, error) {
+		return "digest-a", nil
+	}
+	// discover/assemble/reindex remain the t.Fatal fakes from newTestRefresher:
+	// if the idle path is broken, this test fails loudly rather than silently
+	// passing on an unexercised path.
+
+	r.Revalidate(context.Background())
+
+	require.Equal(t, "digest-a", r.walkDigest)
+	require.Same(t, initial, r.holder.Current())
+	require.Empty(t, listResourceURIs(t, server), "the idle path must not touch the registered listing")
+}
+
+func TestCatalogRefresher_Revalidate_ChangedWalkDigestEqualContentDigest_UpdatesWalkDigestOnly(t *testing.T) {
+	clock := newFakeClock()
+	initial := mustProvider(t, nil)
+	r, server := newTestRefresher(t, initial, clock)
+	r.walkDigest = "digest-a"
+
+	sameSources := []resources.ResourceDefinition{
+		{URI: "acdc://a", Fingerprint: "same-content"},
+	}
+	// Seed the content digest to match the source set discover will return,
+	// so the touch is recognized as content-equal.
+	seededContentDigest := computeContentDigest(sameSources)
+	r.contentDigest = seededContentDigest
+
+	var discoverCalls atomic.Int32
+	r.fingerprint = func(context.Context) (string, error) {
+		return "digest-b", nil // walk digest changed: a file was touched
+	}
+	r.discover = func(context.Context) (resources.DiscoveryResult, error) {
+		discoverCalls.Add(1)
+		return resources.DiscoveryResult{Sources: sameSources}, nil
+	}
+	// assemble/reindex remain the t.Fatal fakes: a pure touch must not reach
+	// them.
+
+	r.Revalidate(context.Background())
+
+	require.Equal(t, int32(1), discoverCalls.Load())
+	require.Equal(t, "digest-b", r.walkDigest, "walk digest must advance so a repeat of this touch is quiet")
+	require.Equal(t, seededContentDigest, r.contentDigest, "content digest must not change on a pure touch")
+	require.Same(t, initial, r.holder.Current(), "no swap on a pure touch")
+	require.Empty(t, listResourceURIs(t, server), "a pure touch must not sync the registrar")
+}
+
+func TestCatalogRefresher_Revalidate_ChangedContent_AssemblesReindexesSwapsAndSyncs(t *testing.T) {
+	clock := newFakeClock()
+	initial := mustProvider(t, []resources.ResourceDefinition{
+		{URI: "acdc://old", Name: "Old", MIMEType: "text/markdown", Content: "old"},
+	})
+	r, refresherServer := newTestRefresher(t, initial, clock)
+	r.walkDigest = "digest-a"
+	r.contentDigest = "content-a"
+
+	discovery := resources.DiscoveryResult{
+		Sources: []resources.ResourceDefinition{
+			{URI: "acdc://new", Name: "New", MIMEType: "text/markdown", Content: "new", Fingerprint: "f2"},
+		},
+	}
+	newProvider := mustProvider(t, discovery.Sources)
+
+	var assembleCalls, reindexCalls atomic.Int32
+	var reindexSawProvider *resources.ResourceProvider
+
+	r.fingerprint = func(context.Context) (string, error) { return "digest-b", nil }
+	r.discover = func(context.Context) (resources.DiscoveryResult, error) { return discovery, nil }
+	r.assemble = func(got resources.DiscoveryResult) (*resources.ResourceProvider, error) {
+		assembleCalls.Add(1)
+		require.Equal(t, discovery, got)
+		return newProvider, nil
+	}
+	r.reindex = func(_ context.Context, provider *resources.ResourceProvider) error {
+		reindexCalls.Add(1)
+		reindexSawProvider = provider
+		// The holder must not be swapped yet: reindex runs before the swap,
+		// not after. (Swap-before-Sync is not independently observable this
+		// way since both happen after reindex returns.)
+		require.Same(t, initial, r.holder.Current(), "reindex must run before the catalog is swapped")
+		return nil
+	}
+
+	r.Revalidate(context.Background())
+
+	require.Equal(t, int32(1), assembleCalls.Load())
+	require.Equal(t, int32(1), reindexCalls.Load())
+	require.Same(t, newProvider, reindexSawProvider)
+
+	require.Same(t, newProvider, r.holder.Current(), "holder must be swapped to the assembled/reindexed provider")
+	uris := listResourceURIs(t, refresherServer)
+	require.ElementsMatch(t, []string{"acdc://new"}, uris, "registrar must be synced to the new listing")
+
+	require.Equal(t, "digest-b", r.walkDigest)
+	require.Equal(t, computeContentDigest(discovery.Sources), r.contentDigest)
+}
+
+func TestCatalogRefresher_Revalidate_FingerprintError_LeavesSnapshotAndDigestsUntouched(t *testing.T) {
+	clock := newFakeClock()
+	initial := mustProvider(t, nil)
+	r, server := newTestRefresher(t, initial, clock)
+	r.walkDigest = "digest-a"
+	r.contentDigest = "content-a"
+
+	r.fingerprint = func(context.Context) (string, error) {
+		return "", errors.New("fingerprint boom")
+	}
+
+	r.Revalidate(context.Background())
+
+	require.Equal(t, "digest-a", r.walkDigest)
+	require.Equal(t, "content-a", r.contentDigest)
+	require.Same(t, initial, r.holder.Current())
+	require.Empty(t, listResourceURIs(t, server), "a fingerprint failure must not sync the registrar")
+}
+
+func TestCatalogRefresher_Revalidate_DiscoverError_LeavesSnapshotAndDigestsUntouched(t *testing.T) {
+	clock := newFakeClock()
+	initial := mustProvider(t, nil)
+	r, server := newTestRefresher(t, initial, clock)
+	r.walkDigest = "digest-a"
+	r.contentDigest = "content-a"
+
+	r.fingerprint = func(context.Context) (string, error) { return "digest-b", nil }
+	r.discover = func(context.Context) (resources.DiscoveryResult, error) {
+		return resources.DiscoveryResult{}, errors.New("discover boom")
+	}
+
+	r.Revalidate(context.Background())
+
+	require.Equal(t, "digest-a", r.walkDigest)
+	require.Equal(t, "content-a", r.contentDigest)
+	require.Same(t, initial, r.holder.Current())
+	require.Empty(t, listResourceURIs(t, server), "a discovery failure must not sync the registrar")
+}
+
+func TestCatalogRefresher_Revalidate_AssembleError_LeavesSnapshotAndDigestsUntouched(t *testing.T) {
+	clock := newFakeClock()
+	initial := mustProvider(t, nil)
+	r, server := newTestRefresher(t, initial, clock)
+	r.walkDigest = "digest-a"
+	r.contentDigest = "content-a"
+
+	discovery := resources.DiscoveryResult{
+		Sources: []resources.ResourceDefinition{{URI: "acdc://a", Fingerprint: "f2"}},
+	}
+	r.fingerprint = func(context.Context) (string, error) { return "digest-b", nil }
+	r.discover = func(context.Context) (resources.DiscoveryResult, error) { return discovery, nil }
+	r.assemble = func(resources.DiscoveryResult) (*resources.ResourceProvider, error) {
+		return nil, errors.New("assemble boom")
+	}
+
+	r.Revalidate(context.Background())
+
+	require.Equal(t, "digest-a", r.walkDigest)
+	require.Equal(t, "content-a", r.contentDigest)
+	require.Same(t, initial, r.holder.Current())
+	require.Empty(t, listResourceURIs(t, server), "an assemble failure must not sync the registrar")
+}
+
+func TestCatalogRefresher_Revalidate_ReindexError_LeavesSnapshotAndDigestsUntouched(t *testing.T) {
+	clock := newFakeClock()
+	initial := mustProvider(t, nil)
+	r, server := newTestRefresher(t, initial, clock)
+	r.walkDigest = "digest-a"
+	r.contentDigest = "content-a"
+
+	discovery := resources.DiscoveryResult{
+		Sources: []resources.ResourceDefinition{{URI: "acdc://a", Fingerprint: "f2"}},
+	}
+	assembled := mustProvider(t, discovery.Sources)
+	r.fingerprint = func(context.Context) (string, error) { return "digest-b", nil }
+	r.discover = func(context.Context) (resources.DiscoveryResult, error) { return discovery, nil }
+	r.assemble = func(resources.DiscoveryResult) (*resources.ResourceProvider, error) { return assembled, nil }
+	r.reindex = func(context.Context, *resources.ResourceProvider) error {
+		return errors.New("reindex boom")
+	}
+
+	r.Revalidate(context.Background())
+
+	require.Equal(t, "digest-a", r.walkDigest)
+	require.Equal(t, "content-a", r.contentDigest)
+	require.Same(t, initial, r.holder.Current(), "the previously published snapshot must survive a reindex failure")
+	require.Empty(t, listResourceURIs(t, server), "a reindex failure must not sync the registrar")
+}
+
+// TestCatalogRefresher_Revalidate_PersistentFingerprintError_DebouncesAcrossFailures
+// pins lastCheck's placement: it is set once per interval regardless of
+// whether fingerprint succeeds, so a persistently failing fingerprint still
+// walks at most once per interval rather than re-walking on every call.
+func TestCatalogRefresher_Revalidate_PersistentFingerprintError_DebouncesAcrossFailures(t *testing.T) {
+	clock := newFakeClock()
+	initial := mustProvider(t, nil)
+	r, _ := newTestRefresher(t, initial, clock)
+
+	var fingerprintCalls atomic.Int32
+	r.fingerprint = func(context.Context) (string, error) {
+		fingerprintCalls.Add(1)
+		return "", errors.New("fingerprint boom")
+	}
+
+	r.Revalidate(context.Background())
+	r.Revalidate(context.Background())
+
+	require.Equal(t, int32(1), fingerprintCalls.Load())
+}
+
+// TestCatalogRefresher_Revalidate_ConcurrentCalls_SingleChangeProducesOneRebuild
+// exercises the mutex under -race and confirms the debounce collapses a burst
+// of concurrent callers reacting to one content change into exactly one
+// rebuild.
+func TestCatalogRefresher_Revalidate_ConcurrentCalls_SingleChangeProducesOneRebuild(t *testing.T) {
+	clock := newFakeClock()
+	initial := mustProvider(t, nil)
+	r, _ := newTestRefresher(t, initial, clock)
+	r.walkDigest = "digest-a"
+	r.contentDigest = "content-a"
+
+	discovery := resources.DiscoveryResult{
+		Sources: []resources.ResourceDefinition{{URI: "acdc://a", Fingerprint: "f2"}},
+	}
+	assembled := mustProvider(t, discovery.Sources)
+
+	var fingerprintCalls, discoverCalls, assembleCalls, reindexCalls atomic.Int32
+	r.fingerprint = func(context.Context) (string, error) {
+		fingerprintCalls.Add(1)
+		return "digest-b", nil
+	}
+	r.discover = func(context.Context) (resources.DiscoveryResult, error) {
+		discoverCalls.Add(1)
+		return discovery, nil
+	}
+	r.assemble = func(resources.DiscoveryResult) (*resources.ResourceProvider, error) {
+		assembleCalls.Add(1)
+		return assembled, nil
+	}
+	r.reindex = func(context.Context, *resources.ResourceProvider) error {
+		reindexCalls.Add(1)
+		return nil
+	}
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			r.Revalidate(context.Background())
+		}()
+	}
+	wg.Wait()
+
+	// The fake clock never advances and the debounce check runs inside the
+	// same critical section as the rest of the algorithm, so exactly one of
+	// the twenty concurrent callers gets past step 1; the rest see a
+	// just-set lastCheck and return immediately. A leaked debounce (e.g. the
+	// interval check reading state outside the lock) would let more than one
+	// goroutine reach these collaborators.
+	require.Equal(t, int32(1), fingerprintCalls.Load())
+	require.Equal(t, int32(1), discoverCalls.Load())
+	require.Equal(t, int32(1), assembleCalls.Load())
+	require.Equal(t, int32(1), reindexCalls.Load())
+	require.Same(t, assembled, r.holder.Current())
+}

--- a/internal/mcp/registrar.go
+++ b/internal/mcp/registrar.go
@@ -1,0 +1,93 @@
+package mcp
+
+import (
+	"log/slog"
+	"net/url"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/sha1n/mcp-acdc-server/internal/resources"
+)
+
+// ResourceRegistrar keeps a server's registered resources reconciled with the
+// catalog snapshot it is given, so notifications/resources/list_changed fires
+// on a genuine change to the resource set and not on every refresh.
+//
+// It is not safe for concurrent use; its caller serializes Sync calls.
+type ResourceRegistrar struct {
+	server      *mcp.Server
+	catalog     resources.Catalog
+	revalidator Revalidator
+	registered  map[string]mcp.Resource
+}
+
+// NewResourceRegistrar creates a registrar that registers resources on s and
+// dispatches their reads through catalog. catalog is retained and handed to
+// every resource handler Sync registers, so a later Swap of a *resources.
+// CatalogHolder passed here is observed by those handlers even though they
+// were registered against an earlier snapshot.
+//
+// revalidator must not be nil: it is invoked directly from the resource
+// handlers Sync registers, with no nil check on that path. mcp.CreateServer
+// is the only caller with a legitimate reason to pass one in, and it
+// normalizes nil to a no-op Revalidator before reaching here; any other
+// caller must supply a real Revalidator (or a no-op of its own) up front.
+func NewResourceRegistrar(s *mcp.Server, catalog resources.Catalog, revalidator Revalidator) *ResourceRegistrar {
+	return &ResourceRegistrar{
+		server:      s,
+		catalog:     catalog,
+		revalidator: revalidator,
+		registered:  make(map[string]mcp.Resource),
+	}
+}
+
+// Sync reconciles the server's registered resources with catalog.
+//
+// A resource whose URI fails url.Parse is skipped rather than registered:
+// mcp.Server.AddResource panics on exactly that input, and an ASCII control
+// character — illegal in a URL but legal in a relative file path on Linux and
+// macOS — is enough to trigger it. The skipped URI is left out of the next
+// registered set entirely so it is never mistaken for something the server
+// already holds; a later Sync call keeps re-validating and re-warning on it
+// rather than silently treating it as registered or attempting to remove a
+// URI the server was never given.
+func (r *ResourceRegistrar) Sync(catalog resources.Catalog) {
+	listing := catalog.ListResources()
+
+	next := make(map[string]mcp.Resource, len(listing))
+	for _, res := range listing {
+		if _, err := url.Parse(res.URI); err != nil {
+			slog.Warn("Skipping resource with unparseable URI", "uri", res.URI, "error", err)
+			continue
+		}
+		next[res.URI] = res
+	}
+
+	var removedURIs []string
+	for uri := range r.registered {
+		if _, ok := next[uri]; !ok {
+			removedURIs = append(removedURIs, uri)
+		}
+	}
+	if len(removedURIs) > 0 {
+		r.server.RemoveResources(removedURIs...)
+	}
+
+	for _, res := range listing {
+		if _, valid := next[res.URI]; !valid {
+			continue // unparseable URI, already logged and excluded above
+		}
+		if prev, existed := r.registered[res.URI]; existed && resourceMetadataEqual(prev, res) {
+			continue
+		}
+		r.server.AddResource(&res, makeResourceHandler(r.catalog, r.revalidator, res.URI))
+	}
+
+	r.registered = next
+}
+
+// resourceMetadataEqual reports whether the fields the MCP resources/list
+// response exposes to clients are identical. mcp.Resource is not reliably
+// comparable with ==, since it may grow uncomparable fields.
+func resourceMetadataEqual(a, b mcp.Resource) bool {
+	return a.Name == b.Name && a.Description == b.Description && a.MIMEType == b.MIMEType
+}

--- a/internal/mcp/registrar_test.go
+++ b/internal/mcp/registrar_test.go
@@ -1,0 +1,197 @@
+package mcp
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/sha1n/mcp-acdc-server/internal/domain"
+	"github.com/sha1n/mcp-acdc-server/internal/resources"
+	"github.com/stretchr/testify/require"
+)
+
+// notificationSettleDelay must exceed the SDK's internal list-changed
+// notification debounce so a test can tell "no notification was sent" apart
+// from "the notification just hasn't arrived yet".
+const notificationSettleDelay = 50 * time.Millisecond
+
+// listCatalog is a resources.Catalog whose listing a test sets directly,
+// independent of the content resources.NewResourceProvider would otherwise
+// require.
+type listCatalog struct {
+	resourcesList []mcp.Resource
+}
+
+func (c listCatalog) ListResources() []mcp.Resource { return c.resourcesList }
+
+func (c listCatalog) ReadResource(string) (string, error) { return "", nil }
+
+func (c listCatalog) StreamChunks(_ context.Context, ch chan<- domain.Chunk) error {
+	close(ch)
+	return nil
+}
+
+func (c listCatalog) StreamResources(_ context.Context, ch chan<- domain.Document) error {
+	close(ch)
+	return nil
+}
+
+func newTestServer() *mcp.Server {
+	return mcp.NewServer(&mcp.Implementation{Name: "test-server", Version: "1.0.0"}, nil)
+}
+
+// connectClient connects a client (and, if onResourceListChanged is non-nil,
+// wires it to observe notifications/resources/list_changed) to s over an
+// in-memory transport, returning the session and a cleanup func.
+func connectClient(ctx context.Context, t *testing.T, s *mcp.Server, onResourceListChanged func()) *mcp.ClientSession {
+	t.Helper()
+
+	var handler func(context.Context, *mcp.ResourceListChangedRequest)
+	if onResourceListChanged != nil {
+		handler = func(context.Context, *mcp.ResourceListChangedRequest) { onResourceListChanged() }
+	}
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "1.0.0"}, &mcp.ClientOptions{
+		ResourceListChangedHandler: handler,
+	})
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	_, err := s.Connect(ctx, serverTransport, nil)
+	require.NoError(t, err)
+	session, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = session.Close() })
+
+	return session
+}
+
+func TestResourceRegistrar_Sync_IdenticalCatalog_NoNotification(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	s := newTestServer()
+	catalog := listCatalog{resourcesList: []mcp.Resource{
+		{URI: "acdc://a", Name: "A", Description: "doc a", MIMEType: "text/markdown"},
+	}}
+
+	registrar := NewResourceRegistrar(s, catalog, noopRevalidator{})
+	registrar.Sync(catalog) // initial registration, before any session connects
+
+	var notifications atomic.Int64
+	connectClient(ctx, t, s, func() { notifications.Add(1) })
+
+	// Resyncing the identical catalog must add and remove nothing, and so
+	// must not trigger notifications/resources/list_changed.
+	registrar.Sync(catalog)
+
+	time.Sleep(notificationSettleDelay)
+	require.Equal(t, int64(0), notifications.Load())
+}
+
+func TestResourceRegistrar_Sync_AddRemoveChange_ProducesExactSet(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	s := newTestServer()
+	initial := listCatalog{resourcesList: []mcp.Resource{
+		{URI: "acdc://keep", Name: "Keep", Description: "unchanged", MIMEType: "text/markdown"},
+		{URI: "acdc://remove", Name: "Remove", Description: "goes away", MIMEType: "text/markdown"},
+		{URI: "acdc://change", Name: "Change", Description: "old description", MIMEType: "text/markdown"},
+	}}
+
+	registrar := NewResourceRegistrar(s, initial, noopRevalidator{})
+	registrar.Sync(initial)
+
+	updated := listCatalog{resourcesList: []mcp.Resource{
+		{URI: "acdc://keep", Name: "Keep", Description: "unchanged", MIMEType: "text/markdown"},
+		{URI: "acdc://change", Name: "Change", Description: "new description", MIMEType: "text/markdown"},
+		{URI: "acdc://added", Name: "Added", Description: "brand new", MIMEType: "text/markdown"},
+	}}
+	registrar.Sync(updated)
+
+	session := connectClient(ctx, t, s, nil)
+	result, err := session.ListResources(ctx, nil)
+	require.NoError(t, err)
+
+	got := make(map[string]*mcp.Resource, len(result.Resources))
+	for _, r := range result.Resources {
+		got[r.URI] = r
+	}
+
+	require.Len(t, got, 3)
+	require.NotContains(t, got, "acdc://remove")
+	require.Contains(t, got, "acdc://keep")
+	require.Contains(t, got, "acdc://added")
+	require.Contains(t, got, "acdc://change")
+	require.Equal(t, "new description", got["acdc://change"].Description)
+}
+
+// TestResourceRegistrar_Sync_UnparseableURI_SkippedWithoutPanic verifies that
+// a resource whose URI fails url.Parse (an ASCII control character is legal
+// in a relative path on Linux and macOS, but not in a URL) is skipped rather
+// than reaching mcp.Server.AddResource, which panics on exactly this input,
+// and that every other resource in the same Sync call still registers.
+func TestResourceRegistrar_Sync_UnparseableURI_SkippedWithoutPanic(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	s := newTestServer()
+	catalog := listCatalog{resourcesList: []mcp.Resource{
+		{URI: "acdc://good-before", Name: "Before", Description: "fine", MIMEType: "text/markdown"},
+		{URI: "acdc://docs/a\nb.md", Name: "Bad", Description: "control character in URI", MIMEType: "text/markdown"},
+		{URI: "acdc://good-after", Name: "After", Description: "fine", MIMEType: "text/markdown"},
+	}}
+
+	registrar := NewResourceRegistrar(s, catalog, noopRevalidator{})
+
+	require.NotPanics(t, func() { registrar.Sync(catalog) })
+
+	session := connectClient(ctx, t, s, nil)
+	result, err := session.ListResources(ctx, nil)
+	require.NoError(t, err)
+
+	got := make(map[string]*mcp.Resource, len(result.Resources))
+	for _, r := range result.Resources {
+		got[r.URI] = r
+	}
+	require.Len(t, got, 2, "only the two parseable resources should be registered")
+	require.Contains(t, got, "acdc://good-before")
+	require.Contains(t, got, "acdc://good-after")
+	require.NotContains(t, got, "acdc://docs/a\nb.md")
+}
+
+// TestResourceRegistrar_HandlersReadThroughConstructorHolder verifies that a
+// registered resource handler resolves reads through the catalog passed to
+// NewResourceRegistrar (which a caller may Swap later), never through the
+// listing snapshot passed to a particular Sync call.
+func TestResourceRegistrar_HandlersReadThroughConstructorHolder(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	s := newTestServer()
+
+	initialProvider, err := resources.NewResourceProvider([]resources.ResourceDefinition{
+		{URI: "acdc://doc", Name: "Doc", Description: "d", MIMEType: "text/markdown", Content: "old content"},
+	}, nil)
+	require.NoError(t, err)
+	holder := resources.NewCatalogHolder(initialProvider)
+
+	registrar := NewResourceRegistrar(s, holder, noopRevalidator{})
+	// Sync with a listing snapshot distinct from the holder, so a pass
+	// proves reads resolve through the holder and not this value.
+	registrar.Sync(listCatalog{resourcesList: holder.ListResources()})
+
+	updatedProvider, err := resources.NewResourceProvider([]resources.ResourceDefinition{
+		{URI: "acdc://doc", Name: "Doc", Description: "d", MIMEType: "text/markdown", Content: "new content"},
+	}, nil)
+	require.NoError(t, err)
+	holder.Swap(updatedProvider)
+
+	session := connectClient(ctx, t, s, nil)
+	result, err := session.ReadResource(ctx, &mcp.ReadResourceParams{URI: "acdc://doc"})
+	require.NoError(t, err)
+	require.Len(t, result.Contents, 1)
+	require.Equal(t, "new content", result.Contents[0].Text)
+}

--- a/internal/mcp/revalidator.go
+++ b/internal/mcp/revalidator.go
@@ -1,0 +1,15 @@
+package mcp
+
+import "context"
+
+// Revalidator refreshes the served catalog before a request reads it.
+type Revalidator interface {
+	Revalidate(ctx context.Context)
+}
+
+// noopRevalidator is the Revalidator used when a caller does not supply one:
+// requests are served from whatever catalog snapshot is current, without
+// ever triggering a refresh.
+type noopRevalidator struct{}
+
+func (noopRevalidator) Revalidate(context.Context) {}

--- a/internal/mcp/revalidator_test.go
+++ b/internal/mcp/revalidator_test.go
@@ -1,0 +1,111 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/sha1n/mcp-acdc-server/internal/config"
+	"github.com/sha1n/mcp-acdc-server/internal/domain"
+	"github.com/sha1n/mcp-acdc-server/internal/search"
+	"github.com/stretchr/testify/require"
+)
+
+// tracingRevalidator records that Revalidate ran onto a trace shared with a
+// tracingCatalog or tracingSearcher, so a test can assert the revalidation
+// happens strictly before the catalog or searcher is touched.
+type tracingRevalidator struct {
+	trace *[]string
+}
+
+func (r tracingRevalidator) Revalidate(context.Context) {
+	*r.trace = append(*r.trace, "revalidate")
+}
+
+// tracingCatalog is a minimal resources.Catalog that records reads onto the
+// trace a tracingRevalidator writes to.
+type tracingCatalog struct {
+	trace   *[]string
+	content string
+}
+
+func (c tracingCatalog) ListResources() []mcp.Resource { return nil }
+
+func (c tracingCatalog) ReadResource(string) (string, error) {
+	*c.trace = append(*c.trace, "catalog.ReadResource")
+	return c.content, nil
+}
+
+func (c tracingCatalog) StreamChunks(_ context.Context, ch chan<- domain.Chunk) error {
+	close(ch)
+	return nil
+}
+
+func (c tracingCatalog) StreamResources(_ context.Context, ch chan<- domain.Document) error {
+	close(ch)
+	return nil
+}
+
+// tracingSearcher is a minimal search.Searcher that records searches onto the
+// trace a tracingRevalidator writes to.
+type tracingSearcher struct {
+	trace *[]string
+}
+
+func (s tracingSearcher) Search(string, int) ([]search.SearchResult, error) {
+	*s.trace = append(*s.trace, "searcher.Search")
+	return nil, nil
+}
+
+func (s tracingSearcher) Close() {}
+
+func (s tracingSearcher) Index(_ context.Context, chunks <-chan domain.Chunk) error {
+	for range chunks {
+		// drain
+	}
+	return nil
+}
+
+func TestMakeResourceHandler_RevalidatesBeforeCatalogAccess(t *testing.T) {
+	var trace []string
+	catalog := tracingCatalog{trace: &trace, content: "body"}
+	revalidator := tracingRevalidator{trace: &trace}
+
+	handler := makeResourceHandler(catalog, revalidator, "acdc://doc")
+	_, err := handler(context.Background(), &mcp.ReadResourceRequest{
+		Params: &mcp.ReadResourceParams{URI: "acdc://doc"},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"revalidate", "catalog.ReadResource"}, trace)
+}
+
+func TestReadToolHandler_RevalidatesBeforeCatalogAccess(t *testing.T) {
+	var trace []string
+	catalog := tracingCatalog{trace: &trace, content: "body"}
+	revalidator := tracingRevalidator{trace: &trace}
+
+	handler := NewReadToolHandler(catalog, revalidator)
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, ReadToolArgument{URI: "acdc://doc"})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"revalidate", "catalog.ReadResource"}, trace)
+}
+
+func TestSearchToolHandler_RevalidatesBeforeSearcherAccess(t *testing.T) {
+	var trace []string
+	searcher := tracingSearcher{trace: &trace}
+	revalidator := tracingRevalidator{trace: &trace}
+
+	handler := NewSearchToolHandler(searcher, revalidator, config.SearchSettings{MaxResults: 10, ResultMode: config.SearchResultModeReferences})
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, SearchToolArgument{Query: "test"})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"revalidate", "searcher.Search"}, trace)
+}
+
+func TestNoopRevalidator_DoesNothing(t *testing.T) {
+	require.NotPanics(t, func() {
+		noopRevalidator{}.Revalidate(context.Background())
+	})
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -18,32 +18,33 @@ const (
 	ToolNameRead = "read"
 )
 
-// CreateServer creates and configures the MCP server
+// CreateServer creates and configures the MCP server. The returned
+// *ResourceRegistrar has already performed the initial resource
+// registration from catalog; a caller that refreshes the catalog later
+// drives further registration changes through it.
+//
+// A nil revalidator is normalized to a no-op, so callers that never refresh
+// the catalog (e.g. tests) can omit it.
 func CreateServer(
 	metadata domain.McpMetadata,
-	resourceProvider *resources.ResourceProvider,
+	catalog resources.Catalog,
 	promptProvider *prompts.PromptProvider,
 	searchService search.Searcher,
 	searchSettings config.SearchSettings,
-) *mcp.Server {
+	revalidator Revalidator,
+) (*mcp.Server, *ResourceRegistrar) {
+	if revalidator == nil {
+		revalidator = noopRevalidator{}
+	}
+
 	// Create server with official SDK
 	s := mcp.NewServer(&mcp.Implementation{
 		Name:    metadata.Server.Name,
 		Version: metadata.Server.Version,
 	}, &mcp.ServerOptions{Instructions: metadata.Server.Instructions})
 
-	// Register Resources
-	for _, res := range resourceProvider.ListResources() {
-		// Capture uri for closure
-		uri := res.URI
-
-		s.AddResource(&mcp.Resource{
-			URI:         uri,
-			Name:        res.Name,
-			Description: res.Description,
-			MIMEType:    res.MIMEType,
-		}, makeResourceHandler(resourceProvider, uri))
-	}
+	registrar := NewResourceRegistrar(s, catalog, revalidator)
+	registrar.Sync(catalog)
 
 	// Register Prompts
 	for _, p := range promptProvider.ListPrompts() {
@@ -60,11 +61,11 @@ func CreateServer(
 	}
 
 	// Register Tools
-	RegisterSearchTool(s, searchService, searchSettings, metadata.GetToolMetadata(ToolNameSearch))
+	RegisterSearchTool(s, searchService, revalidator, searchSettings, metadata.GetToolMetadata(ToolNameSearch))
 	slog.Info("Registered tool", "name", ToolNameSearch)
 
-	RegisterReadTool(s, resourceProvider, metadata.GetToolMetadata(ToolNameRead))
+	RegisterReadTool(s, catalog, revalidator, metadata.GetToolMetadata(ToolNameRead))
 	slog.Info("Registered tool", "name", ToolNameRead)
 
-	return s
+	return s, registrar
 }

--- a/internal/mcp/server_helpers.go
+++ b/internal/mcp/server_helpers.go
@@ -10,10 +10,11 @@ import (
 	"github.com/sha1n/mcp-acdc-server/internal/resources"
 )
 
-func makeResourceHandler(resourceProvider *resources.ResourceProvider, uri string) mcp.ResourceHandler {
+func makeResourceHandler(catalog resources.Catalog, revalidator Revalidator, uri string) mcp.ResourceHandler {
 	return func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		revalidator.Revalidate(ctx)
 		slog.Info("Resource request", "uri", uri)
-		content, err := resourceProvider.ReadResource(uri)
+		content, err := catalog.ReadResource(uri)
 		if err != nil {
 			slog.Error("Resource read failed", "uri", uri, "error", err)
 			return nil, err

--- a/internal/mcp/server_helpers_test.go
+++ b/internal/mcp/server_helpers_test.go
@@ -35,7 +35,7 @@ func TestMakeResourceHandler_Success(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	handler := makeResourceHandler(resourceProvider, "acdc://test-resource")
+	handler := makeResourceHandler(resourceProvider, noopRevalidator{}, "acdc://test-resource")
 	require.NotNil(t, handler)
 
 	ctx := context.Background()
@@ -55,11 +55,45 @@ func TestMakeResourceHandler_Success(t *testing.T) {
 	assert.Equal(t, "# Test Content\n\nThis is test content.", result.Contents[0].Text)
 }
 
+// TestMakeResourceHandler_ServesSwappedCatalogContent verifies that a handler
+// created before a CatalogHolder.Swap serves the new snapshot's content
+// afterwards. A handler that captured a *resources.ResourceProvider snapshot
+// at construction time instead of the holder would keep serving stale
+// content here.
+func TestMakeResourceHandler_ServesSwappedCatalogContent(t *testing.T) {
+	initial, err := resources.NewResourceProvider([]resources.ResourceDefinition{
+		{URI: "acdc://doc", Name: "Doc", Description: "d", MIMEType: "text/markdown", Content: "old content"},
+	}, nil)
+	require.NoError(t, err)
+	holder := resources.NewCatalogHolder(initial)
+
+	handler := makeResourceHandler(holder, noopRevalidator{}, "acdc://doc")
+
+	ctx := context.Background()
+	req := &mcp.ReadResourceRequest{Params: &mcp.ReadResourceParams{URI: "acdc://doc"}}
+
+	result, err := handler(ctx, req)
+	require.NoError(t, err)
+	require.Len(t, result.Contents, 1)
+	assert.Equal(t, "old content", result.Contents[0].Text)
+
+	updated, err := resources.NewResourceProvider([]resources.ResourceDefinition{
+		{URI: "acdc://doc", Name: "Doc", Description: "d", MIMEType: "text/markdown", Content: "new content"},
+	}, nil)
+	require.NoError(t, err)
+	holder.Swap(updated)
+
+	result, err = handler(ctx, req)
+	require.NoError(t, err)
+	require.Len(t, result.Contents, 1)
+	assert.Equal(t, "new content", result.Contents[0].Text)
+}
+
 func TestMakeResourceHandler_Error_NotFound(t *testing.T) {
 	resourceProvider, err := resources.NewResourceProvider([]resources.ResourceDefinition{}, nil)
 	require.NoError(t, err)
 
-	handler := makeResourceHandler(resourceProvider, "acdc://nonexistent")
+	handler := makeResourceHandler(resourceProvider, noopRevalidator{}, "acdc://nonexistent")
 	require.NotNil(t, handler)
 
 	ctx := context.Background()

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -36,9 +36,12 @@ func TestCreateServer(t *testing.T) {
 	promptProvider := prompts.NewPromptProvider([]prompts.PromptDefinition{}, nil)
 	searchService := &mockSearcher{}
 
-	server := CreateServer(metadata, resourceProvider, promptProvider, searchService, config.SearchSettings{MaxResults: 10, ResultMode: config.SearchResultModeReferences})
+	server, registrar := CreateServer(metadata, resourceProvider, promptProvider, searchService, config.SearchSettings{MaxResults: 10, ResultMode: config.SearchResultModeReferences}, nil)
 	if server == nil {
 		t.Fatal("Server should not be nil")
+	}
+	if registrar == nil {
+		t.Fatal("Registrar should not be nil")
 	}
 }
 
@@ -64,7 +67,7 @@ func TestCreateServer_InstructionsReachClient(t *testing.T) {
 	require.NoError(t, err)
 	promptProvider := prompts.NewPromptProvider([]prompts.PromptDefinition{}, nil)
 
-	server := CreateServer(metadata, resourceProvider, promptProvider, &mockSearcher{}, config.SearchSettings{MaxResults: 10, ResultMode: config.SearchResultModeReferences})
+	server, _ := CreateServer(metadata, resourceProvider, promptProvider, &mockSearcher{}, config.SearchSettings{MaxResults: 10, ResultMode: config.SearchResultModeReferences}, nil)
 	require.NotNil(t, server)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -102,7 +105,7 @@ func TestCreateServer_EmptyInstructionsDoesNotBreakCreation(t *testing.T) {
 	require.NoError(t, err)
 	promptProvider := prompts.NewPromptProvider([]prompts.PromptDefinition{}, nil)
 
-	server := CreateServer(metadata, resourceProvider, promptProvider, &mockSearcher{}, config.SearchSettings{MaxResults: 10, ResultMode: config.SearchResultModeReferences})
+	server, _ := CreateServer(metadata, resourceProvider, promptProvider, &mockSearcher{}, config.SearchSettings{MaxResults: 10, ResultMode: config.SearchResultModeReferences}, nil)
 	require.NotNil(t, server)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -134,6 +137,3 @@ func (m *mockSearcher) Index(ctx context.Context, chunks <-chan domain.Chunk) er
 	}
 	return nil
 }
-
-func (m *mockSearcher) ReplaceSource(context.Context, string, []domain.Chunk) error { return nil }
-func (m *mockSearcher) DeleteSource(context.Context, string) error                  { return nil }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -22,32 +22,33 @@ type ReadToolArgument struct {
 }
 
 // RegisterSearchTool registers the search tool with the server
-func RegisterSearchTool(s *mcp.Server, searchService search.Searcher, settings config.SearchSettings, metadata domain.ToolMetadata) {
+func RegisterSearchTool(s *mcp.Server, searchService search.Searcher, revalidator Revalidator, settings config.SearchSettings, metadata domain.ToolMetadata) {
 	mcp.AddTool(s,
 		&mcp.Tool{
 			Name:        metadata.Name,
 			Description: metadata.Description,
 			// InputSchema auto-generated from SearchToolArgument
 		},
-		NewSearchToolHandler(searchService, settings),
+		NewSearchToolHandler(searchService, revalidator, settings),
 	)
 }
 
 // RegisterReadTool registers the read tool with the server
-func RegisterReadTool(s *mcp.Server, resourceProvider *resources.ResourceProvider, metadata domain.ToolMetadata) {
+func RegisterReadTool(s *mcp.Server, catalog resources.Catalog, revalidator Revalidator, metadata domain.ToolMetadata) {
 	mcp.AddTool(s,
 		&mcp.Tool{
 			Name:        metadata.Name,
 			Description: metadata.Description,
 			// InputSchema auto-generated from ReadToolArgument
 		},
-		NewReadToolHandler(resourceProvider),
+		NewReadToolHandler(catalog, revalidator),
 	)
 }
 
 // NewSearchToolHandler creates the handler for the search tool
-func NewSearchToolHandler(searchService search.Searcher, settings config.SearchSettings) mcp.ToolHandlerFor[SearchToolArgument, any] {
+func NewSearchToolHandler(searchService search.Searcher, revalidator Revalidator, settings config.SearchSettings) mcp.ToolHandlerFor[SearchToolArgument, any] {
 	return func(ctx context.Context, req *mcp.CallToolRequest, args SearchToolArgument) (*mcp.CallToolResult, any, error) {
+		revalidator.Revalidate(ctx)
 		// Args are already validated and unmarshaled by SDK via jsonschema tags
 		slog.Info("Search request", "query", args.Query)
 
@@ -68,12 +69,13 @@ func NewSearchToolHandler(searchService search.Searcher, settings config.SearchS
 }
 
 // NewReadToolHandler creates the handler for the read tool
-func NewReadToolHandler(resourceProvider *resources.ResourceProvider) mcp.ToolHandlerFor[ReadToolArgument, any] {
+func NewReadToolHandler(catalog resources.Catalog, revalidator Revalidator) mcp.ToolHandlerFor[ReadToolArgument, any] {
 	return func(ctx context.Context, req *mcp.CallToolRequest, args ReadToolArgument) (*mcp.CallToolResult, any, error) {
+		revalidator.Revalidate(ctx)
 		// Args are already validated and unmarshaled by SDK via jsonschema tags
 		slog.Info("Get resource request", "uri", args.URI)
 
-		content, err := resourceProvider.ReadResource(args.URI)
+		content, err := catalog.ReadResource(args.URI)
 		if err != nil {
 			slog.Error("Get resource failed", "uri", args.URI, "error", err)
 			return nil, nil, err

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -40,20 +40,17 @@ func (m *TestMockSearcher) Index(ctx context.Context, chunks <-chan domain.Chunk
 	return nil
 }
 
-func (m *TestMockSearcher) ReplaceSource(context.Context, string, []domain.Chunk) error { return nil }
-func (m *TestMockSearcher) DeleteSource(context.Context, string) error                  { return nil }
-
 func TestToolRegistration(t *testing.T) {
 	// Just verify tools can be created without panic
 	mockSearcher := &TestMockSearcher{}
-	searchHandler := NewSearchToolHandler(mockSearcher, config.SearchSettings{})
+	searchHandler := NewSearchToolHandler(mockSearcher, noopRevalidator{}, config.SearchSettings{})
 	if searchHandler == nil {
 		t.Error("Search handler should not be nil")
 	}
 
 	resourceProvider, err := resources.NewResourceProvider([]resources.ResourceDefinition{}, nil)
 	require.NoError(t, err)
-	readHandler := NewReadToolHandler(resourceProvider)
+	readHandler := NewReadToolHandler(resourceProvider, noopRevalidator{})
 	if readHandler == nil {
 		t.Error("Read handler should not be nil")
 	}
@@ -82,7 +79,7 @@ func TestSearchToolHandler_Success_WithResults(t *testing.T) {
 		},
 	}
 
-	handler := NewSearchToolHandler(mockSearcher, config.SearchSettings{MaxResults: 10, ResultMode: config.SearchResultModeReferences})
+	handler := NewSearchToolHandler(mockSearcher, noopRevalidator{}, config.SearchSettings{MaxResults: 10, ResultMode: config.SearchResultModeReferences})
 	require.NotNil(t, handler)
 
 	ctx := context.Background()
@@ -114,7 +111,7 @@ func TestSearchToolHandler_UsesServerWideModeAndCandidateWindow(t *testing.T) {
 		SourceTitle: "One",
 		Content:     "full chunk",
 	}}}
-	handler := NewSearchToolHandler(searcher, config.SearchSettings{MaxResults: 10, ResultMode: config.SearchResultModeContent})
+	handler := NewSearchToolHandler(searcher, noopRevalidator{}, config.SearchSettings{MaxResults: 10, ResultMode: config.SearchResultModeContent})
 
 	result, _, err := handler(context.Background(), nil, SearchToolArgument{Query: "chunk"})
 
@@ -126,7 +123,7 @@ func TestSearchToolHandler_UsesServerWideModeAndCandidateWindow(t *testing.T) {
 func TestSearchToolHandler_Success_NoResults(t *testing.T) {
 	mockSearcher := &TestMockSearcher{}
 
-	handler := NewSearchToolHandler(mockSearcher, config.SearchSettings{MaxResults: 10, ResultMode: config.SearchResultModeReferences})
+	handler := NewSearchToolHandler(mockSearcher, noopRevalidator{}, config.SearchSettings{MaxResults: 10, ResultMode: config.SearchResultModeReferences})
 	ctx := context.Background()
 	req := &mcp.CallToolRequest{}
 	args := SearchToolArgument{Query: "nonexistent"}
@@ -149,7 +146,7 @@ func TestSearchToolHandler_Error(t *testing.T) {
 		err: expectedErr,
 	}
 
-	handler := NewSearchToolHandler(mockSearcher, config.SearchSettings{MaxResults: 10, ResultMode: config.SearchResultModeReferences})
+	handler := NewSearchToolHandler(mockSearcher, noopRevalidator{}, config.SearchSettings{MaxResults: 10, ResultMode: config.SearchResultModeReferences})
 	ctx := context.Background()
 	req := &mcp.CallToolRequest{}
 	args := SearchToolArgument{Query: "failing query"}
@@ -193,7 +190,7 @@ func TestReadToolHandler_Success(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	handler := NewReadToolHandler(resourceProvider)
+	handler := NewReadToolHandler(resourceProvider, noopRevalidator{})
 	require.NotNil(t, handler)
 
 	ctx := context.Background()
@@ -216,7 +213,7 @@ func TestReadToolHandler_Error_ResourceNotFound(t *testing.T) {
 	resourceProvider, err := resources.NewResourceProvider([]resources.ResourceDefinition{}, nil)
 	require.NoError(t, err)
 
-	handler := NewReadToolHandler(resourceProvider)
+	handler := NewReadToolHandler(resourceProvider, noopRevalidator{})
 	ctx := context.Background()
 	req := &mcp.CallToolRequest{}
 	args := ReadToolArgument{URI: "acdc://nonexistent"}

--- a/internal/resources/catalog.go
+++ b/internal/resources/catalog.go
@@ -1,0 +1,74 @@
+package resources
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/sha1n/mcp-acdc-server/internal/domain"
+)
+
+// Catalog is the read side of a discovered source and chunk catalog: the
+// operations the MCP server and the indexer perform against one snapshot.
+type Catalog interface {
+	ListResources() []mcp.Resource
+	ReadResource(uri string) (string, error)
+	StreamChunks(ctx context.Context, ch chan<- domain.Chunk) error
+	StreamResources(ctx context.Context, ch chan<- domain.Document) error
+}
+
+var (
+	_ Catalog = (*ResourceProvider)(nil)
+	_ Catalog = (*CatalogHolder)(nil)
+)
+
+// CatalogHolder publishes one immutable *ResourceProvider snapshot at a time.
+// Readers resolve the current snapshot once per call, so a Swap that
+// publishes a new catalog never tears a call already in flight: it either
+// runs entirely against the snapshot it started with, or entirely against
+// the one that replaces it.
+type CatalogHolder struct {
+	current atomic.Pointer[ResourceProvider]
+}
+
+// NewCatalogHolder creates a holder publishing provider as its initial
+// snapshot. provider must not be nil.
+func NewCatalogHolder(provider *ResourceProvider) *CatalogHolder {
+	holder := &CatalogHolder{}
+	holder.current.Store(provider)
+	return holder
+}
+
+// Current returns the snapshot most recently published by Swap, or the one
+// passed to NewCatalogHolder if Swap has not been called yet.
+func (h *CatalogHolder) Current() *ResourceProvider {
+	return h.current.Load()
+}
+
+// Swap publishes provider as the new current snapshot. provider must not be
+// nil.
+func (h *CatalogHolder) Swap(provider *ResourceProvider) {
+	h.current.Store(provider)
+}
+
+// ListResources lists resources from the current snapshot.
+func (h *CatalogHolder) ListResources() []mcp.Resource {
+	return h.current.Load().ListResources()
+}
+
+// ReadResource reads a resource from the current snapshot.
+func (h *CatalogHolder) ReadResource(uri string) (string, error) {
+	return h.current.Load().ReadResource(uri)
+}
+
+// StreamChunks streams chunks from the snapshot current at the time of the
+// call; a later Swap does not affect an in-flight stream.
+func (h *CatalogHolder) StreamChunks(ctx context.Context, ch chan<- domain.Chunk) error {
+	return h.current.Load().StreamChunks(ctx, ch)
+}
+
+// StreamResources streams resources from the snapshot current at the time of
+// the call; a later Swap does not affect an in-flight stream.
+func (h *CatalogHolder) StreamResources(ctx context.Context, ch chan<- domain.Document) error {
+	return h.current.Load().StreamResources(ctx, ch)
+}

--- a/internal/resources/catalog_test.go
+++ b/internal/resources/catalog_test.go
@@ -1,0 +1,202 @@
+package resources
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/sha1n/mcp-acdc-server/internal/domain"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestProvider(t *testing.T, prefix string, n int) *ResourceProvider {
+	t.Helper()
+	sources := make([]domain.SourceDocument, 0, n)
+	chunks := make([]domain.Chunk, 0, n)
+	for i := 0; i < n; i++ {
+		uri := prefix + string(rune('a'+i))
+		sources = append(sources, domain.SourceDocument{ID: uri, URI: uri, Name: uri, Content: uri + "-content"})
+		chunkURI := uri + "#chunk"
+		chunks = append(chunks, domain.Chunk{ID: chunkURI, SourceID: uri, SourceURI: uri, ChunkURI: chunkURI, Content: uri + "-chunk"})
+	}
+	provider, err := NewResourceProvider(sources, chunks)
+	require.NoError(t, err)
+	return provider
+}
+
+func TestCatalogHolder_ReadsResolveAgainstTheCurrentSnapshot(t *testing.T) {
+	providerA := newTestProvider(t, "acdc://a-", 2)
+	providerB := newTestProvider(t, "acdc://b-", 2)
+
+	holder := NewCatalogHolder(providerA)
+
+	resourcesA := holder.ListResources()
+	require.Len(t, resourcesA, 2)
+	for _, r := range resourcesA {
+		require.Contains(t, r.URI, "acdc://a-")
+		body, err := holder.ReadResource(r.URI)
+		require.NoError(t, err)
+		require.Contains(t, body, "-content")
+	}
+	_, err := holder.ReadResource("acdc://b-a")
+	require.ErrorIs(t, err, ErrUnknownResource)
+
+	holder.Swap(providerB)
+
+	resourcesB := holder.ListResources()
+	require.Len(t, resourcesB, 2)
+	for _, r := range resourcesB {
+		require.Contains(t, r.URI, "acdc://b-")
+		body, err := holder.ReadResource(r.URI)
+		require.NoError(t, err)
+		require.Contains(t, body, "-content")
+	}
+	_, err = holder.ReadResource("acdc://a-a")
+	require.ErrorIs(t, err, ErrUnknownResource)
+}
+
+// TestCatalogHolder_SwapUnderConcurrentReaders races readers against a writer
+// swapping between two providers with disjoint URI sets. It exercises the
+// property under test with -race: every ListResources call must see URIs
+// from exactly one provider; a pinned snapshot's ReadResource for a URI its
+// own ListResources returned must always succeed; and holder.ReadResource
+// itself, called directly while Swap is in flight, must never resolve two
+// different snapshots within one call.
+func TestCatalogHolder_SwapUnderConcurrentReaders(t *testing.T) {
+	const iterations = 500
+	const readers = 8
+
+	providerA := newTestProvider(t, "acdc://a-", 3)
+	providerB := newTestProvider(t, "acdc://b-", 3)
+	holder := NewCatalogHolder(providerA)
+
+	var wg sync.WaitGroup
+	wg.Add(readers + 1)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			if i%2 == 0 {
+				holder.Swap(providerB)
+			} else {
+				holder.Swap(providerA)
+			}
+		}
+	}()
+
+	for r := 0; r < readers; r++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				// A single ListResources call must never combine URIs from both
+				// providers: it resolves one snapshot and builds the whole list
+				// from it, regardless of swaps landing mid-loop in other goroutines.
+				list := holder.ListResources()
+				require.NotEmpty(t, list)
+				prefix := list[0].URI[:len("acdc://a-")]
+				require.Contains(t, []string{"acdc://a-", "acdc://b-"}, prefix)
+				for _, res := range list {
+					require.Truef(t, len(res.URI) >= len(prefix) && res.URI[:len(prefix)] == prefix,
+						"listing mixed URIs from both providers: %v", list)
+				}
+
+				// Pin one snapshot via Current so the listing and the read that
+				// follows cannot straddle an intervening Swap: holder.ListResources
+				// followed by holder.ReadResource as two independent calls would be
+				// racing the writer goroutine even with a correct implementation,
+				// since the two providers' URI sets are disjoint by design.
+				snapshot := holder.Current()
+				pinnedList := snapshot.ListResources()
+				require.NotEmpty(t, pinnedList)
+				body, err := snapshot.ReadResource(pinnedList[0].URI)
+				require.NoError(t, err)
+				require.Contains(t, body, "-content")
+
+				// Also call the holder's own ReadResource delegate directly under
+				// concurrent Swap pressure. Racing it against a stale URI has two
+				// legitimate outcomes: the provider that owned the URI is still
+				// current (exact content match), or a Swap has since replaced it
+				// with the other, disjoint provider (ErrUnknownResource). Anything
+				// else — a different error, or a success with mismatched content —
+				// would mean the call resolved two different snapshots internally.
+				uri := list[0].URI
+				readBody, readErr := holder.ReadResource(uri)
+				if readErr != nil {
+					require.ErrorIsf(t, readErr, ErrUnknownResource, "unexpected error reading %s", uri)
+				} else {
+					require.Equalf(t, uri+"-content", readBody, "content mismatch reading %s: got %q", uri, readBody)
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestCatalogHolder_StreamChunksUsesOneSnapshot verifies StreamChunks resolves
+// its snapshot once at the start of the call: swapping the holder mid-stream
+// must not change which provider's chunks are delivered.
+func TestCatalogHolder_StreamChunksUsesOneSnapshot(t *testing.T) {
+	providerA := newTestProvider(t, "acdc://a-", 5)
+	providerB := newTestProvider(t, "acdc://b-", 5)
+	holder := NewCatalogHolder(providerA)
+
+	// Small buffer plus a pausing reader forces StreamChunks to block
+	// mid-flight so the swap below lands while the call is in progress.
+	stream := make(chan domain.Chunk, 1)
+	errs := make(chan error, 1)
+	go func() {
+		errs <- holder.StreamChunks(context.Background(), stream)
+	}()
+
+	first := <-stream
+	require.Contains(t, first.ChunkURI, "acdc://a-")
+
+	holder.Swap(providerB)
+
+	received := []domain.Chunk{first}
+	for len(received) < 5 {
+		received = append(received, <-stream)
+	}
+	require.NoError(t, <-errs)
+
+	require.Len(t, received, 5)
+	for _, chunk := range received {
+		require.Contains(t, chunk.ChunkURI, "acdc://a-")
+	}
+}
+
+// TestCatalogHolder_StreamResourcesUsesOneSnapshot verifies StreamResources
+// delegates to the current snapshot's own StreamResources rather than being
+// left unimplemented or bypassed, and that it resolves that snapshot once at
+// the start of the call: swapping the holder mid-stream must not change
+// which provider's resources are delivered.
+func TestCatalogHolder_StreamResourcesUsesOneSnapshot(t *testing.T) {
+	providerA := newTestProvider(t, "acdc://a-", 5)
+	providerB := newTestProvider(t, "acdc://b-", 5)
+	holder := NewCatalogHolder(providerA)
+
+	// Small buffer plus a pausing reader forces StreamResources to block
+	// mid-flight so the swap below lands while the call is in progress.
+	stream := make(chan domain.Document, 1)
+	errs := make(chan error, 1)
+	go func() {
+		errs <- holder.StreamResources(context.Background(), stream)
+	}()
+
+	first := <-stream
+	require.Contains(t, first.URI, "acdc://a-")
+
+	holder.Swap(providerB)
+
+	received := []domain.Document{first}
+	for len(received) < 5 {
+		received = append(received, <-stream)
+	}
+	require.NoError(t, <-errs)
+
+	require.Len(t, received, 5)
+	for _, document := range received {
+		require.Contains(t, document.URI, "acdc://a-")
+	}
+}

--- a/internal/resources/discovery.go
+++ b/internal/resources/discovery.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/sha1n/mcp-acdc-server/internal/content"
@@ -105,23 +107,61 @@ func discoverWithOps(ctx context.Context, cp *content.ContentProvider, index *do
 	}
 	policy := resolvePolicy(opts)
 
-	patterns, err := validatePatterns(index.Include)
+	root, selected, err := selectConfiguredFiles(ctx, cp, index, ops, policy)
 	if err != nil {
 		return DiscoveryResult{}, err
 	}
+	if len(selected) == 0 {
+		if policy.lenient {
+			slog.Warn("Configured index matched no files", "root", root)
+			return DiscoveryResult{}, nil
+		}
+		return DiscoveryResult{}, fmt.Errorf("configured index matched no files")
+	}
+
+	paths := make([]string, len(selected))
+	for i, file := range selected {
+		paths[i] = file.path
+	}
+	return buildCatalog(ctx, root, paths, scheme, ops, policy)
+}
+
+// selectedFile is a member of the file set a Discover call would select,
+// with the cheap-to-obtain filesystem attributes Fingerprint needs. It never
+// carries file content: that stays exclusive to buildCatalog and
+// discoverLegacy, the callers that actually read a file's bytes.
+type selectedFile struct {
+	path         string // canonical absolute path
+	relativePath string // slash-separated, relative to root
+	size         int64
+	modTime      time.Time
+}
+
+// selectConfiguredFiles walks cp.ContentDir and returns, in native canonical
+// path order, every regular file matching index's include/exclude patterns under
+// policy. It performs every check that must fail the invocation outright --
+// pattern validity, root resolution, and root-escape containment -- but
+// leaves the "selected nothing" decision to the caller, since that decision
+// differs between Discover (fatal unless lenient) and Fingerprint (an empty
+// selection is a legitimate digest).
+func selectConfiguredFiles(ctx context.Context, cp *content.ContentProvider, index *domain.IndexMetadata, ops discoveryOps, policy discoverPolicy) (string, []selectedFile, error) {
+	patterns, err := validatePatterns(index.Include)
+	if err != nil {
+		return "", nil, err
+	}
 	excludes, err := validatePatterns(index.Exclude)
 	if err != nil {
-		return DiscoveryResult{}, err
+		return "", nil, err
 	}
 
 	root, err := ops.canonicalPath(cp.ContentDir)
 	if err != nil {
-		return DiscoveryResult{}, fmt.Errorf("resolve content root: %w", err)
+		return "", nil, fmt.Errorf("resolve content root: %w", err)
 	}
 
 	descent := newDescentFilter(patterns)
 
-	var selected []string
+	var selected []selectedFile
 	err = ops.walkDir(root, func(filePath string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
@@ -173,22 +213,20 @@ func discoverWithOps(ctx context.Context, cp *content.ContentProvider, index *do
 		if !matchesAny(patterns, relativePath) || matchesAny(excludes, relativePath) {
 			return nil
 		}
-		selected = append(selected, canonicalFile)
+		selected = append(selected, selectedFile{
+			path:         canonicalFile,
+			relativePath: relativePath,
+			size:         info.Size(),
+			modTime:      info.ModTime(),
+		})
 		return nil
 	})
 	if err != nil {
-		return DiscoveryResult{}, err
-	}
-	if len(selected) == 0 {
-		if policy.lenient {
-			slog.Warn("Configured index matched no files", "root", root)
-			return DiscoveryResult{}, nil
-		}
-		return DiscoveryResult{}, fmt.Errorf("configured index matched no files")
+		return "", nil, err
 	}
 
-	sort.Strings(selected)
-	return buildCatalog(ctx, root, selected, scheme, ops, policy)
+	sortSelectedFiles(selected)
+	return root, selected, nil
 }
 
 // DiscoverResources returns legacy mcp-resources definitions for callers that
@@ -202,15 +240,63 @@ func DiscoverResources(cp *content.ContentProvider, scheme string) ([]ResourceDe
 }
 
 func discoverLegacy(ctx context.Context, cp *content.ContentProvider, scheme string, ops discoveryOps) (DiscoveryResult, error) {
+	_, files, err := selectLegacyFiles(ctx, cp, ops)
+	if err != nil {
+		return DiscoveryResult{}, err
+	}
+
+	result := DiscoveryResult{}
+	for _, file := range files {
+		if err := ctx.Err(); err != nil {
+			return DiscoveryResult{}, err
+		}
+		raw, err := ops.readFile(file.path)
+		if err != nil {
+			slog.Warn("Skipping invalid resource file", "file", filepath.Base(file.path), "error", err)
+			continue
+		}
+		parsed, err := content.ParseMarkdown(raw, content.FrontmatterRequired)
+		if err != nil {
+			slog.Warn("Skipping invalid resource file", "file", filepath.Base(file.path), "error", err)
+			continue
+		}
+		name, _ := parsed.Metadata["name"].(string)
+		description, _ := parsed.Metadata["description"].(string)
+		if name == "" || description == "" {
+			slog.Warn("Skipping resource with missing metadata", "file", filepath.Base(file.path))
+			continue
+		}
+		uri := sourceURI(scheme, file.relativePath)
+		if _, err := url.Parse(uri); err != nil {
+			slog.Warn("Skipping invalid resource file", "file", filepath.Base(file.path), "error", err)
+			continue
+		}
+		source := buildParsedSource(parsed, content.SourceOptions{
+			URI: uri, FilePath: file.path, RelativePath: file.relativePath, Raw: raw,
+		})
+		chunks := chunkParsedSource(source, parsed)
+		result.Sources = append(result.Sources, source)
+		result.Chunks = append(result.Chunks, chunks...)
+		slog.Info("Loaded resource", "uri", uri, "name", source.Name)
+	}
+	return result, nil
+}
+
+// selectLegacyFiles walks cp.ResourcesDir and returns, in native canonical
+// path order, every regular Markdown file beneath it. A missing resources
+// directory is not a configuration error in legacy mode -- it simply means
+// there are no legacy resources -- so it yields an empty selection rather
+// than propagating the stat failure.
+func selectLegacyFiles(ctx context.Context, cp *content.ContentProvider, ops discoveryOps) (string, []selectedFile, error) {
 	root, err := ops.canonicalPath(cp.ResourcesDir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return DiscoveryResult{}, nil
+			return "", nil, nil
 		}
-		return DiscoveryResult{}, fmt.Errorf("resolve resources root: %w", err)
+		return "", nil, fmt.Errorf("resolve resources root: %w", err)
 	}
 
-	var files []string
+	var files []selectedFile
 	err = ops.walkDir(root, func(filePath string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
@@ -228,49 +314,35 @@ func discoverLegacy(ctx context.Context, cp *content.ContentProvider, scheme str
 		if !info.Mode().IsRegular() {
 			return nil
 		}
-		files = append(files, filePath)
+		relativePath, err := ops.relativePath(root, filePath)
+		if err != nil {
+			return err
+		}
+		files = append(files, selectedFile{
+			path:         filePath,
+			relativePath: filepath.ToSlash(relativePath),
+			size:         info.Size(),
+			modTime:      info.ModTime(),
+		})
 		return nil
 	})
 	if err != nil {
-		return DiscoveryResult{}, err
+		return "", nil, err
 	}
-	sort.Strings(files)
 
-	result := DiscoveryResult{}
-	for _, filePath := range files {
-		if err := ctx.Err(); err != nil {
-			return DiscoveryResult{}, err
-		}
-		raw, err := ops.readFile(filePath)
-		if err != nil {
-			slog.Warn("Skipping invalid resource file", "file", filepath.Base(filePath), "error", err)
-			continue
-		}
-		parsed, err := content.ParseMarkdown(raw, content.FrontmatterRequired)
-		if err != nil {
-			slog.Warn("Skipping invalid resource file", "file", filepath.Base(filePath), "error", err)
-			continue
-		}
-		name, _ := parsed.Metadata["name"].(string)
-		description, _ := parsed.Metadata["description"].(string)
-		if name == "" || description == "" {
-			slog.Warn("Skipping resource with missing metadata", "file", filepath.Base(filePath))
-			continue
-		}
-		relativePath, err := ops.relativePath(root, filePath)
-		if err != nil {
-			return DiscoveryResult{}, err
-		}
-		uri := sourceURI(scheme, relativePath)
-		source := buildParsedSource(parsed, content.SourceOptions{
-			URI: uri, FilePath: filePath, RelativePath: filepath.ToSlash(relativePath), Raw: raw,
-		})
-		chunks := chunkParsedSource(source, parsed)
-		result.Sources = append(result.Sources, source)
-		result.Chunks = append(result.Chunks, chunks...)
-		slog.Info("Loaded resource", "uri", uri, "name", source.Name)
-	}
-	return result, nil
+	sortSelectedFiles(files)
+	return root, files, nil
+}
+
+// sortSelectedFiles orders files by native canonical path, matching the order
+// each selection walk produced before it moved behind this shared helper.
+// Sorting by path rather than the slash-converted relativePath matters on a
+// platform whose path separator is not '/': a file directly at a directory
+// boundary can compare on opposite sides of a sibling name under the two
+// forms (for example "aZ.md" vs. "a\sub.md": '\' is 0x5C, so it sorts after
+// 'Z' natively but "/" is 0x2F, so the slash form would sort before it).
+func sortSelectedFiles(files []selectedFile) {
+	sort.Slice(files, func(i, j int) bool { return files[i].path < files[j].path })
 }
 
 func buildCatalog(ctx context.Context, root string, files []string, scheme string, ops discoveryOps, policy discoverPolicy) (DiscoveryResult, error) {
@@ -303,6 +375,13 @@ func buildCatalog(ctx context.Context, root string, files []string, scheme strin
 			return DiscoveryResult{}, err
 		}
 		uri := sourceURI(scheme, relativePath)
+		if _, err := url.Parse(uri); err != nil {
+			if policy.lenient {
+				slog.Warn("Skipping unaddressable configured file", "file", filepath.Base(filePath), "error", err)
+				continue
+			}
+			return DiscoveryResult{}, fmt.Errorf("address configured file %s: %w", filePath, err)
+		}
 		source := buildParsedSource(parsed, content.SourceOptions{
 			URI: uri, FilePath: filePath, RelativePath: filepath.ToSlash(relativePath), Raw: raw,
 		})

--- a/internal/resources/discovery_test.go
+++ b/internal/resources/discovery_test.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"io/fs"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -201,6 +202,64 @@ func TestDiscover_LenientSkipsUnparsableFilesButIndexesSiblings(t *testing.T) {
 		Include: []string{"docs/*.md"},
 	}, "acdc")
 	require.ErrorContains(t, err, "invalid YAML in frontmatter")
+}
+
+// TestDiscover_ConfiguredRejectsUnaddressableURI covers the strict-policy
+// side of a file selected by the index whose generated URI cannot be
+// registered as an MCP resource: the go-sdk's AddResource panics on a URI
+// that fails url.Parse, and an ASCII control character -- illegal in a URL
+// but legal in a relative file path on Linux and macOS -- is enough to
+// trigger it. An operator who declared an explicit index named this file;
+// one it cannot address is a configuration-level failure, not a warning.
+func TestDiscover_ConfiguredRejectsUnaddressableURI(t *testing.T) {
+	root := t.TempDir()
+	badPath := writeFile(t, root, "docs/a\nb.md", "# Bad\n")
+
+	// The fixture must actually reproduce the failure mode under test, not a
+	// weaker proxy: confirm the file exists on disk and that url.Parse
+	// genuinely rejects the URI discovery would build for it.
+	_, statErr := os.Stat(badPath)
+	require.NoError(t, statErr, "fixture file with a control character in its name must exist")
+	_, parseErr := url.Parse(sourceURI("acdc", "docs/a\nb"))
+	require.Error(t, parseErr, "fixture URI must fail url.Parse or this test proves nothing")
+
+	_, err := Discover(context.Background(), content.NewContentProvider(root), &domain.IndexMetadata{
+		Include: []string{"docs/**/*.md"},
+	}, "acdc")
+	require.ErrorContains(t, err, badPath)
+}
+
+// TestDiscover_LenientSkipsUnaddressableURIButIndexesSiblings covers the
+// zero-config side of the same failure: the user declared nothing, so
+// refusing to start over one malformed filename would turn it into zero
+// documentation. The file is skipped and its siblings are still discovered.
+func TestDiscover_LenientSkipsUnaddressableURIButIndexesSiblings(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "docs/good.md", "# Good\n\nBody.\n")
+	badPath := writeFile(t, root, "docs/a\nb.md", "# Bad\n")
+	_, statErr := os.Stat(badPath)
+	require.NoError(t, statErr, "fixture file with a control character in its name must exist")
+
+	result, err := Discover(context.Background(), content.NewContentProvider(root), &domain.IndexMetadata{
+		Include: []string{"docs/*.md"},
+	}, "acdc", WithLenientIndex())
+	require.NoError(t, err)
+	require.Equal(t, []string{"acdc://docs/good"}, sourceURIs(result.Sources))
+}
+
+// TestDiscover_LegacySkipsUnaddressableURI pins legacy discovery's existing,
+// policy-agnostic convention: skip with a warning and keep going, the same
+// way it already treats an unreadable or unparsable legacy resource file.
+func TestDiscover_LegacySkipsUnaddressableURI(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "mcp-resources/valid.md", "---\nname: Valid\ndescription: Valid description\n---\n# Valid\n\nBody.\n")
+	badPath := writeFile(t, root, "mcp-resources/a\nb.md", "---\nname: Bad\ndescription: Bad description\n---\n# Bad\n")
+	_, statErr := os.Stat(badPath)
+	require.NoError(t, statErr, "fixture file with a control character in its name must exist")
+
+	result, err := Discover(context.Background(), content.NewContentProvider(root), nil, "acdc")
+	require.NoError(t, err)
+	require.Equal(t, []string{"acdc://valid"}, sourceURIs(result.Sources))
 }
 
 func TestDiscover_LenientStillRejectsRootEscapingPatterns(t *testing.T) {
@@ -483,4 +542,37 @@ func sourceURIs(sources []domain.SourceDocument) []string {
 		uris[i] = source.URI
 	}
 	return uris
+}
+
+// sortSelectedFiles must order by the native canonical path, not by the
+// slash-converted relativePath -- the two disagree whenever a directory
+// separator byte and an ordinary filename byte fall on opposite sides of each
+// other under the two encodings. This test constructs that disagreement
+// directly as data, with a literal '\' byte in one path, rather than relying
+// on a filesystem walk: a real walk's paths use whatever separator the host
+// OS produces, so on a '/'-separator platform the two sort keys always
+// coincide and a walk-based test cannot observe a regression here at all.
+//
+// The pair is "a\sub.md" vs "aZ.md": '\' is 0x5C and 'Z' is 0x5A, so 'Z'
+// sorts first natively (byte 0x5A < 0x5C) but last under the slash form,
+// where the corresponding byte is '/' (0x2F < 0x5A). Any implementation
+// that sorts by relativePath instead of path fails this on every platform.
+func TestSortSelectedFiles_OrdersByNativePathNotSlashForm(t *testing.T) {
+	nested := selectedFile{path: `root\a\sub.md`, relativePath: "a/sub.md"}
+	sibling := selectedFile{path: `root\aZ.md`, relativePath: "aZ.md"}
+
+	tests := []struct {
+		name  string
+		input []selectedFile
+	}{
+		{name: "nested first", input: []selectedFile{nested, sibling}},
+		{name: "sibling first", input: []selectedFile{sibling, nested}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			files := append([]selectedFile(nil), tt.input...)
+			sortSelectedFiles(files)
+			require.Equal(t, []selectedFile{sibling, nested}, files)
+		})
+	}
 }

--- a/internal/resources/fingerprint.go
+++ b/internal/resources/fingerprint.go
@@ -1,0 +1,49 @@
+package resources
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/sha1n/mcp-acdc-server/internal/content"
+	"github.com/sha1n/mcp-acdc-server/internal/domain"
+)
+
+// Fingerprint digests the file set a Discover call with the same arguments
+// would select: the relative path, size and modification time of each file. It
+// reads no file contents, so it is a cheap gate in front of a rediscovery
+// rather than a content comparison — a touched file with unchanged content
+// changes the digest.
+func Fingerprint(ctx context.Context, cp *content.ContentProvider, index *domain.IndexMetadata, opts ...DiscoverOption) (string, error) {
+	ops := defaultDiscoveryOps()
+
+	var files []selectedFile
+	if index == nil {
+		_, selected, err := selectLegacyFiles(ctx, cp, ops)
+		if err != nil {
+			return "", err
+		}
+		files = selected
+	} else {
+		policy := resolvePolicy(opts)
+		_, selected, err := selectConfiguredFiles(ctx, cp, index, ops, policy)
+		if err != nil {
+			return "", err
+		}
+		files = selected
+	}
+
+	hasher := sha256.New()
+	for _, file := range files {
+		// hash.Hash.Write never returns an error (per the io.Writer contract it
+		// documents), so the write's result is deliberately discarded here.
+		//
+		// The trailing newline is a per-file record separator, so this format
+		// assumes relativePath contains no literal newline; a path with one
+		// (legal on Linux and macOS) would let its record boundary land in an
+		// unexpected place relative to the fields that follow it.
+		_, _ = fmt.Fprintf(hasher, "%s\x00%d\x00%d\n", file.relativePath, file.size, file.modTime.UnixNano())
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}

--- a/internal/resources/fingerprint_test.go
+++ b/internal/resources/fingerprint_test.go
@@ -1,0 +1,231 @@
+package resources
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sha1n/mcp-acdc-server/internal/content"
+	"github.com/sha1n/mcp-acdc-server/internal/domain"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFingerprint_StableAcrossRepeatedCallsWithNoChange(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "docs/guide.md", "# Guide\n")
+	cp := content.NewContentProvider(root)
+	index := &domain.IndexMetadata{Include: []string{"docs/**/*.md"}}
+
+	first, err := Fingerprint(context.Background(), cp, index)
+	require.NoError(t, err)
+	second, err := Fingerprint(context.Background(), cp, index)
+	require.NoError(t, err)
+
+	require.Equal(t, first, second)
+	require.NotEmpty(t, first)
+}
+
+func TestFingerprint_ChangesWithSelectedFileSetOrContentSize(t *testing.T) {
+	cp := func(root string) *content.ContentProvider { return content.NewContentProvider(root) }
+	index := &domain.IndexMetadata{Include: []string{"docs/**/*.md"}}
+
+	t.Run("a matching file is added", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, root, "docs/guide.md", "# Guide\n")
+		before, err := Fingerprint(context.Background(), cp(root), index)
+		require.NoError(t, err)
+
+		writeFile(t, root, "docs/extra.md", "# Extra\n")
+		after, err := Fingerprint(context.Background(), cp(root), index)
+		require.NoError(t, err)
+
+		require.NotEqual(t, before, after)
+	})
+
+	t.Run("a matching file's content changes size", func(t *testing.T) {
+		root := t.TempDir()
+		path := writeFile(t, root, "docs/guide.md", "# Guide\n")
+		before, err := Fingerprint(context.Background(), cp(root), index)
+		require.NoError(t, err)
+
+		require.NoError(t, os.WriteFile(path, []byte("# Guide\n\nMore body text.\n"), 0o600))
+		after, err := Fingerprint(context.Background(), cp(root), index)
+		require.NoError(t, err)
+
+		require.NotEqual(t, before, after)
+	})
+
+	t.Run("a matching file is deleted", func(t *testing.T) {
+		root := t.TempDir()
+		path := writeFile(t, root, "docs/guide.md", "# Guide\n")
+		writeFile(t, root, "docs/other.md", "# Other\n")
+		before, err := Fingerprint(context.Background(), cp(root), index)
+		require.NoError(t, err)
+
+		require.NoError(t, os.Remove(path))
+		after, err := Fingerprint(context.Background(), cp(root), index)
+		require.NoError(t, err)
+
+		require.NotEqual(t, before, after)
+	})
+
+	t.Run("a matching file is renamed with identical content", func(t *testing.T) {
+		root := t.TempDir()
+		path := writeFile(t, root, "docs/guide.md", "# Guide\n")
+		before, err := Fingerprint(context.Background(), cp(root), index)
+		require.NoError(t, err)
+
+		require.NoError(t, os.Rename(path, filepath.Join(root, "docs", "renamed.md")))
+		after, err := Fingerprint(context.Background(), cp(root), index)
+		require.NoError(t, err)
+
+		require.NotEqual(t, before, after)
+	})
+}
+
+// A pure timestamp touch with unchanged content still moves the digest. This
+// is the documented cost of a read-free gate: Fingerprint never reads file
+// contents, so modification time is the only signal it has for "this file's
+// bytes might differ." A later, content-aware digest is what would suppress
+// the resulting needless rebuild.
+func TestFingerprint_ChangesOnTimestampTouchWithIdenticalContent(t *testing.T) {
+	root := t.TempDir()
+	path := writeFile(t, root, "docs/guide.md", "# Guide\n")
+	cp := content.NewContentProvider(root)
+	index := &domain.IndexMetadata{Include: []string{"docs/**/*.md"}}
+
+	before, err := Fingerprint(context.Background(), cp, index)
+	require.NoError(t, err)
+
+	touched := time.Now().Add(time.Hour)
+	require.NoError(t, os.Chtimes(path, touched, touched))
+
+	after, err := Fingerprint(context.Background(), cp, index)
+	require.NoError(t, err)
+
+	require.NotEqual(t, before, after)
+}
+
+// These are the two cases that prove Fingerprint reuses Discover's own
+// selection predicate rather than walking the whole tree: a file outside the
+// include patterns, and a file under a directory the lenient policy prunes,
+// must never move the digest.
+func TestFingerprint_UnchangedForFilesOutsideSelection(t *testing.T) {
+	t.Run("a non-matching file is added", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, root, "docs/guide.md", "# Guide\n")
+		cp := content.NewContentProvider(root)
+		index := &domain.IndexMetadata{Include: []string{"docs/**/*.md"}}
+
+		before, err := Fingerprint(context.Background(), cp, index)
+		require.NoError(t, err)
+
+		writeFile(t, root, "CONTRIBUTING.md", "# Contributing\n")
+		writeFile(t, root, "src/notes.md", "# Notes\n")
+		after, err := Fingerprint(context.Background(), cp, index)
+		require.NoError(t, err)
+
+		require.Equal(t, before, after)
+	})
+
+	t.Run("a file appears under a lenient-pruned directory", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, root, "docs/guide.md", "# Guide\n")
+		cp := content.NewContentProvider(root)
+		index := &domain.IndexMetadata{Include: []string{"**/*.md"}}
+
+		before, err := Fingerprint(context.Background(), cp, index, WithLenientIndex())
+		require.NoError(t, err)
+
+		writeFile(t, root, "node_modules/pkg/readme.md", "# Vendored\n")
+		after, err := Fingerprint(context.Background(), cp, index, WithLenientIndex())
+		require.NoError(t, err)
+
+		require.Equal(t, before, after)
+	})
+}
+
+func TestFingerprint_LegacyMode(t *testing.T) {
+	t.Run("digests mcp-resources", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, root, "mcp-resources/guide.md", "# Guide\n")
+		cp := content.NewContentProvider(root)
+
+		before, err := Fingerprint(context.Background(), cp, nil)
+		require.NoError(t, err)
+
+		writeFile(t, root, "mcp-resources/extra.md", "# Extra\n")
+		after, err := Fingerprint(context.Background(), cp, nil)
+		require.NoError(t, err)
+
+		require.NotEqual(t, before, after)
+	})
+
+	t.Run("a missing resources directory yields the stable empty digest with no error", func(t *testing.T) {
+		root := t.TempDir()
+		cp := content.NewContentProvider(root)
+
+		digest, err := Fingerprint(context.Background(), cp, nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, digest)
+
+		emptyDigestAgain, err := Fingerprint(context.Background(), cp, nil)
+		require.NoError(t, err)
+		require.Equal(t, digest, emptyDigestAgain)
+	})
+}
+
+func TestFingerprint_EmptySelectionIsNotTheEmptyString(t *testing.T) {
+	root := t.TempDir()
+	cp := content.NewContentProvider(root)
+
+	digest, err := Fingerprint(context.Background(), cp, nil)
+	require.NoError(t, err)
+	require.NotEqual(t, "", digest)
+}
+
+// An invalid include pattern is a configuration error, not an empty
+// selection: Fingerprint must propagate it rather than digesting whatever
+// happened to already match. Pattern validation runs before any filesystem
+// access, so no content root is needed to observe it.
+func TestFingerprint_ConfiguredInvalidPatternReturnsError(t *testing.T) {
+	cp := content.NewContentProvider("")
+	index := &domain.IndexMetadata{Include: []string{"/abs/pattern/**"}}
+
+	_, err := Fingerprint(context.Background(), cp, index)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "index pattern must be relative")
+}
+
+func TestFingerprint_ConfiguredCancelledContextReturnsError(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "docs/guide.md", "# Guide\n")
+	cp := content.NewContentProvider(root)
+	index := &domain.IndexMetadata{Include: []string{"docs/**/*.md"}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := Fingerprint(ctx, cp, index)
+
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// The legacy walk observes cancellation from inside its per-entry callback,
+// so the mcp-resources fixture must contain at least one file for the walk
+// to reach that check rather than exiting beforehand for an unrelated reason.
+func TestFingerprint_LegacyCancelledContextReturnsError(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "mcp-resources/guide.md", "# Guide\n")
+	cp := content.NewContentProvider(root)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := Fingerprint(ctx, cp, nil)
+
+	require.ErrorIs(t, err, context.Canceled)
+}

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -45,8 +45,6 @@ type SearchResult struct {
 type Searcher interface {
 	Search(query string, candidateLimit int) ([]SearchResult, error)
 	Index(ctx context.Context, chunks <-chan domain.Chunk) error
-	ReplaceSource(ctx context.Context, sourceID string, chunks []domain.Chunk) error
-	DeleteSource(ctx context.Context, sourceID string) error
 	Close()
 }
 
@@ -65,11 +63,10 @@ type searchIndex interface {
 
 // Service search service using Bleve
 type Service struct {
-	mu           sync.RWMutex
-	settings     config.SearchSettings
-	index        searchIndex
-	indexDir     string
-	sourceChunks map[string][]string
+	mu       sync.RWMutex
+	settings config.SearchSettings
+	index    searchIndex
+	indexDir string
 }
 
 // Ensure Service implements Searcher
@@ -78,8 +75,7 @@ var _ Searcher = (*Service)(nil)
 // NewService creates a new search service
 func NewService(settings config.SearchSettings) *Service {
 	return &Service{
-		settings:     settings,
-		sourceChunks: make(map[string][]string),
+		settings: settings,
 	}
 }
 
@@ -92,8 +88,7 @@ func (s *Service) Index(ctx context.Context, chunks <-chan domain.Chunk) error {
 	if err != nil {
 		return err
 	}
-	newSourceChunks := make(map[string][]string)
-	if err := batchIndex(ctx, index, chunks, newSourceChunks); err != nil {
+	if err := batchIndex(ctx, index, chunks); err != nil {
 		_ = index.Close()
 		if indexDir != "" {
 			_ = removeAll(indexDir)
@@ -104,7 +99,6 @@ func (s *Service) Index(ctx context.Context, chunks <-chan domain.Chunk) error {
 	oldIndex, oldIndexDir := s.index, s.indexDir
 	s.index = index
 	s.indexDir = indexDir
-	s.sourceChunks = newSourceChunks
 	if oldIndex != nil {
 		_ = oldIndex.Close()
 	}
@@ -139,15 +133,10 @@ func (s *Service) newIndex() (searchIndex, string, error) {
 	return index, indexDir, nil
 }
 
-func (s *Service) batchIndex(ctx context.Context, index BatchIndexer, chunks <-chan domain.Chunk) error {
-	return batchIndex(ctx, index, chunks, s.sourceChunks)
-}
-
-func batchIndex(ctx context.Context, index BatchIndexer, chunks <-chan domain.Chunk, sourceChunks map[string][]string) error {
+func batchIndex(ctx context.Context, index BatchIndexer, chunks <-chan domain.Chunk) error {
 	batch := index.NewBatch()
 	batchSize := 100
 	count := 0
-	pendingSources := make(map[string][]string)
 
 	for {
 		select {
@@ -159,7 +148,6 @@ func batchIndex(ctx context.Context, index BatchIndexer, chunks <-chan domain.Ch
 					if err := index.Batch(batch); err != nil {
 						return fmt.Errorf("failed to execute final batch index: %w", err)
 					}
-					addSourceChunks(sourceChunks, pendingSources)
 				}
 				return nil
 			}
@@ -167,25 +155,16 @@ func batchIndex(ctx context.Context, index BatchIndexer, chunks <-chan domain.Ch
 			if err := batch.Index(chunk.ID, chunk); err != nil {
 				return fmt.Errorf("failed to add chunk to batch: %w", err)
 			}
-			pendingSources[chunk.SourceID] = append(pendingSources[chunk.SourceID], chunk.ID)
 			count++
 
 			if count >= batchSize {
 				if err := index.Batch(batch); err != nil {
 					return fmt.Errorf("failed to execute batch index: %w", err)
 				}
-				addSourceChunks(sourceChunks, pendingSources)
 				batch = index.NewBatch()
 				count = 0
-				pendingSources = make(map[string][]string)
 			}
 		}
-	}
-}
-
-func addSourceChunks(destination, sourceChunks map[string][]string) {
-	for sourceID, chunkIDs := range sourceChunks {
-		destination[sourceID] = append(destination[sourceID], chunkIDs...)
 	}
 }
 
@@ -351,66 +330,6 @@ func fieldInt(fields map[string]interface{}, field string) int {
 	default:
 		return 0
 	}
-}
-
-// ReplaceSource atomically removes a source's known chunks and indexes its replacements.
-func (s *Service) ReplaceSource(ctx context.Context, sourceID string, chunks []domain.Chunk) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	if s.index == nil {
-		return fmt.Errorf("search index is not initialized")
-	}
-
-	batch := s.index.NewBatch()
-	for _, chunkID := range s.sourceChunks[sourceID] {
-		batch.Delete(chunkID)
-	}
-	for _, chunk := range chunks {
-		if err := batch.Index(chunk.ID, chunk); err != nil {
-			return fmt.Errorf("failed to add replacement chunk to batch: %w", err)
-		}
-	}
-	if err := s.index.Batch(batch); err != nil {
-		return fmt.Errorf("failed to replace source chunks: %w", err)
-	}
-
-	chunkIDs := make([]string, len(chunks))
-	for i, chunk := range chunks {
-		chunkIDs[i] = chunk.ID
-	}
-	s.sourceChunks[sourceID] = chunkIDs
-	return nil
-}
-
-// DeleteSource atomically removes all known chunks for sourceID.
-func (s *Service) DeleteSource(ctx context.Context, sourceID string) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	if s.index == nil {
-		return nil
-	}
-	chunkIDs := s.sourceChunks[sourceID]
-	if len(chunkIDs) == 0 {
-		return nil
-	}
-
-	batch := s.index.NewBatch()
-	for _, chunkID := range chunkIDs {
-		batch.Delete(chunkID)
-	}
-	if err := s.index.Batch(batch); err != nil {
-		return fmt.Errorf("failed to delete source chunks: %w", err)
-	}
-	delete(s.sourceChunks, sourceID)
-	return nil
 }
 
 // Close cleans up resources

--- a/internal/search/service_test.go
+++ b/internal/search/service_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	"sync"
 	"testing"
 
 	"github.com/blevesearch/bleve/v2"
@@ -267,45 +266,6 @@ func TestService_ReportsIndexOperationFailures(t *testing.T) {
 	require.Nil(t, results)
 }
 
-func TestService_MutationFailureBoundaries(t *testing.T) {
-	t.Run("replace cancellation and uninitialized index", func(t *testing.T) {
-		service := NewService(testSettings())
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-		require.ErrorIs(t, service.ReplaceSource(ctx, "source", nil), context.Canceled)
-		require.ErrorContains(t, service.ReplaceSource(context.Background(), "source", nil), "not initialized")
-	})
-
-	t.Run("replace and delete batch failures preserve source state", func(t *testing.T) {
-		backing, err := bleve.NewMemOnly(buildMapping())
-		require.NoError(t, err)
-		index := &failingSearchIndex{backing: backing, batchErr: errors.New("batch failed")}
-		service := NewService(testSettings())
-		defer service.Close()
-		service.index = index
-		service.sourceChunks = map[string][]string{"source": {"old"}}
-
-		require.ErrorContains(t, service.ReplaceSource(context.Background(), "source", []domain.Chunk{{ID: "new"}}), "failed to replace source chunks")
-		require.ErrorContains(t, service.DeleteSource(context.Background(), "source"), "failed to delete source chunks")
-		index.batchErr = nil
-		require.NoError(t, service.DeleteSource(context.Background(), "source"))
-		require.NotContains(t, service.sourceChunks, "source")
-	})
-
-	t.Run("delete cancellation, no index, and unknown source", func(t *testing.T) {
-		service := NewService(testSettings())
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-		require.ErrorIs(t, service.DeleteSource(ctx, "source"), context.Canceled)
-		require.NoError(t, service.DeleteSource(context.Background(), "source"))
-		indexChunks(t, service, []domain.Chunk{{ID: "known", SourceID: "known", SourceURI: "acdc://known", ChunkURI: "acdc://known#chunk", Content: "known"}})
-		require.NoError(t, service.DeleteSource(context.Background(), "unknown"))
-		results, err := service.Search("known", 10)
-		require.NoError(t, err)
-		require.Len(t, results, 1)
-	})
-}
-
 func TestService_IndexCreationFailuresPreserveExistingState(t *testing.T) {
 	settings := testSettings()
 	settings.InMemory = false
@@ -452,8 +412,6 @@ func TestService_Index_FailedRebuildPreservesExistingIndex(t *testing.T) {
 }
 
 func TestService_BatchIndexFailures(t *testing.T) {
-	service := NewService(testSettings())
-	defer service.Close()
 	index, err := bleve.NewMemOnly(buildMapping())
 	require.NoError(t, err)
 
@@ -461,14 +419,14 @@ func TestService_BatchIndexFailures(t *testing.T) {
 		stream := make(chan domain.Chunk, 1)
 		stream <- domain.Chunk{Content: "invalid"}
 		close(stream)
-		require.ErrorContains(t, service.batchIndex(context.Background(), index, stream), "failed to add chunk to batch")
+		require.ErrorContains(t, batchIndex(context.Background(), index, stream), "failed to add chunk to batch")
 	})
 	t.Run("reports final batch failure", func(t *testing.T) {
 		stream := make(chan domain.Chunk, 1)
 		stream <- domain.Chunk{ID: "chunk", Content: "valid"}
 		close(stream)
 		mock := &mockBatchIndexer{realIndex: index, batchErr: errors.New("batch failed")}
-		require.ErrorContains(t, service.batchIndex(context.Background(), mock, stream), "failed to execute final batch index")
+		require.ErrorContains(t, batchIndex(context.Background(), mock, stream), "failed to execute final batch index")
 	})
 	t.Run("reports full batch failure", func(t *testing.T) {
 		stream := make(chan domain.Chunk, 100)
@@ -477,7 +435,7 @@ func TestService_BatchIndexFailures(t *testing.T) {
 		}
 		close(stream)
 		mock := &mockBatchIndexer{realIndex: index, batchErr: errors.New("batch failed")}
-		require.ErrorContains(t, service.batchIndex(context.Background(), mock, stream), "failed to execute batch index")
+		require.ErrorContains(t, batchIndex(context.Background(), mock, stream), "failed to execute batch index")
 	})
 }
 
@@ -496,74 +454,6 @@ func TestService_IndexRebuildsAndBatchesChunks(t *testing.T) {
 	count, err = service.DocCount()
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), count)
-}
-
-func TestService_ReplaceAndDeleteSource(t *testing.T) {
-	service := NewService(testSettings())
-	defer service.Close()
-	indexChunks(t, service, []domain.Chunk{{ID: "old", SourceID: "source", SourceURI: "acdc://source", ChunkURI: "acdc://source#old", Content: "legacy"}})
-
-	require.NoError(t, service.ReplaceSource(context.Background(), "source", []domain.Chunk{{ID: "new", SourceID: "source", SourceURI: "acdc://source", ChunkURI: "acdc://source#new", Content: "modern"}}))
-	oldResults, err := service.Search("legacy", 10)
-	require.NoError(t, err)
-	require.Empty(t, oldResults)
-	newResults, err := service.Search("modern", 10)
-	require.NoError(t, err)
-	require.Len(t, newResults, 1)
-
-	require.NoError(t, service.DeleteSource(context.Background(), "source"))
-	newResults, err = service.Search("modern", 10)
-	require.NoError(t, err)
-	require.Empty(t, newResults)
-}
-
-func TestService_ReplaceSource_InvalidChunkPreservesExistingSource(t *testing.T) {
-	service := NewService(testSettings())
-	defer service.Close()
-	indexChunks(t, service, []domain.Chunk{{ID: "old", SourceID: "source", SourceURI: "acdc://source", ChunkURI: "acdc://source#old", Content: "legacy"}})
-
-	err := service.ReplaceSource(context.Background(), "source", []domain.Chunk{{Content: "invalid"}})
-	require.ErrorContains(t, err, "failed to add replacement chunk to batch")
-	results, err := service.Search("legacy", 10)
-	require.NoError(t, err)
-	require.Len(t, results, 1)
-	require.Equal(t, "old", results[0].ChunkID)
-}
-
-func TestService_ReplaceSource_SerializesConcurrentMutations(t *testing.T) {
-	service := NewService(testSettings())
-	defer service.Close()
-	indexChunks(t, service, []domain.Chunk{{ID: "old", SourceID: "source", SourceURI: "acdc://source", ChunkURI: "acdc://source#old", Content: "legacy"}})
-
-	const replacements = 32
-	start := make(chan struct{})
-	errs := make(chan error, replacements)
-	var wait sync.WaitGroup
-	for i := 0; i < replacements; i++ {
-		wait.Add(1)
-		go func(i int) {
-			defer wait.Done()
-			<-start
-			errs <- service.ReplaceSource(context.Background(), "source", []domain.Chunk{{
-				ID:        fmt.Sprintf("replacement-%d", i),
-				SourceID:  "source",
-				SourceURI: "acdc://source",
-				ChunkURI:  fmt.Sprintf("acdc://source#replacement-%d", i),
-				Content:   "replacement",
-			}})
-		}(i)
-	}
-	close(start)
-	wait.Wait()
-	close(errs)
-	for err := range errs {
-		require.NoError(t, err)
-	}
-
-	results, err := service.Search("replacement", replacements)
-	require.NoError(t, err)
-	require.Len(t, results, 1)
-	require.Equal(t, "source", results[0].SourceID)
 }
 
 func chunkIDs(results []SearchResult) []string {

--- a/tests/integration/refresh_test.go
+++ b/tests/integration/refresh_test.go
@@ -1,0 +1,191 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/sha1n/mcp-acdc-server/tests/integration/testkit"
+	"github.com/stretchr/testify/require"
+)
+
+// refreshTimeout and refreshTick bound the require.Eventually polling loops
+// below. The debounce interval under test is 2 seconds; 10 seconds gives a
+// loaded CI machine enough headroom that the timeout signals a genuine
+// failure to refresh rather than scheduling jitter, and the polling itself
+// (calling search) is what drives the debounced refresh forward rather than
+// a fixed sleep.
+const (
+	refreshTimeout = 10 * time.Second
+	refreshTick    = 250 * time.Millisecond
+)
+
+// TestRefresh_NewDocumentBecomesSearchableMidSession proves a document
+// written after the server has started is discovered, indexed and
+// registered without a restart: search is unable to find a term before the
+// file exists, finds it once the debounced refresh has run, and both read
+// and resources/list agree the new document is present.
+func TestRefresh_NewDocumentBecomesSearchableMidSession(t *testing.T) {
+	contentDir := t.TempDir()
+	writeFile(t, contentDir, "README.md", "# Sample Repo\n\nOverview text for the refresh test fixture.\n")
+	writeFile(t, contentDir, "docs/a.md", "# Guide A\n\n"+
+		"## Setup\n\nInstall dependencies before running Guide A procedures.\n")
+
+	client := testkit.NewStdioTestClientForDir(t, contentDir)
+	defer client.Close()
+	ctx := context.Background()
+
+	const term = "crystalburst"
+
+	// Precondition snapshot, asserted once rather than polled: the term
+	// cannot be found before the document containing it exists.
+	searchText := callTextTool(t, ctx, client, "search", map[string]any{"query": term})
+	require.Equal(t, fmt.Sprintf("No results found for '%s'", term), searchText)
+
+	writeFile(t, contentDir, "docs/new.md", "# New Document\n\n"+
+		"## Details\n\nThe unique term "+term+" only appears in this section.\n")
+
+	var found string
+	require.Eventually(t, func() bool {
+		result, err := client.CallTool(ctx, "search", map[string]any{"query": term})
+		if err != nil {
+			return false
+		}
+		text := firstTextContentOrEmpty(result)
+		if !strings.Contains(text, "docs/new.md") {
+			return false
+		}
+		found = text
+		return true
+	}, refreshTimeout, refreshTick, "expected docs/new.md to become searchable after the debounced refresh")
+
+	uri := extractFirstMarkdownURI(t, found)
+	require.True(t, strings.HasPrefix(uri, "acdc://docs/new"), "expected a docs/new resource URI, got %s", uri)
+
+	readText := callTextTool(t, ctx, client, "read", map[string]any{"uri": uri})
+	require.Contains(t, readText, term)
+
+	require.Contains(t, resourceURIs(t, ctx, client), "acdc://docs/new")
+}
+
+// TestRefresh_DeletedDocumentDisappears proves a document removed from the
+// content root mid-session stops being searchable, stops being readable and
+// drops out of resources/list — the half of reconciliation that exercises
+// ResourceRegistrar.Sync's RemoveResources path rather than AddResource.
+func TestRefresh_DeletedDocumentDisappears(t *testing.T) {
+	contentDir := t.TempDir()
+	writeFile(t, contentDir, "README.md", "# Sample Repo\n\nOverview text for the refresh test fixture.\n")
+	const relativePath = "docs/a.md"
+	writeFile(t, contentDir, relativePath, "# Guide A\n\n"+
+		"## Setup\n\nThe unique term driftwoodanchor marks Guide A's setup section.\n")
+
+	client := testkit.NewStdioTestClientForDir(t, contentDir)
+	defer client.Close()
+	ctx := context.Background()
+
+	const term = "driftwoodanchor"
+
+	// Precondition snapshot, asserted once: the term is findable before the
+	// file is deleted.
+	searchText := callTextTool(t, ctx, client, "search", map[string]any{"query": term})
+	require.Contains(t, searchText, "docs/a.md")
+
+	require.NoError(t, os.Remove(filepath.Join(contentDir, filepath.FromSlash(relativePath))))
+
+	require.Eventually(t, func() bool {
+		result, err := client.CallTool(ctx, "search", map[string]any{"query": term})
+		if err != nil {
+			return false
+		}
+		return firstTextContentOrEmpty(result) == fmt.Sprintf("No results found for '%s'", term)
+	}, refreshTimeout, refreshTick, "expected docs/a.md to stop matching after the debounced refresh")
+
+	requireReadFails(t, ctx, client, "acdc://docs/a")
+	require.NotContains(t, resourceURIs(t, ctx, client), "acdc://docs/a")
+}
+
+// TestRefresh_EditedDocumentIsSearchableAndResourceSetUnchanged proves a
+// content edit to an existing document is picked up by search without
+// disturbing the registered resource set: the document keeps its URI, so
+// ResourceRegistrar.Sync must diff it as unchanged rather than remove and
+// re-add it.
+func TestRefresh_EditedDocumentIsSearchableAndResourceSetUnchanged(t *testing.T) {
+	contentDir := t.TempDir()
+	writeFile(t, contentDir, "README.md", "# Sample Repo\n\nOverview text for the refresh test fixture.\n")
+	writeFile(t, contentDir, "docs/a.md", "# Guide A\n\n"+
+		"## Setup\n\nInstall dependencies before running Guide A procedures.\n")
+
+	client := testkit.NewStdioTestClientForDir(t, contentDir)
+	defer client.Close()
+	ctx := context.Background()
+
+	beforeURIs := resourceURIs(t, ctx, client)
+
+	const term = "molybdenumfalcon"
+	// The rewritten file is longer than the original and contains a
+	// different term, so both the cheap walk's size digest and the content
+	// digest are guaranteed to move - a same-size rewrite could otherwise
+	// race the filesystem's mtime resolution and be missed by the cheap
+	// walk gate.
+	writeFile(t, contentDir, "docs/a.md", "# Guide A\n\n"+
+		"## Setup\n\nInstall dependencies before running Guide A procedures.\n\n"+
+		"## Updated\n\nThe unique term "+term+" now appears in this revised section.\n")
+
+	require.Eventually(t, func() bool {
+		result, err := client.CallTool(ctx, "search", map[string]any{"query": term})
+		if err != nil {
+			return false
+		}
+		return strings.Contains(firstTextContentOrEmpty(result), "docs/a.md")
+	}, refreshTimeout, refreshTick, "expected the edited docs/a.md content to become searchable after the debounced refresh")
+
+	require.ElementsMatch(t, beforeURIs, resourceURIs(t, ctx, client))
+}
+
+// resourceURIs returns the URIs currently in the server's resources/list
+// response.
+func resourceURIs(t *testing.T, ctx context.Context, client *testkit.TestClient) []string {
+	t.Helper()
+	result, err := client.ListResources(ctx)
+	require.NoError(t, err)
+	uris := make([]string, 0, len(result.Resources))
+	for _, r := range result.Resources {
+		uris = append(uris, r.URI)
+	}
+	return uris
+}
+
+// requireReadFails asserts that reading uri through the read tool fails,
+// either as a protocol-level error or as a result flagged IsError - the SDK
+// client can surface a tool handler's returned error either way.
+func requireReadFails(t *testing.T, ctx context.Context, client *testkit.TestClient, uri string) {
+	t.Helper()
+	result, err := client.CallTool(ctx, "read", map[string]any{"uri": uri})
+	if err != nil {
+		return
+	}
+	require.NotNil(t, result)
+	require.True(t, result.IsError, "expected read of %s to fail", uri)
+}
+
+// firstTextContentOrEmpty extracts the first text content item from a tool
+// result, or "" if there is none. Unlike the package's require-based text
+// helpers, it makes no test assertions, so it is safe to call from inside a
+// require.Eventually condition, which testify runs on a goroutine other than
+// the test's own.
+func firstTextContentOrEmpty(result *mcp.CallToolResult) string {
+	if result == nil {
+		return ""
+	}
+	for _, item := range result.Content {
+		if content, ok := item.(*mcp.TextContent); ok {
+			return content.Text
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary

The catalog and search index were built exactly once at startup and never revisited. Since zero-config repository mode, that means the server indexes the very documents you are editing — write a design doc, ask the agent about it, and get an answer from the snapshot taken when the session started. The staleness window became a working session rather than a deploy cycle.

This adds a debounced, request-triggered refresh, so edits are picked up without restarting the server.

Closes #82.

## Changes

- **Trigger.** `Revalidate` runs at the start of the `search` and `read` tool handlers and the resource-read handler, debounced at 2s. `resources/list` is served by the SDK with no handler to hook, so it cannot trigger revalidation — it reflects the last refresh a `search`/`read` drove.
- **Two digests.** A read-free walk digest (paths + sizes + mtimes) gates rediscovery; a content digest over `SourceDocument.Fingerprint` gates the rebuild. A pure `touch` therefore costs one walk and nothing else. `resources.Fingerprint` shares discovery's selection walk rather than duplicating the predicate, which is what keeps the gate from drifting out of sync with what `Discover` actually selects.
- **The seam.** New `resources.Catalog` interface plus a `CatalogHolder` over `atomic.Pointer[ResourceProvider]`. `ResourceProvider` stays immutable and each holder method resolves the snapshot exactly once per call, so a swap never tears a call in flight. `internal/mcp` serves through the interface, and `ResourceRegistrar` registers handlers against the **holder**, never a snapshot — that is the property the whole design rests on.
- **Full re-assembly, not an incremental diff.** `search.Service.Index` already builds a fresh index and swaps it atomically, so a failed rebuild leaves the previous index installed. That makes `Searcher.ReplaceSource`/`DeleteSource` permanently unreachable, so they and the per-source chunk bookkeeping only they read are deleted.
- **Registration is diffed** by URI and descriptor, so `notifications/resources/list_changed` fires only on a genuine change to the resource set — an edited document that keeps its URI does not churn it.
- **Refresh-path errors are logged and swallowed by design**: a mid-session discovery or indexing failure leaves the previous catalog serving rather than taking down a live server.

## Decisions worth a reviewer's attention

- **No new configuration surface.** The debounce is an unexported constant — no `ACDC_MCP_*` variable, no flag, no `config.Settings` field. Adding one later is non-breaking; removing one is not.
- **Metadata is frozen at startup.** Refresh re-runs `discover` onward with the metadata and policy resolved once at boot, so `resolveMetadata` keeps exactly one call site and the zero-config invariants hold by construction. A manifest created or edited mid-session needs a restart.
- **Prompts are explicitly out of scope.** They come from `PromptsDir`, a directory absent from every zero-config repository, so they are not part of the problem this solves. They still go stale for the whole session.
- **Unaddressable documents follow `discoverPolicy`.** The SDK's `AddResource` panics on a URI that fails `url.Parse`, so a control character in a filename — legal on Linux and macOS — would have killed a live server mid-session (pre-change it failed at startup instead). Discovery now rejects such a file before it enters the catalog, using the same split that already governs unreadable and unparsable files: fatal under strict with an error naming the file, skipped-with-warning under lenient, and never fatal mid-session. `ResourceRegistrar.Sync` skips it too, as defense in depth.

## Costs and limits

- A rebuild holds the refresher mutex and `search.Service`'s write lock, so concurrent searches stall for its duration. Negligible in repository mode; a real cost for a large curated corpus served over SSE, with no opt-out by design.
- Refresh applies to the legacy `mcp-resources/` discovery mode as well, not only zero-config.
- A persistently failing discovery re-walks and re-parses the corpus once per interval while repeating its warning.
