### PR TITLE
feat(config): expose the heading and path boosts as configuration

### DIFF
--- a/docs/SPECIFICATIONS.md
+++ b/docs/SPECIFICATIONS.md
@@ -24,7 +24,9 @@ The server is configured via environment variables, command-line flags, or a `.e
 | `ACDC_MCP_PORT` | `--port`, `-p` | Port to listen on for SSE transport. | `8080` |
 | `ACDC_MCP_SEARCH_MAX_RESULTS` | `--search-max-results`, `-m` | Max results returned by the search tool. | `10` |
 | `ACDC_MCP_SEARCH_KEYWORDS_BOOST` | `--search-keywords-boost` | Boost factor for keyword matches. | `3.0` |
+| `ACDC_MCP_SEARCH_HEADING_BOOST` | `--search-heading-boost` | Boost factor for heading path (`heading_path`) matches. | `2.5` |
 | `ACDC_MCP_SEARCH_TITLE_BOOST` | `--search-title-boost` | Boost factor for document title (`source_title`) matches. | `2.0` |
+| `ACDC_MCP_SEARCH_PATH_BOOST` | `--search-path-boost` | Boost factor for path label (`path_labels`) matches. | `1.25` |
 | `ACDC_MCP_SEARCH_CONTENT_BOOST` | `--search-content-boost` | Boost factor for content matches. | `1.0` |
 | `ACDC_MCP_SEARCH_RESULT_MODE` | `--search-result-mode` | Search output detail: `references` or `content`. | `references` |
 | `ACDC_MCP_AUTH_TYPE` | `--auth-type`, `-a` | Authentication mode for SSE: `none`, `basic`, `apikey`. | `none` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,9 +23,46 @@ When the same setting is specified in multiple places, the following priority ap
 | `--cross-ref` | — | `ACDC_MCP_CROSS_REF` | Transform relative markdown links between resources into resource URIs | `false` |
 | `--search-max-results` | `-m` | `ACDC_MCP_SEARCH_MAX_RESULTS` | Maximum search results | `10` |
 | `--search-keywords-boost` | — | `ACDC_MCP_SEARCH_KEYWORDS_BOOST` | Boost for keywords matches | `3.0` |
+| `--search-heading-boost` | — | `ACDC_MCP_SEARCH_HEADING_BOOST` | Boost for heading path (`heading_path`) matches | `2.5` |
 | `--search-title-boost` | — | `ACDC_MCP_SEARCH_TITLE_BOOST` | Boost for document title (`source_title`) matches | `2.0` |
+| `--search-path-boost` | — | `ACDC_MCP_SEARCH_PATH_BOOST` | Boost for path label (`path_labels`) matches | `1.25` |
 | `--search-content-boost` | — | `ACDC_MCP_SEARCH_CONTENT_BOOST` | Boost for content matches | `1.0` |
 | `--search-result-mode` | — | `ACDC_MCP_SEARCH_RESULT_MODE` | Search output detail: `references` (chunk citations only) or `content` (citations plus the full matched chunk body) | `references` |
+
+### What the search boosts actually do
+
+A boost is a relative weight within a single normalized query, not a ranking override. What
+raising one buys depends on whether that field is already winning. Raising the boost of a
+field that is losing narrows its gap to the others and then converges — the scores approach
+each other without ever crossing, so no value makes it overtake. Raising the boost of a field
+that already leads widens its score margin without changing its position, because there is no
+position above first. Field length normalization compounds this: a short `heading_path` match
+stays ahead of a long body match largely independently of the weights. Expect to need a change
+of roughly an order of magnitude before any ranking moves, and expect some orderings not to be
+reachable through boosts at all.
+
+Setting a boost to `0` is different in kind: it removes that field from the query entirely
+rather than just weighting it down. Whether that makes a document unreachable depends on
+whether the same words also live in another indexed field:
+
+- `--search-path-boost 0` genuinely removes a retrieval route. Path labels come from the file
+  path and are not duplicated anywhere else, so documents matched only by their path stop
+  being returned. This is the practical way to suppress path-label noise.
+- `--search-heading-boost 0` demotes rather than hides. A chunk's body text begins at its own
+  heading line, so heading words are also indexed as content and the document is still
+  retrieved — lower down. That holds only for a section's first chunk: when a long section is
+  split into multiple chunks, the later ones carry the section's `heading_path` but not its
+  heading line in their content, so for those chunks `--search-heading-boost 0` does hide
+  rather than demote.
+
+Two of the five fields carry no signal on plain repository Markdown. `keywords` comes only
+from YAML frontmatter, and without frontmatter a document's `source_title` is its first `#`
+heading — which is already the head of every chunk's `heading_path`. So in the default
+zero-config mode, `--search-heading-boost`, `--search-path-boost`, and `--search-content-boost`
+are the three boosts that discriminate between documents; `--search-keywords-boost` and
+`--search-title-boost` have nothing to act on until a document supplies frontmatter.
+
+Negative, `NaN`, infinite and unparseable boost values are rejected at startup.
 
 ## Authentication Settings
 

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -10,6 +10,8 @@ func RegisterFlags(flags *pflag.FlagSet) {
 	flags.IntP("port", "p", 0, "Port for SSE transport (default: 8080)")
 	flags.IntP("search-max-results", "m", 0, "Maximum search results (default: 10)")
 	flags.Float64("search-keywords-boost", 0, "Boost for keywords matches (default: 3.0)")
+	flags.Float64("search-heading-boost", 0, "Boost for heading path matches (default: 2.5)")
+	flags.Float64("search-path-boost", 0, "Boost for path label matches (default: 1.25)")
 	flags.Float64("search-title-boost", 0, "Boost for document title matches (default: 2.0)")
 	flags.Float64("search-content-boost", 0, "Boost for content matches (default: 1.0)")
 	flags.String("search-result-mode", "", "Search output mode: references or content (default: references)")

--- a/internal/app/cli_test.go
+++ b/internal/app/cli_test.go
@@ -143,3 +143,25 @@ func TestCLI_FlagParsing_SearchTitleBoost(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 7.5, settings.Search.TitleBoost)
 }
+
+func TestCLI_FlagParsing_SearchHeadingBoost(t *testing.T) {
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	RegisterFlags(flags)
+	require.NoError(t, flags.Set("search-heading-boost", "7.5"))
+
+	settings, err := config.LoadSettingsWithFlags(flags)
+
+	require.NoError(t, err)
+	require.Equal(t, 7.5, settings.Search.HeadingBoost)
+}
+
+func TestCLI_FlagParsing_SearchPathBoost(t *testing.T) {
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	RegisterFlags(flags)
+	require.NoError(t, flags.Set("search-path-boost", "7.5"))
+
+	settings, err := config.LoadSettingsWithFlags(flags)
+
+	require.NoError(t, err)
+	require.Equal(t, 7.5, settings.Search.PathBoost)
+}

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -23,6 +23,8 @@ func LogWithLogger(s *Settings, logger *slog.Logger) {
 	logger.InfoContext(ctx, "Config: search.max_results", "value", s.Search.MaxResults)
 	logger.InfoContext(ctx, "Config: search.in_memory", "value", s.Search.InMemory)
 	logger.InfoContext(ctx, "Config: search.keywords_boost", "value", s.Search.KeywordsBoost)
+	logger.InfoContext(ctx, "Config: search.heading_boost", "value", s.Search.HeadingBoost)
+	logger.InfoContext(ctx, "Config: search.path_boost", "value", s.Search.PathBoost)
 	logger.InfoContext(ctx, "Config: search.title_boost", "value", s.Search.TitleBoost)
 	logger.InfoContext(ctx, "Config: search.content_boost", "value", s.Search.ContentBoost)
 	logger.InfoContext(ctx, "Config: search.result_mode", "value", s.Search.ResultMode)
@@ -43,6 +45,8 @@ func SearchSettingsLogValue(s SearchSettings) slog.Value {
 		slog.Int("max_results", s.MaxResults),
 		slog.Bool("in_memory", s.InMemory),
 		slog.Float64("keywords_boost", s.KeywordsBoost),
+		slog.Float64("heading_boost", s.HeadingBoost),
+		slog.Float64("path_boost", s.PathBoost),
 		slog.Float64("title_boost", s.TitleBoost),
 		slog.Float64("content_boost", s.ContentBoost),
 		slog.String("result_mode", string(s.ResultMode)),

--- a/internal/config/logging_test.go
+++ b/internal/config/logging_test.go
@@ -184,6 +184,33 @@ func TestLogValues(t *testing.T) {
 	})
 }
 
+func TestLog_IncludesHeadingAndPathBoosts(t *testing.T) {
+	captured := make(map[string]any)
+	logger := slog.New(&mapHandler{attrs: captured})
+
+	LogWithLogger(&Settings{
+		Transport: "stdio",
+		Search:    SearchSettings{HeadingBoost: 2.5, PathBoost: 1.25},
+		Auth:      AuthSettings{Type: AuthTypeNone},
+	}, logger)
+
+	assert.Equal(t, 2.5, captured["Config: search.heading_boost"])
+	assert.Equal(t, 1.25, captured["Config: search.path_boost"])
+}
+
+func TestSearchSettingsLogValue_IncludesHeadingAndPathBoosts(t *testing.T) {
+	attrs := SearchSettingsLogValue(SearchSettings{HeadingBoost: 2.5, PathBoost: 1.25}).Group()
+
+	found := make(map[string]float64)
+	for _, attr := range attrs {
+		if attr.Value.Kind() == slog.KindFloat64 {
+			found[attr.Key] = attr.Value.Float64()
+		}
+	}
+	assert.Equal(t, 2.5, found["heading_boost"])
+	assert.Equal(t, 1.25, found["path_boost"])
+}
+
 // Custom handler for testing LogValue output
 type mapHandler struct {
 	attrs map[string]any

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"errors"
+	"fmt"
+	"math"
 	"os"
 	"regexp"
 	"strings"
@@ -21,12 +23,28 @@ const (
 	SearchResultModeContent    SearchResultMode = "content"
 )
 
+// Default relative weights for the five searchable fields. Exported so the
+// viper defaults and ranking-sensitive tests cannot drift apart.
+//
+// A boost is a weight within a normalized disjunction, not a ranking override:
+// raising one clause is bounded by Bleve's per-clause normalization. A boost of
+// 0 removes its field from the query entirely.
+const (
+	DefaultKeywordsBoost float64 = 3.0
+	DefaultTitleBoost    float64 = 2.0
+	DefaultHeadingBoost  float64 = 2.5
+	DefaultPathBoost     float64 = 1.25
+	DefaultContentBoost  float64 = 1.0
+)
+
 // SearchSettings configuration for search service
 type SearchSettings struct {
 	MaxResults    int              `mapstructure:"max_results"`
 	InMemory      bool             `mapstructure:"in_memory"`
 	KeywordsBoost float64          `mapstructure:"keywords_boost"`
+	HeadingBoost  float64          `mapstructure:"heading_boost"`
 	TitleBoost    float64          `mapstructure:"title_boost"`
+	PathBoost     float64          `mapstructure:"path_boost"`
 	ContentBoost  float64          `mapstructure:"content_boost"`
 	ResultMode    SearchResultMode `mapstructure:"result_mode"`
 }
@@ -83,9 +101,11 @@ func LoadSettingsWithFlags(flags *pflag.FlagSet) (*Settings, error) {
 	v.SetDefault("port", 8080)
 	v.SetDefault("uri_scheme", "acdc")
 	v.SetDefault("search.max_results", 10)
-	v.SetDefault("search.keywords_boost", 3.0)
-	v.SetDefault("search.title_boost", 2.0)
-	v.SetDefault("search.content_boost", 1.0)
+	v.SetDefault("search.keywords_boost", DefaultKeywordsBoost)
+	v.SetDefault("search.heading_boost", DefaultHeadingBoost)
+	v.SetDefault("search.title_boost", DefaultTitleBoost)
+	v.SetDefault("search.path_boost", DefaultPathBoost)
+	v.SetDefault("search.content_boost", DefaultContentBoost)
 	v.SetDefault("search.result_mode", SearchResultModeReferences)
 	v.SetDefault("cross_ref", false)
 	v.SetDefault("auth.type", AuthTypeNone)
@@ -100,6 +120,8 @@ func LoadSettingsWithFlags(flags *pflag.FlagSet) (*Settings, error) {
 	// with hardcoded keys. Errors are intentionally discarded here.
 	_ = v.BindEnv("search.max_results", "ACDC_MCP_SEARCH_MAX_RESULTS")
 	_ = v.BindEnv("search.keywords_boost", "ACDC_MCP_SEARCH_KEYWORDS_BOOST")
+	_ = v.BindEnv("search.heading_boost", "ACDC_MCP_SEARCH_HEADING_BOOST")
+	_ = v.BindEnv("search.path_boost", "ACDC_MCP_SEARCH_PATH_BOOST")
 	_ = v.BindEnv("search.title_boost", "ACDC_MCP_SEARCH_TITLE_BOOST")
 	_ = v.BindEnv("search.content_boost", "ACDC_MCP_SEARCH_CONTENT_BOOST")
 	_ = v.BindEnv("search.result_mode", "ACDC_MCP_SEARCH_RESULT_MODE")
@@ -122,6 +144,8 @@ func LoadSettingsWithFlags(flags *pflag.FlagSet) (*Settings, error) {
 		_ = v.BindPFlag("cross_ref", flags.Lookup("cross-ref"))
 		_ = v.BindPFlag("search.max_results", flags.Lookup("search-max-results"))
 		_ = v.BindPFlag("search.keywords_boost", flags.Lookup("search-keywords-boost"))
+		_ = v.BindPFlag("search.heading_boost", flags.Lookup("search-heading-boost"))
+		_ = v.BindPFlag("search.path_boost", flags.Lookup("search-path-boost"))
 		_ = v.BindPFlag("search.title_boost", flags.Lookup("search-title-boost"))
 		_ = v.BindPFlag("search.content_boost", flags.Lookup("search-content-boost"))
 		_ = v.BindPFlag("search.result_mode", flags.Lookup("search-result-mode"))
@@ -183,6 +207,10 @@ func ValidateSettings(s *Settings) error {
 		return errors.New("search result mode must be 'references' or 'content', got: " + string(s.Search.ResultMode))
 	}
 
+	if err := validateBoosts(s.Search); err != nil {
+		return err
+	}
+
 	hasBasicCreds := s.Auth.Basic.Username != "" || s.Auth.Basic.Password != ""
 	hasAPIKeys := len(s.Auth.APIKeys) > 0
 
@@ -209,5 +237,26 @@ func ValidateSettings(s *Settings) error {
 		return errors.New("unknown auth-type: " + s.Auth.Type)
 	}
 
+	return nil
+}
+
+// validateBoosts rejects boost values Bleve cannot score meaningfully. Zero is
+// legal and disables the field's clause.
+func validateBoosts(s SearchSettings) error {
+	boosts := []struct {
+		key   string
+		value float64
+	}{
+		{"search.keywords_boost", s.KeywordsBoost},
+		{"search.heading_boost", s.HeadingBoost},
+		{"search.title_boost", s.TitleBoost},
+		{"search.path_boost", s.PathBoost},
+		{"search.content_boost", s.ContentBoost},
+	}
+	for _, boost := range boosts {
+		if math.IsNaN(boost.value) || math.IsInf(boost.value, 0) || boost.value < 0 {
+			return fmt.Errorf("%s must be a finite, non-negative number, got: %v", boost.key, boost.value)
+		}
+	}
 	return nil
 }

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"math"
 	"os"
 	"strings"
 	"testing"
@@ -758,4 +759,131 @@ func TestLoadSettings_SearchTitleBoostIgnoresRetiredNameEnvVar(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, 2.0, settings.Search.TitleBoost)
+}
+
+func TestLoadSettings_SearchHeadingBoostDefault(t *testing.T) {
+	settings, err := LoadSettings()
+
+	require.NoError(t, err)
+	require.Equal(t, 2.5, settings.Search.HeadingBoost)
+}
+
+func TestLoadSettings_SearchPathBoostDefault(t *testing.T) {
+	settings, err := LoadSettings()
+
+	require.NoError(t, err)
+	require.Equal(t, 1.25, settings.Search.PathBoost)
+}
+
+func TestLoadSettings_SearchHeadingBoostEnvVar(t *testing.T) {
+	t.Setenv("ACDC_MCP_SEARCH_HEADING_BOOST", "4.5")
+
+	settings, err := LoadSettings()
+
+	require.NoError(t, err)
+	require.Equal(t, 4.5, settings.Search.HeadingBoost)
+}
+
+func TestLoadSettings_SearchPathBoostEnvVar(t *testing.T) {
+	t.Setenv("ACDC_MCP_SEARCH_PATH_BOOST", "0.5")
+
+	settings, err := LoadSettings()
+
+	require.NoError(t, err)
+	require.Equal(t, 0.5, settings.Search.PathBoost)
+}
+
+func TestLoadSettingsWithFlags_SearchHeadingBoostFlagBeatsEnvVar(t *testing.T) {
+	t.Setenv("ACDC_MCP_SEARCH_HEADING_BOOST", "4.5")
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.Float64("search-heading-boost", 0, "")
+	require.NoError(t, flags.Set("search-heading-boost", "6.0"))
+
+	settings, err := LoadSettingsWithFlags(flags)
+
+	require.NoError(t, err)
+	require.Equal(t, 6.0, settings.Search.HeadingBoost)
+}
+
+func TestLoadSettingsWithFlags_SearchPathBoostFlagBeatsEnvVar(t *testing.T) {
+	t.Setenv("ACDC_MCP_SEARCH_PATH_BOOST", "0.5")
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.Float64("search-path-boost", 0, "")
+	require.NoError(t, flags.Set("search-path-boost", "3.0"))
+
+	settings, err := LoadSettingsWithFlags(flags)
+
+	require.NoError(t, err)
+	require.Equal(t, 3.0, settings.Search.PathBoost)
+}
+
+// The exported defaults and the values viper installs must not drift apart.
+func TestLoadSettings_BoostDefaultsMatchExportedConstants(t *testing.T) {
+	settings, err := LoadSettings()
+
+	require.NoError(t, err)
+	require.Equal(t, DefaultKeywordsBoost, settings.Search.KeywordsBoost)
+	require.Equal(t, DefaultTitleBoost, settings.Search.TitleBoost)
+	require.Equal(t, DefaultHeadingBoost, settings.Search.HeadingBoost)
+	require.Equal(t, DefaultPathBoost, settings.Search.PathBoost)
+	require.Equal(t, DefaultContentBoost, settings.Search.ContentBoost)
+}
+
+func TestValidateSettings_RejectsInvalidBoosts(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*SearchSettings)
+		wantErr string
+	}{
+		{"negative keywords", func(s *SearchSettings) { s.KeywordsBoost = -1 }, "search.keywords_boost"},
+		{"negative heading", func(s *SearchSettings) { s.HeadingBoost = -0.5 }, "search.heading_boost"},
+		{"negative title", func(s *SearchSettings) { s.TitleBoost = -1 }, "search.title_boost"},
+		{"negative path", func(s *SearchSettings) { s.PathBoost = -1 }, "search.path_boost"},
+		{"negative content", func(s *SearchSettings) { s.ContentBoost = -1 }, "search.content_boost"},
+		{"NaN heading", func(s *SearchSettings) { s.HeadingBoost = math.NaN() }, "search.heading_boost"},
+		{"positive infinity path", func(s *SearchSettings) { s.PathBoost = math.Inf(1) }, "search.path_boost"},
+		{"negative infinity content", func(s *SearchSettings) { s.ContentBoost = math.Inf(-1) }, "search.content_boost"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			search := SearchSettings{ResultMode: SearchResultModeReferences}
+			tt.mutate(&search)
+			s := &Settings{Transport: "stdio", Scheme: "acdc", Search: search, Auth: AuthSettings{Type: AuthTypeNone}}
+
+			err := ValidateSettings(s)
+
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+// Zero disables a field's contribution and is a supported operator choice —
+// notably as a mitigation for fuzzy path-label noise. It must never be rejected.
+func TestValidateSettings_AcceptsZeroBoosts(t *testing.T) {
+	s := &Settings{
+		Transport: "stdio",
+		Scheme:    "acdc",
+		Search: SearchSettings{
+			ResultMode:    SearchResultModeReferences,
+			KeywordsBoost: 0, HeadingBoost: 0, TitleBoost: 0, PathBoost: 0, ContentBoost: 0,
+		},
+		Auth: AuthSettings{Type: AuthTypeNone},
+	}
+
+	require.NoError(t, ValidateSettings(s))
+}
+
+// A malformed boost fails to decode rather than coercing to zero, which would
+// silently disable the field. Pinned because validateBoosts cannot catch a
+// value that has already become a legal 0.
+func TestLoadSettings_MalformedBoostIsRejected(t *testing.T) {
+	t.Setenv("ACDC_MCP_SEARCH_HEADING_BOOST", "2.5x")
+
+	settings, err := LoadSettings()
+
+	require.Error(t, err)
+	require.Nil(t, settings)
+	require.Contains(t, err.Error(), "search.heading_boost")
 }

--- a/internal/search/golden_test.go
+++ b/internal/search/golden_test.go
@@ -347,3 +347,69 @@ func TestGolden_ContentBoostCannotOutweighAHeadingMatch(t *testing.T) {
 		})
 	}
 }
+
+// TestGolden_HeadingBoostInfluenceIsBounded measures what the heading boost
+// buys once it is configurable, over the same document pair as
+// TestGolden_ContentBoostCannotOutweighAHeadingMatch: the internals page
+// carries "checksums" as a heading and never in its body, the CLI reference
+// carries it in a body and in no heading.
+//
+// The influence is not symmetric, and not for the reason it might seem.
+// Raising heading_boost cannot change the ranking here because the
+// heading-only document already leads at the default 2.5: ranks at 2.5 and
+// at 1000 are identical because rank 1 has nowhere left to go, not because a
+// large boost is inert. (Scores do keep moving — at 1000 the heading match's
+// score is over 4000x the body match's, versus ~12x at 2.5 — the ranks just
+// can't reflect it.) The measured bound on how far a boost can pull a
+// *losing* clause toward overtaking a winner is established separately, by
+// the sibling test TestGolden_ContentBoostCannotOutweighAHeadingMatch, which
+// raises content_boost against this same heading match instead.
+//
+// The boost: 1000 row is not evidence of a bound; it pins that a very large
+// boost does not destabilize the ordering (for example through score
+// overflow), which is a fact worth guarding on its own even though the rank
+// it asserts cannot change by construction.
+//
+// Lowering heading_boost to 0 does drop the heading_path clause from the
+// query, but it does not remove the heading-only document's only route to
+// the term: the chunker slices a section's Content starting at its own
+// heading line, so the heading text is also present in the content field and
+// keeps matching through the content_boost clause. At heading_boost 0 the
+// heading-only document therefore still surfaces, just behind the body match
+// instead of ahead of it — measured, not predicted. That asymmetry, plus the
+// content-field duplication behind it, is the honest description of what an
+// operator gets from --search-heading-boost at 0; docs/configuration.md
+// should say so. Expectations here are measured, not desired; a change means
+// the ranking model moved.
+func TestGolden_HeadingBoostInfluenceIsBounded(t *testing.T) {
+	const (
+		query       = "checksums"
+		headingOnly = "acdc://docs/internals/indexing#checksums"
+		bodyOnly    = "acdc://docs/reference/cli#ledger-verify"
+	)
+
+	tests := []struct {
+		boost       float64
+		wantHeading int
+		wantBody    int
+	}{
+		{boost: 0, wantHeading: 2, wantBody: 1},
+		{boost: 0.1, wantHeading: 1, wantBody: 2},
+		{boost: 2.5, wantHeading: 1, wantBody: 2},
+		{boost: 1000, wantHeading: 1, wantBody: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("heading_boost_%g", tt.boost), func(t *testing.T) {
+			settings := testSettings()
+			settings.HeadingBoost = tt.boost
+			service := goldenServiceWith(t, settings, zeroConfigCorpus)
+
+			results, err := service.Search(query, goldenCandidates)
+			require.NoError(t, err)
+			reportRanking(t, query, results)
+			require.Equal(t, tt.wantHeading, rankOf(results, headingOnly), "heading-only document at heading_boost %g", tt.boost)
+			require.Equal(t, tt.wantBody, rankOf(results, bodyOnly), "body-only document at heading_boost %g", tt.boost)
+		})
+	}
+}

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -13,11 +13,6 @@ import (
 	"github.com/sha1n/mcp-acdc-server/internal/domain"
 )
 
-const (
-	headingBoost = 2.5
-	pathBoost    = 1.25
-)
-
 var (
 	newMemoryIndex = bleve.NewMemOnly
 	makeTempDir    = os.MkdirTemp
@@ -229,13 +224,7 @@ func (s *Service) Search(queryStr string, candidateLimit int) ([]SearchResult, e
 	if queryStr == "*" {
 		q = bleve.NewMatchAllQuery()
 	} else {
-		q = bleve.NewDisjunctionQuery(
-			fieldQuery(queryStr, domain.FieldKeywords, s.settings.KeywordsBoost),
-			fieldQuery(queryStr, domain.FieldHeadingPath, headingBoost),
-			fieldQuery(queryStr, domain.FieldSourceTitle, s.settings.TitleBoost),
-			fieldQuery(queryStr, domain.FieldPathLabels, pathBoost),
-			fieldQuery(queryStr, domain.FieldContent, s.settings.ContentBoost),
-		)
+		q = bleve.NewDisjunctionQuery(s.boostedFieldQueries(queryStr)...)
 	}
 
 	searchRequest := bleve.NewSearchRequest(q)
@@ -276,6 +265,35 @@ func (s *Service) Search(queryStr string, candidateLimit int) ([]SearchResult, e
 	}
 
 	return results, nil
+}
+
+// boostedFieldQueries builds one match clause per field carrying a positive boost.
+// Bleve's boost only scales a matching clause's score contribution — it does not
+// stop the clause from matching — so a field configured at boost 0 is omitted
+// entirely rather than included with a score of zero. The guard is <= 0, not
+// == 0, because NewService accepts an unvalidated SearchSettings: a negative
+// boost would feed a negative weight into bleve's sumOfSquaredWeights,
+// producing a NaN queryNorm and NaN scores for every clause, not just its own.
+func (s *Service) boostedFieldQueries(queryStr string) []query.Query {
+	fields := []struct {
+		name  string
+		boost float64
+	}{
+		{domain.FieldKeywords, s.settings.KeywordsBoost},
+		{domain.FieldHeadingPath, s.settings.HeadingBoost},
+		{domain.FieldSourceTitle, s.settings.TitleBoost},
+		{domain.FieldPathLabels, s.settings.PathBoost},
+		{domain.FieldContent, s.settings.ContentBoost},
+	}
+
+	queries := make([]query.Query, 0, len(fields))
+	for _, f := range fields {
+		if f.boost <= 0 {
+			continue
+		}
+		queries = append(queries, fieldQuery(queryStr, f.name, f.boost))
+	}
+	return queries
 }
 
 func fieldQuery(queryStr, field string, boost float64) *query.MatchQuery {

--- a/internal/search/service_test.go
+++ b/internal/search/service_test.go
@@ -64,9 +64,11 @@ func testSettings() config.SearchSettings {
 	return config.SearchSettings{
 		InMemory:      true,
 		MaxResults:    10,
-		KeywordsBoost: 3,
-		TitleBoost:    2,
-		ContentBoost:  1,
+		KeywordsBoost: config.DefaultKeywordsBoost,
+		HeadingBoost:  config.DefaultHeadingBoost,
+		TitleBoost:    config.DefaultTitleBoost,
+		PathBoost:     config.DefaultPathBoost,
+		ContentBoost:  config.DefaultContentBoost,
 	}
 }
 
@@ -462,4 +464,64 @@ func chunkIDs(results []SearchResult) []string {
 		ids[i] = result.ChunkID
 	}
 	return ids
+}
+
+// TestSearch_ReadsHeadingAndPathBoostsFromSettings pins that both boosts are
+// configuration rather than constants. Zeroing the heading boost must remove the
+// heading_path clause from the query, letting a body-only match overtake a
+// heading-only one — the ordering TestSearch_ChunkFieldBoosts pins at defaults.
+func TestSearch_ReadsHeadingAndPathBoostsFromSettings(t *testing.T) {
+	newService := func(t *testing.T, mutate func(*config.SearchSettings)) *Service {
+		t.Helper()
+		settings := testSettings()
+		mutate(&settings)
+		service := NewService(settings)
+		t.Cleanup(service.Close)
+		indexChunks(t, service, []domain.Chunk{
+			{
+				ID: "heading", SourceID: "heading-source",
+				SourceURI: "acdc://heading", ChunkURI: "acdc://heading#chunk",
+				HeadingPath: []string{"oauth"}, Content: "unrelated",
+			},
+			{
+				ID: "body", SourceID: "body-source",
+				SourceURI: "acdc://body", ChunkURI: "acdc://body#chunk",
+				Content: "oauth",
+			},
+		})
+		return service
+	}
+
+	t.Run("heading boost leads at the default", func(t *testing.T) {
+		results, err := newService(t, func(*config.SearchSettings) {}).Search("oauth", 10)
+		require.NoError(t, err)
+		require.Len(t, results, 2)
+		require.Equal(t, "heading", results[0].ChunkID)
+	})
+
+	t.Run("zero heading boost removes the clause", func(t *testing.T) {
+		results, err := newService(t, func(s *config.SearchSettings) { s.HeadingBoost = 0 }).Search("oauth", 10)
+		require.NoError(t, err)
+		require.NotEmpty(t, results)
+		require.Equal(t, "body", results[0].ChunkID)
+	})
+
+	t.Run("zero path boost removes the clause", func(t *testing.T) {
+		service := NewService(func() config.SearchSettings {
+			s := testSettings()
+			s.PathBoost = 0
+			s.ContentBoost = 0
+			return s
+		}())
+		t.Cleanup(service.Close)
+		indexChunks(t, service, []domain.Chunk{{
+			ID: "path", SourceID: "path-source",
+			SourceURI: "acdc://path", ChunkURI: "acdc://path#chunk",
+			PathLabels: []string{"oauth"}, Content: "unrelated",
+		}})
+
+		results, err := service.Search("oauth", 10)
+		require.NoError(t, err)
+		require.Empty(t, results, "no clause can match once path and content boosts are zero")
+	})
 }


### PR DESCRIPTION
Closes #84.

## Summary

`heading_path` and `path_labels` were the only two of the five search boosts still hard-coded, while `keywords`, `source_title` and `content` already had flags and environment variables. This promotes both to the standard configuration path with their current values as defaults, so ranking at default settings is unchanged.

The split mattered more than it looked. On frontmatter-free repository Markdown — the mode the server defaults to since #78 — `keywords` never matches, and a `source_title` match is always already a `heading_path` match. Two of the five fields are inert there, and one of the three that still discriminate could not be adjusted.

## Changes

- `--search-heading-boost` / `ACDC_MCP_SEARCH_HEADING_BOOST` (default `2.5`) and `--search-path-boost` / `ACDC_MCP_SEARCH_PATH_BOOST` (default `1.25`), wired identically to the existing three. The five defaults are now exported constants in `internal/config` so the viper defaults and the search test fixture cannot drift.
- **One non-additive change:** `ValidateSettings` now rejects negative, NaN and infinite boosts for **all five** settings, including the three that previously accepted them silently. `0` stays legal.
- `0` removes a field's clause from the query entirely. bleve's `SetBoost(0)` only zeroes a clause's score without stopping it matching, so `boostedFieldQueries` omits zero-boost fields instead. An all-zero configuration yields a clauseless disjunction, which bleve answers with a match-none searcher — empty results, no error.
- `docs/configuration.md` gains a section on what boosts actually do, written against measurements rather than intuition. Raising the boost of a field that is *losing* narrows its gap and converges without ever overtaking; raising one that already *leads* widens its score margin without changing its position. Setting `--search-path-boost 0` removes a retrieval route outright, but `--search-heading-boost 0` usually only demotes, because the first chunk of a section begins at its own heading line and so heading words are indexed as content too.

## Risk

The only commit that can alter search results is the one that rewires the query. Its behavior at default settings was checked by diffing the golden harness's verbose ranking output between this branch and `master`: every pre-existing ranking line is identical, scores included. Each commit builds and passes the full suite standalone; coverage holds at 98.5%.

## Known gaps, deliberately left for a follow-up issue

- Setting all five boosts to `0` passes validation and silently disables search — real queries return nothing while `*` still returns everything.
- `validateBoosts` accepts finite values that overflow inside bleve. Above roughly `1e200` the squared weight becomes `+Inf`, `queryNorm` collapses to `0`, and ranking inverts to the tiebreak order.