### PR TITLE
fix(search): match path labels exactly instead of fuzzily

### DIFF
--- a/docs/SPECIFICATIONS.md
+++ b/docs/SPECIFICATIONS.md
@@ -150,7 +150,7 @@ Performs a full-text search over indexed chunks and returns chunk citations, opt
     }
     ```
 *   **Behavior:**
-    *   Searches against `source_title`, `path_labels`, `heading_path`, `content`, and `keywords` fields using fuzzy matching (distance 1) and stemming.
+    *   Searches against `source_title`, `path_labels`, `heading_path`, `content`, and `keywords` fields, with stemming throughout; fuzzy matching (distance 1) applies to all but `path_labels`, which is matched exactly.
     *   Applies boosting: `keywords` (3.0, configurable), `heading_path` (2.5), `source_title` (2.0, configurable), `path_labels` (1.25), `content` (1.0, configurable).
     *   Applies per-source-document result diversity — see [Chunking and Fragment URIs](#3-chunking-and-fragment-uris-both-modes).
 *   **Output:**
@@ -239,7 +239,7 @@ Used for remote connections.
 *   **Engine**: Bleve (Go) full-text search engine.
 *   **Indexing**: Indexes document chunks (not whole documents), in-memory or in a temporary directory — no persistence across restarts. Built in full at startup, and rebuilt in full again mid-session whenever a debounced refresh detects a content change; see [Content Refresh](#content-refresh) for the trigger, debounce interval, and concurrency cost.
 *   **Features**:
-    *   **Fuzzy Search**: Matches terms with an edit distance of 1.
+    *   **Fuzzy Search**: Matches terms with an edit distance of 1 on four of the five indexed fields; `path_labels` is matched exactly.
     *   **Stemming**: Uses the standard English analyzer for language-aware matching.
     *   **Highlighting**: Generates dynamic snippets with search term context.
     *   **Result Diversity**: Caps results per source document (1 in `references` mode, 2 in `content` mode) so results aren't dominated by a single document.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,7 +47,7 @@ whether the same words also live in another indexed field:
 
 - `--search-path-boost 0` genuinely removes a retrieval route. Path labels come from the file
   path and are not duplicated anywhere else, so documents matched only by their path stop
-  being returned. This is the practical way to suppress path-label noise.
+  being returned.
 - `--search-heading-boost 0` demotes rather than hides. A chunk's body text begins at its own
   heading line, so heading words are also indexed as content and the document is still
   retrieved — lower down. That holds only for a section's first chunk: when a long section is
@@ -70,6 +70,34 @@ magnitudes no meaningful ranking could use; the boundary itself is accepted, and
 strictly above it are rejected. Setting *all five* boosts to `0` is also rejected: the query
 would carry no clauses at all, so every search would return nothing while reporting success.
 Zeroing any subset of the five remains supported.
+
+### How closely a query has to match
+
+Four of the five indexed fields tolerate a single-character difference between a query term and
+an indexed term, so a mistyped `authentcation` still finds the authentication page. `path_labels`
+does not: it is matched exactly.
+
+The asymmetry is deliberate. Path labels are a small vocabulary of short path segments, and they
+are the only field whose terms appear nowhere else in the index — heading text is also indexed as
+content, but a path label comes from the file path alone. Nearly every segment therefore has a
+neighbour within one edit, so tolerating differences there retrieves documents on words they do
+not contain: a query for `readiness` matched the path label `readme` and filled ranks 2 through 5
+of the result page with README chunks that never mention it.
+
+Tolerance is narrow, and it applies to *stems* rather than to the words you typed — the English
+analyzer reduces both the query term and the indexed term before they are compared. How much a
+given misspelling gets rescued therefore depends on whether it still stems. `authentcation`
+finds the authentication page and `cheksums` finds the checksums section, but `deploymnet` does
+not find `deployment`: it fails to stem at all, which leaves it four edits from that word's
+`deploy` stem rather than the one edit the raw spellings suggest. Bleve measures plain
+Levenshtein distance, so swapping two adjacent characters costs two edits, not one. Nor does
+this tolerance bridge spelling variants such as `authorisation` against `authorization`. Plural
+and tense differences are handled by the analyzer before matching, not by this tolerance at all.
+
+Two alternatives were measured and rejected. A minimum matching prefix does not help: the terms
+that collide here already share their first four characters. Bleve's automatic mode is worse — it
+raises the tolerance to two characters for any term longer than five, which widens exactly the
+problem described above.
 
 ## Authentication Settings
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,7 +62,9 @@ zero-config mode, `--search-heading-boost`, `--search-path-boost`, and `--search
 are the three boosts that discriminate between documents; `--search-keywords-boost` and
 `--search-title-boost` have nothing to act on until a document supplies frontmatter.
 
-Negative, `NaN`, infinite and unparseable boost values are rejected at startup.
+Negative, `NaN`, infinite and unparseable boost values are rejected at startup. Setting *all
+five* boosts to `0` is also rejected: the query would carry no clauses at all, so every search
+would return nothing while reporting success. Zeroing any subset of the five remains supported.
 
 ## Authentication Settings
 
@@ -124,6 +126,7 @@ The server validates configuration at startup and will fail with a clear error i
 
 - `--uri-scheme` is empty or doesn't match RFC 3986 (must start with a letter, then letters/digits/`+`/`-`/`.`)
 - `--search-result-mode` is set to anything other than `references` or `content`
+- every search boost is `0`, which would leave the query with no clauses and silently return no results
 - `--auth-type=basic` is set without username/password
 - `--auth-type=apikey` is set without API keys
 - `--auth-type=none` is set with auth credentials (conflicting intent)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,9 +62,14 @@ zero-config mode, `--search-heading-boost`, `--search-path-boost`, and `--search
 are the three boosts that discriminate between documents; `--search-keywords-boost` and
 `--search-title-boost` have nothing to act on until a document supplies frontmatter.
 
-Negative, `NaN`, infinite and unparseable boost values are rejected at startup. Setting *all
-five* boosts to `0` is also rejected: the query would carry no clauses at all, so every search
-would return nothing while reporting success. Zeroing any subset of the five remains supported.
+Negative, `NaN`, infinite and unparseable boost values are rejected at startup, as are values
+above roughly `1.34e154`. That cap is a conservative sanity check, not a guarantee that scoring
+stays sound below it: Bleve squares boost × idf, not the boost alone, so on a real corpus a
+boost far below the cap can already collapse every score to zero. The cap only rejects
+magnitudes no meaningful ranking could use; the boundary itself is accepted, and only values
+strictly above it are rejected. Setting *all five* boosts to `0` is also rejected: the query
+would carry no clauses at all, so every search would return nothing while reporting success.
+Zeroing any subset of the five remains supported.
 
 ## Authentication Settings
 
@@ -127,6 +132,8 @@ The server validates configuration at startup and will fail with a clear error i
 - `--uri-scheme` is empty or doesn't match RFC 3986 (must start with a letter, then letters/digits/`+`/`-`/`.`)
 - `--search-result-mode` is set to anything other than `references` or `content`
 - every search boost is `0`, which would leave the query with no clauses and silently return no results
+- a search boost exceeds `1.34e154`, a conservative sanity cap beyond which no meaningful ranking
+  could use the value (smaller boosts can still degenerate scoring — see above)
 - `--auth-type=basic` is set without username/password
 - `--auth-type=apikey` is set without API keys
 - `--auth-type=none` is set with auth credentials (conflicting intent)

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -240,8 +240,10 @@ func ValidateSettings(s *Settings) error {
 	return nil
 }
 
-// validateBoosts rejects boost values Bleve cannot score meaningfully. Zero is
-// legal and disables the field's clause.
+// validateBoosts rejects boost values Bleve cannot score meaningfully. An
+// individual zero is legal and disables that field's clause; all five at zero
+// is not, because the resulting clauseless disjunction answers every query
+// with nothing while reporting no error.
 func validateBoosts(s SearchSettings) error {
 	boosts := []struct {
 		key   string
@@ -253,10 +255,17 @@ func validateBoosts(s SearchSettings) error {
 		{"search.path_boost", s.PathBoost},
 		{"search.content_boost", s.ContentBoost},
 	}
+	anyPositive := false
 	for _, boost := range boosts {
 		if math.IsNaN(boost.value) || math.IsInf(boost.value, 0) || boost.value < 0 {
 			return fmt.Errorf("%s must be a finite, non-negative number, got: %v", boost.key, boost.value)
 		}
+		if boost.value > 0 {
+			anyPositive = true
+		}
+	}
+	if !anyPositive {
+		return errors.New("at least one search boost must be positive; all five at zero disables search entirely")
 	}
 	return nil
 }

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -240,6 +240,15 @@ func ValidateSettings(s *Settings) error {
 	return nil
 }
 
+// maxBoost is a conservative sanity cap on search boosts, not a guarantee
+// that scoring stays sound below it. Bleve's term weight squares boost × idf,
+// not the boost alone, so a value well under this cap can already collapse
+// every score to zero on a corpus whose idf is large enough. The true
+// overflow threshold depends on corpus statistics and clause count, neither
+// known at configuration-validation time, so this cap only rejects
+// magnitudes no meaningful ranking could ever use.
+var maxBoost = math.Sqrt(math.MaxFloat64)
+
 // validateBoosts rejects boost values Bleve cannot score meaningfully. An
 // individual zero is legal and disables that field's clause; all five at zero
 // is not, because the resulting clauseless disjunction answers every query
@@ -260,12 +269,15 @@ func validateBoosts(s SearchSettings) error {
 		if math.IsNaN(boost.value) || math.IsInf(boost.value, 0) || boost.value < 0 {
 			return fmt.Errorf("%s must be a finite, non-negative number, got: %v", boost.key, boost.value)
 		}
+		if boost.value > maxBoost {
+			return fmt.Errorf("%s must not exceed %v, a sanity cap on search boosts, got: %v", boost.key, maxBoost, boost.value)
+		}
 		if boost.value > 0 {
 			anyPositive = true
 		}
 	}
 	if !anyPositive {
-		return errors.New("at least one search boost must be positive; all five at zero disables search entirely")
+		return errors.New("at least one of search.keywords_boost, search.heading_boost, search.title_boost, search.path_boost, or search.content_boost must be positive; all five at zero disables search entirely")
 	}
 	return nil
 }

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -336,8 +336,24 @@ func TestLoadSettingsWithFlags_SearchResultModeDefaultsToReferences(t *testing.T
 
 // --- ValidateSettings Tests ---
 
+// defaultSearchSettings returns a SearchSettings populated with the default
+// boosts and the default result mode. ValidateSettings rejects an all-zero
+// boost configuration, so tests exercising unrelated validation rules — auth,
+// transport, scheme — can no longer rely on the Go zero value here and start
+// from this instead, mutating only the field under test.
+func defaultSearchSettings() SearchSettings {
+	return SearchSettings{
+		ResultMode:    SearchResultModeReferences,
+		KeywordsBoost: DefaultKeywordsBoost,
+		HeadingBoost:  DefaultHeadingBoost,
+		TitleBoost:    DefaultTitleBoost,
+		PathBoost:     DefaultPathBoost,
+		ContentBoost:  DefaultContentBoost,
+	}
+}
+
 func TestValidateSettings_ValidNone(t *testing.T) {
-	s := &Settings{Transport: "stdio", Scheme: "acdc", Search: SearchSettings{ResultMode: SearchResultModeReferences}, Auth: AuthSettings{Type: AuthTypeNone}}
+	s := &Settings{Transport: "stdio", Scheme: "acdc", Search: defaultSearchSettings(), Auth: AuthSettings{Type: AuthTypeNone}}
 	if err := ValidateSettings(s); err != nil {
 		t.Errorf("Expected no error for valid none auth, got: %v", err)
 	}
@@ -347,17 +363,15 @@ func TestValidateSettings_SearchResultMode(t *testing.T) {
 	settings := &Settings{
 		Transport: "stdio",
 		Scheme:    "acdc",
-		Search: SearchSettings{
-			ResultMode: SearchResultModeReferences,
-		},
-		Auth: AuthSettings{Type: AuthTypeNone},
+		Search:    defaultSearchSettings(),
+		Auth:      AuthSettings{Type: AuthTypeNone},
 	}
 	settings.Search.ResultMode = "verbose"
 	require.EqualError(t, ValidateSettings(settings), "search result mode must be 'references' or 'content', got: verbose")
 }
 
 func TestValidateSettings_ValidNone_EmptyType(t *testing.T) {
-	s := &Settings{Transport: "stdio", Scheme: "acdc", Search: SearchSettings{ResultMode: SearchResultModeReferences}, Auth: AuthSettings{Type: ""}}
+	s := &Settings{Transport: "stdio", Scheme: "acdc", Search: defaultSearchSettings(), Auth: AuthSettings{Type: ""}}
 	if err := ValidateSettings(s); err != nil {
 		t.Errorf("Expected no error for empty auth type, got: %v", err)
 	}
@@ -367,7 +381,7 @@ func TestValidateSettings_ValidBasic(t *testing.T) {
 	s := &Settings{
 		Transport: "stdio",
 		Scheme:    "acdc",
-		Search:    SearchSettings{ResultMode: SearchResultModeReferences},
+		Search:    defaultSearchSettings(),
 		Auth: AuthSettings{
 			Type: AuthTypeBasic,
 			Basic: BasicAuthSettings{
@@ -385,7 +399,7 @@ func TestValidateSettings_ValidAPIKey(t *testing.T) {
 	s := &Settings{
 		Transport: "stdio",
 		Scheme:    "acdc",
-		Search:    SearchSettings{ResultMode: SearchResultModeReferences},
+		Search:    defaultSearchSettings(),
 		Auth: AuthSettings{
 			Type:    AuthTypeAPIKey,
 			APIKeys: []string{"key1", "key2"},
@@ -406,7 +420,7 @@ func TestValidateSettings_NoneWithCredentials(t *testing.T) {
 			settings: Settings{
 				Transport: "stdio",
 				Scheme:    "acdc",
-				Search:    SearchSettings{ResultMode: SearchResultModeReferences},
+				Search:    defaultSearchSettings(),
 				Auth: AuthSettings{
 					Type:  AuthTypeNone,
 					Basic: BasicAuthSettings{Username: "admin"},
@@ -418,7 +432,7 @@ func TestValidateSettings_NoneWithCredentials(t *testing.T) {
 			settings: Settings{
 				Transport: "stdio",
 				Scheme:    "acdc",
-				Search:    SearchSettings{ResultMode: SearchResultModeReferences},
+				Search:    defaultSearchSettings(),
 				Auth: AuthSettings{
 					Type:  AuthTypeNone,
 					Basic: BasicAuthSettings{Password: "secret"},
@@ -430,7 +444,7 @@ func TestValidateSettings_NoneWithCredentials(t *testing.T) {
 			settings: Settings{
 				Transport: "stdio",
 				Scheme:    "acdc",
-				Search:    SearchSettings{ResultMode: SearchResultModeReferences},
+				Search:    defaultSearchSettings(),
 				Auth: AuthSettings{
 					Type:    AuthTypeNone,
 					APIKeys: []string{"key1"},
@@ -456,7 +470,7 @@ func TestValidateSettings_BasicAuthMissingUsername(t *testing.T) {
 	s := &Settings{
 		Transport: "stdio",
 		Scheme:    "acdc",
-		Search:    SearchSettings{ResultMode: SearchResultModeReferences},
+		Search:    defaultSearchSettings(),
 		Auth: AuthSettings{
 			Type: AuthTypeBasic,
 			Basic: BasicAuthSettings{
@@ -477,7 +491,7 @@ func TestValidateSettings_BasicAuthMissingPassword(t *testing.T) {
 	s := &Settings{
 		Transport: "stdio",
 		Scheme:    "acdc",
-		Search:    SearchSettings{ResultMode: SearchResultModeReferences},
+		Search:    defaultSearchSettings(),
 		Auth: AuthSettings{
 			Type: AuthTypeBasic,
 			Basic: BasicAuthSettings{
@@ -495,7 +509,7 @@ func TestValidateSettings_BasicAuthWithAPIKeys(t *testing.T) {
 	s := &Settings{
 		Transport: "stdio",
 		Scheme:    "acdc",
-		Search:    SearchSettings{ResultMode: SearchResultModeReferences},
+		Search:    defaultSearchSettings(),
 		Auth: AuthSettings{
 			Type: AuthTypeBasic,
 			Basic: BasicAuthSettings{
@@ -518,7 +532,7 @@ func TestValidateSettings_APIKeyMissingKeys(t *testing.T) {
 	s := &Settings{
 		Transport: "stdio",
 		Scheme:    "acdc",
-		Search:    SearchSettings{ResultMode: SearchResultModeReferences},
+		Search:    defaultSearchSettings(),
 		Auth: AuthSettings{
 			Type: AuthTypeAPIKey,
 		},
@@ -536,7 +550,7 @@ func TestValidateSettings_APIKeyWithBasicCreds(t *testing.T) {
 	s := &Settings{
 		Transport: "stdio",
 		Scheme:    "acdc",
-		Search:    SearchSettings{ResultMode: SearchResultModeReferences},
+		Search:    defaultSearchSettings(),
 		Auth: AuthSettings{
 			Type:    AuthTypeAPIKey,
 			APIKeys: []string{"key1"},
@@ -558,7 +572,7 @@ func TestValidateSettings_UnknownAuthType(t *testing.T) {
 	s := &Settings{
 		Transport: "stdio",
 		Scheme:    "acdc",
-		Search:    SearchSettings{ResultMode: SearchResultModeReferences},
+		Search:    defaultSearchSettings(),
 		Auth: AuthSettings{
 			Type: "oauth",
 		},
@@ -575,14 +589,14 @@ func TestValidateSettings_UnknownAuthType(t *testing.T) {
 // --- Transport Validation Tests ---
 
 func TestValidateSettings_ValidTransportStdio(t *testing.T) {
-	s := &Settings{Transport: "stdio", Scheme: "acdc", Search: SearchSettings{ResultMode: SearchResultModeReferences}, Auth: AuthSettings{Type: AuthTypeNone}}
+	s := &Settings{Transport: "stdio", Scheme: "acdc", Search: defaultSearchSettings(), Auth: AuthSettings{Type: AuthTypeNone}}
 	if err := ValidateSettings(s); err != nil {
 		t.Errorf("Expected no error for valid stdio transport, got: %v", err)
 	}
 }
 
 func TestValidateSettings_ValidTransportSSE(t *testing.T) {
-	s := &Settings{Transport: "sse", Scheme: "acdc", Search: SearchSettings{ResultMode: SearchResultModeReferences}, Auth: AuthSettings{Type: AuthTypeNone}}
+	s := &Settings{Transport: "sse", Scheme: "acdc", Search: defaultSearchSettings(), Auth: AuthSettings{Type: AuthTypeNone}}
 	if err := ValidateSettings(s); err != nil {
 		t.Errorf("Expected no error for valid sse transport, got: %v", err)
 	}
@@ -604,7 +618,7 @@ func TestValidateSettings_InvalidTransport(t *testing.T) {
 			s := &Settings{
 				Transport: tt.transport,
 				Scheme:    "acdc",
-				Search:    SearchSettings{ResultMode: SearchResultModeReferences},
+				Search:    defaultSearchSettings(),
 				Auth:      AuthSettings{Type: AuthTypeNone},
 			}
 			err := ValidateSettings(s)
@@ -696,7 +710,7 @@ func TestValidateSettings_ValidSchemes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := &Settings{Transport: "stdio", Scheme: tt.scheme, Search: SearchSettings{ResultMode: SearchResultModeReferences}, Auth: AuthSettings{Type: AuthTypeNone}}
+			s := &Settings{Transport: "stdio", Scheme: tt.scheme, Search: defaultSearchSettings(), Auth: AuthSettings{Type: AuthTypeNone}}
 			if err := ValidateSettings(s); err != nil {
 				t.Errorf("Expected no error for scheme %q, got: %v", tt.scheme, err)
 			}
@@ -719,7 +733,7 @@ func TestValidateSettings_InvalidSchemes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := &Settings{Transport: "stdio", Scheme: tt.scheme, Search: SearchSettings{ResultMode: SearchResultModeReferences}, Auth: AuthSettings{Type: AuthTypeNone}}
+			s := &Settings{Transport: "stdio", Scheme: tt.scheme, Search: defaultSearchSettings(), Auth: AuthSettings{Type: AuthTypeNone}}
 			err := ValidateSettings(s)
 			if err == nil {
 				t.Fatalf("Expected error for scheme %q", tt.scheme)
@@ -860,8 +874,34 @@ func TestValidateSettings_RejectsInvalidBoosts(t *testing.T) {
 }
 
 // Zero disables a field's contribution and is a supported operator choice —
-// notably as a mitigation for fuzzy path-label noise. It must never be rejected.
-func TestValidateSettings_AcceptsZeroBoosts(t *testing.T) {
+// notably --search-path-boost 0. An individual zero must never be rejected.
+func TestValidateSettings_AcceptsIndividualZeroBoosts(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*SearchSettings)
+	}{
+		{"zero keywords", func(s *SearchSettings) { s.KeywordsBoost = 0 }},
+		{"zero heading", func(s *SearchSettings) { s.HeadingBoost = 0 }},
+		{"zero title", func(s *SearchSettings) { s.TitleBoost = 0 }},
+		{"zero path", func(s *SearchSettings) { s.PathBoost = 0 }},
+		{"zero content", func(s *SearchSettings) { s.ContentBoost = 0 }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			search := defaultSearchSettings()
+			tt.mutate(&search)
+			s := &Settings{Transport: "stdio", Scheme: "acdc", Search: search, Auth: AuthSettings{Type: AuthTypeNone}}
+
+			require.NoError(t, ValidateSettings(s))
+		})
+	}
+}
+
+// All five boosts at zero produces a clauseless disjunction, which bleve
+// answers with MatchNoneSearcher: every real query returns nothing while "*"
+// still returns everything. Silent, and indistinguishable from an empty index.
+func TestValidateSettings_RejectsAllZeroBoosts(t *testing.T) {
 	s := &Settings{
 		Transport: "stdio",
 		Scheme:    "acdc",
@@ -872,7 +912,10 @@ func TestValidateSettings_AcceptsZeroBoosts(t *testing.T) {
 		Auth: AuthSettings{Type: AuthTypeNone},
 	}
 
-	require.NoError(t, ValidateSettings(s))
+	err := ValidateSettings(s)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "at least one")
 }
 
 // A malformed boost fails to decode rather than coercing to zero, which would

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -918,6 +918,65 @@ func TestValidateSettings_RejectsAllZeroBoosts(t *testing.T) {
 	require.Contains(t, err.Error(), "at least one")
 }
 
+// Above sqrt(MaxFloat64) the squared weight overflows to +Inf inside bleve's
+// sumOfSquaredWeights, queryNorm collapses to zero, every score becomes
+// exactly zero, and ranking degenerates to the sort tiebreak. Such a value is
+// finite and non-negative, so the pre-existing checks let it through.
+func TestValidateSettings_RejectsBoostsBleveCannotSquare(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*SearchSettings)
+		wantErr string
+	}{
+		{"overflowing keywords", func(s *SearchSettings) { s.KeywordsBoost = 1e200 }, "search.keywords_boost"},
+		{"overflowing heading", func(s *SearchSettings) { s.HeadingBoost = 1e200 }, "search.heading_boost"},
+		{"largest float content", func(s *SearchSettings) { s.ContentBoost = math.MaxFloat64 }, "search.content_boost"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			search := defaultSearchSettings()
+			tt.mutate(&search)
+			s := &Settings{Transport: "stdio", Scheme: "acdc", Search: search, Auth: AuthSettings{Type: AuthTypeNone}}
+
+			err := ValidateSettings(s)
+
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+// The bound exists to stop overflow, not to cap how far an operator may push a
+// field. A large value bleve can still square stays legal.
+func TestValidateSettings_AcceptsLargeButSquarableBoosts(t *testing.T) {
+	search := defaultSearchSettings()
+	search.HeadingBoost = 1e150
+	s := &Settings{
+		Transport: "stdio",
+		Scheme:    "acdc",
+		Search:    search,
+		Auth:      AuthSettings{Type: AuthTypeNone},
+	}
+
+	require.NoError(t, ValidateSettings(s))
+}
+
+// The check is strict (>), so the cap itself is a legal boost value. Only
+// values strictly greater than maxBoost are rejected.
+func TestValidateSettings_AcceptsBoostAtExactCap(t *testing.T) {
+	search := defaultSearchSettings()
+	search.HeadingBoost = maxBoost
+	s := &Settings{
+		Transport: "stdio",
+		Scheme:    "acdc",
+		Search:    search,
+		Auth:      AuthSettings{Type: AuthTypeNone},
+	}
+
+	require.NoError(t, ValidateSettings(s))
+}
+
 // A malformed boost fails to decode rather than coercing to zero, which would
 // silently disable the field. Pinned because validateBoosts cannot catch a
 // value that has already become a legal 0.

--- a/internal/search/golden_test.go
+++ b/internal/search/golden_test.go
@@ -79,17 +79,6 @@ func goldenServiceWith(t *testing.T, settings config.SearchSettings, corpora ...
 	return service
 }
 
-// goldenServiceFuzzy indexes a corpus and then overrides the edit distance
-// applied to every field, so the harness can measure the ranking model at
-// settings other than the shipped one. Fuzziness is a query-time property, so
-// overriding it after indexing is safe; call it before any Search.
-func goldenServiceFuzzy(t *testing.T, fuzziness int, corpora ...string) *Service {
-	t.Helper()
-	service := goldenService(t, corpora...)
-	service.fuzziness = func(string) int { return fuzziness }
-	return service
-}
-
 // rankOf returns the best 1-based rank at which uri appears, or 0 when absent.
 func rankOf(results []SearchResult, uri string) int {
 	for rank, result := range results {
@@ -213,15 +202,15 @@ func TestGolden_ZeroConfigRanking(t *testing.T) {
 			absent:    []string{"acdc://docs/deployment/docker"},
 		},
 		{
-			name:    "fuzziness admits an unrelated document",
+			name:    "path labels no longer admit an unrelated document",
 			corpora: corpus,
 			query:   "readiness",
 			rationale: "README has no bearing on readiness probes, and the corpus contains one obviously correct answer. " +
-				"Measured: every README chunk matches, taking ranks 2-5, because the path label 'readme' stems to a term within edit distance 1 of the query. " +
-				"Fuzziness is applied to every field with no prefix_length, so a document is retrieved on a term it does not contain.",
-			top:     "acdc://docs/deployment/kubernetes#readiness",
-			ranks:   map[string]int{"acdc://README": 2},
-			finding: "#85 — fuzziness=1 with no prefix_length",
+				"Edit-distance matching is applied to content and headings but not to path_labels, so the label 'readme' — " +
+				"which stems to within one edit of the query — no longer retrieves the file on a term it does not contain. " +
+				"Both leading chunks now come from the page that answers the query; the README is demoted, not excluded.",
+			top:   "acdc://docs/deployment/kubernetes#readiness",
+			ranks: map[string]int{"acdc://README": 3},
 		},
 	}
 
@@ -451,6 +440,7 @@ func TestGolden_FuzzinessPollutesThroughPathLabels(t *testing.T) {
 	}{
 		{name: "every field", fuzziness: func(string) int { return 1 }, wantJunk: 2},
 		{name: "no field", fuzziness: func(string) int { return 0 }, wantJunk: 0},
+		{name: "every field but path labels", fuzziness: fieldFuzziness, wantJunk: 3},
 	}
 
 	for _, tt := range tests {
@@ -484,49 +474,57 @@ func TestGolden_FuzzinessRecallProbes(t *testing.T) {
 		wantFuzzy string
 		// wantExact is the same with edit-distance matching off everywhere.
 		wantExact string
-		rationale string
+		// wantShipped is the same under the shipped per-field policy.
+		wantShipped string
+		rationale   string
 	}{
 		{
-			name:      "a dropped character is rescued",
-			probe:     "authentcation",
-			wantFuzzy: "acdc://docs/authentication#authentication",
-			wantExact: "",
-			rationale: "authentcation stems to authentc, one edit from authentication's authent.",
+			name:        "a dropped character is rescued",
+			probe:       "authentcation",
+			wantFuzzy:   "acdc://docs/authentication#authentication",
+			wantExact:   "",
+			wantShipped: "acdc://docs/authentication#authentication",
+			rationale:   "authentcation stems to authentc, one edit from authentication's authent.",
 		},
 		{
-			name:      "a dropped character mid-word is rescued",
-			probe:     "compation",
-			wantFuzzy: "acdc://docs/internals/indexing#segment-compaction",
-			wantExact: "",
-			rationale: "compation stems to compat, one edit from compaction's compact.",
+			name:        "a dropped character mid-word is rescued",
+			probe:       "compation",
+			wantFuzzy:   "acdc://docs/internals/indexing#segment-compaction",
+			wantExact:   "",
+			wantShipped: "acdc://docs/internals/indexing#segment-compaction",
+			rationale:   "compation stems to compat, one edit from compaction's compact.",
 		},
 		{
-			name:      "a dropped character in a heading term is rescued",
-			probe:     "cheksums",
-			wantFuzzy: "acdc://docs/internals/indexing#checksums",
-			wantExact: "",
-			rationale: "cheksums stems to cheksum, one edit from checksums' checksum.",
+			name:        "a dropped character in a heading term is rescued",
+			probe:       "cheksums",
+			wantFuzzy:   "acdc://docs/internals/indexing#checksums",
+			wantExact:   "",
+			wantShipped: "acdc://docs/internals/indexing#checksums",
+			rationale:   "cheksums stems to cheksum, one edit from checksums' checksum.",
 		},
 		{
-			name:      "the stemmer alone handles a plural near-miss",
-			probe:     "kubernets",
-			wantFuzzy: "acdc://docs/deployment/kubernetes#running-ledger-on-kubernetes",
-			wantExact: "acdc://docs/deployment/kubernetes#running-ledger-on-kubernetes",
-			rationale: "Both kubernets and kubernetes stem to kubernet, so this costs no fuzziness. Control: without it the table reads as though fuzziness were the only thing rescuing near-misses.",
+			name:        "the stemmer alone handles a plural near-miss",
+			probe:       "kubernets",
+			wantFuzzy:   "acdc://docs/deployment/kubernetes#running-ledger-on-kubernetes",
+			wantExact:   "acdc://docs/deployment/kubernetes#running-ledger-on-kubernetes",
+			wantShipped: "acdc://docs/deployment/kubernetes#running-ledger-on-kubernetes",
+			rationale:   "Both kubernets and kubernetes stem to kubernet, so this costs no fuzziness. Control: without it the table reads as though fuzziness were the only thing rescuing near-misses.",
 		},
 		{
-			name:      "a two-edit typo is beyond rescue",
-			probe:     "deploymnet",
-			wantFuzzy: "",
-			wantExact: "",
-			rationale: "deploymnet does not stem at all, leaving it four edits from deployment's deploy. Control: edit distance 1 is a narrow safety net, not typo correction.",
+			name:        "a two-edit typo is beyond rescue",
+			probe:       "deploymnet",
+			wantFuzzy:   "",
+			wantExact:   "",
+			wantShipped: "",
+			rationale:   "deploymnet does not stem at all, leaving it four edits from deployment's deploy. Control: edit distance 1 is a narrow safety net, not typo correction.",
 		},
 		{
-			name:      "a British spelling is beyond rescue",
-			probe:     "authorisation",
-			wantFuzzy: "",
-			wantExact: "",
-			rationale: "The stemmer takes authorization to author but authorisation only to authoris — two edits apart. Control: fuzziness is not a spelling-variant mechanism.",
+			name:        "a British spelling is beyond rescue",
+			probe:       "authorisation",
+			wantFuzzy:   "",
+			wantExact:   "",
+			wantShipped: "",
+			rationale:   "The stemmer takes authorization to author but authorisation only to authoris — two edits apart. Control: fuzziness is not a spelling-variant mechanism.",
 		},
 	}
 
@@ -535,24 +533,26 @@ func TestGolden_FuzzinessRecallProbes(t *testing.T) {
 			t.Log(tt.rationale)
 			for _, setting := range []struct {
 				label     string
-				fuzziness int
+				fuzziness func(string) int
 				want      string
 			}{
-				{"fuzzy", 1, tt.wantFuzzy},
-				{"exact", 0, tt.wantExact},
+				{"fuzzy", func(string) int { return 1 }, tt.wantFuzzy},
+				{"exact", func(string) int { return 0 }, tt.wantExact},
+				{"shipped", fieldFuzziness, tt.wantShipped},
 			} {
 				t.Run(setting.label, func(t *testing.T) {
-					service := goldenServiceFuzzy(t, setting.fuzziness, zeroConfigCorpus)
+					service := goldenService(t, zeroConfigCorpus)
+					service.fuzziness = setting.fuzziness
 
 					results, err := service.Search(tt.probe, goldenCandidates)
 					require.NoError(t, err)
 					reportRanking(t, tt.probe, results)
 
 					if setting.want == "" {
-						require.Empty(t, results, "%s\n%q must retrieve nothing at fuzziness %d", tt.rationale, tt.probe, setting.fuzziness)
+						require.Empty(t, results, "%s\n%q must retrieve nothing under the %s policy", tt.rationale, tt.probe, setting.label)
 						return
 					}
-					require.Equal(t, 1, rankOf(results, setting.want), "%s\n%q at fuzziness %d", tt.rationale, tt.probe, setting.fuzziness)
+					require.Equal(t, 1, rankOf(results, setting.want), "%s\n%q under the %s policy", tt.rationale, tt.probe, setting.label)
 				})
 			}
 		})

--- a/internal/search/golden_test.go
+++ b/internal/search/golden_test.go
@@ -83,8 +83,6 @@ func goldenServiceWith(t *testing.T, settings config.SearchSettings, corpora ...
 // applied to every field, so the harness can measure the ranking model at
 // settings other than the shipped one. Fuzziness is a query-time property, so
 // overriding it after indexing is safe; call it before any Search.
-//
-//nolint:unused // seam for #85's fuzziness-policy measurements, adopted by a later commit.
 func goldenServiceFuzzy(t *testing.T, fuzziness int, corpora ...string) *Service {
 	t.Helper()
 	service := goldenService(t, corpora...)
@@ -466,6 +464,97 @@ func TestGolden_FuzzinessPollutesThroughPathLabels(t *testing.T) {
 
 			require.Equal(t, 1, rankOf(results, correct), "the page that answers the query must lead")
 			require.Equal(t, tt.wantJunk, rankOf(results, junk), "README rank with fuzziness %q", tt.name)
+		})
+	}
+}
+
+// TestGolden_FuzzinessRecallProbes measures the benefit side of edit-distance
+// matching: what a mistyped query retrieves with it and without it.
+//
+// A probe is only meaningful if it stems to a term within edit distance 1 of
+// its target — the analyzer runs before the fuzzy searcher, and stemming a
+// misspelling is not predictable. Verify any new probe with an analyzer dump
+// before adding it; a probe that misses measures nothing while still passing.
+func TestGolden_FuzzinessRecallProbes(t *testing.T) {
+	tests := []struct {
+		name  string
+		probe string
+		// wantFuzzy is the chunk URI required at rank 1 with edit distance 1 on
+		// every field, or "" when the probe must retrieve nothing at all.
+		wantFuzzy string
+		// wantExact is the same with edit-distance matching off everywhere.
+		wantExact string
+		rationale string
+	}{
+		{
+			name:      "a dropped character is rescued",
+			probe:     "authentcation",
+			wantFuzzy: "acdc://docs/authentication#authentication",
+			wantExact: "",
+			rationale: "authentcation stems to authentc, one edit from authentication's authent.",
+		},
+		{
+			name:      "a dropped character mid-word is rescued",
+			probe:     "compation",
+			wantFuzzy: "acdc://docs/internals/indexing#segment-compaction",
+			wantExact: "",
+			rationale: "compation stems to compat, one edit from compaction's compact.",
+		},
+		{
+			name:      "a dropped character in a heading term is rescued",
+			probe:     "cheksums",
+			wantFuzzy: "acdc://docs/internals/indexing#checksums",
+			wantExact: "",
+			rationale: "cheksums stems to cheksum, one edit from checksums' checksum.",
+		},
+		{
+			name:      "the stemmer alone handles a plural near-miss",
+			probe:     "kubernets",
+			wantFuzzy: "acdc://docs/deployment/kubernetes#running-ledger-on-kubernetes",
+			wantExact: "acdc://docs/deployment/kubernetes#running-ledger-on-kubernetes",
+			rationale: "Both kubernets and kubernetes stem to kubernet, so this costs no fuzziness. Control: without it the table reads as though fuzziness were the only thing rescuing near-misses.",
+		},
+		{
+			name:      "a two-edit typo is beyond rescue",
+			probe:     "deploymnet",
+			wantFuzzy: "",
+			wantExact: "",
+			rationale: "deploymnet does not stem at all, leaving it four edits from deployment's deploy. Control: edit distance 1 is a narrow safety net, not typo correction.",
+		},
+		{
+			name:      "a British spelling is beyond rescue",
+			probe:     "authorisation",
+			wantFuzzy: "",
+			wantExact: "",
+			rationale: "The stemmer takes authorization to author but authorisation only to authoris — two edits apart. Control: fuzziness is not a spelling-variant mechanism.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Log(tt.rationale)
+			for _, setting := range []struct {
+				label     string
+				fuzziness int
+				want      string
+			}{
+				{"fuzzy", 1, tt.wantFuzzy},
+				{"exact", 0, tt.wantExact},
+			} {
+				t.Run(setting.label, func(t *testing.T) {
+					service := goldenServiceFuzzy(t, setting.fuzziness, zeroConfigCorpus)
+
+					results, err := service.Search(tt.probe, goldenCandidates)
+					require.NoError(t, err)
+					reportRanking(t, tt.probe, results)
+
+					if setting.want == "" {
+						require.Empty(t, results, "%s\n%q must retrieve nothing at fuzziness %d", tt.rationale, tt.probe, setting.fuzziness)
+						return
+					}
+					require.Equal(t, 1, rankOf(results, setting.want), "%s\n%q at fuzziness %d", tt.rationale, tt.probe, setting.fuzziness)
+				})
+			}
 		})
 	}
 }

--- a/internal/search/golden_test.go
+++ b/internal/search/golden_test.go
@@ -79,6 +79,19 @@ func goldenServiceWith(t *testing.T, settings config.SearchSettings, corpora ...
 	return service
 }
 
+// goldenServiceFuzzy indexes a corpus and then overrides the edit distance
+// applied to every field, so the harness can measure the ranking model at
+// settings other than the shipped one. Fuzziness is a query-time property, so
+// overriding it after indexing is safe; call it before any Search.
+//
+//nolint:unused // seam for #85's fuzziness-policy measurements, adopted by a later commit.
+func goldenServiceFuzzy(t *testing.T, fuzziness int, corpora ...string) *Service {
+	t.Helper()
+	service := goldenService(t, corpora...)
+	service.fuzziness = func(string) int { return fuzziness }
+	return service
+}
+
 // rankOf returns the best 1-based rank at which uri appears, or 0 when absent.
 func rankOf(results []SearchResult, uri string) int {
 	for rank, result := range results {
@@ -410,6 +423,49 @@ func TestGolden_HeadingBoostInfluenceIsBounded(t *testing.T) {
 			reportRanking(t, query, results)
 			require.Equal(t, tt.wantHeading, rankOf(results, headingOnly), "heading-only document at heading_boost %g", tt.boost)
 			require.Equal(t, tt.wantBody, rankOf(results, bodyOnly), "body-only document at heading_boost %g", tt.boost)
+		})
+	}
+}
+
+// TestGolden_FuzzinessPollutesThroughPathLabels measures the cost side of
+// edit-distance matching, isolated to the field that causes it. The corpus has
+// exactly one document about readiness probes. The README has no bearing on
+// the query, but its path label "readme" stems to a term one edit from the
+// query's "readi", so fuzzing path_labels retrieves it on a term it does not
+// contain.
+//
+// Expectations are measured, not desired. A change means the ranking model
+// moved.
+func TestGolden_FuzzinessPollutesThroughPathLabels(t *testing.T) {
+	const (
+		query   = "readiness"
+		correct = "acdc://docs/deployment/kubernetes#readiness"
+		junk    = "acdc://README"
+	)
+
+	tests := []struct {
+		name string
+		// fuzziness resolves the edit distance per field, mirroring
+		// Service.fuzziness.
+		fuzziness func(string) int
+		// wantJunk is the README's best rank, or 0 when it is absent.
+		wantJunk int
+	}{
+		{name: "every field", fuzziness: func(string) int { return 1 }, wantJunk: 2},
+		{name: "no field", fuzziness: func(string) int { return 0 }, wantJunk: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := goldenService(t, zeroConfigCorpus)
+			service.fuzziness = tt.fuzziness
+
+			results, err := service.Search(query, goldenCandidates)
+			require.NoError(t, err)
+			reportRanking(t, query, results)
+
+			require.Equal(t, 1, rankOf(results, correct), "the page that answers the query must lead")
+			require.Equal(t, tt.wantJunk, rankOf(results, junk), "README rank with fuzziness %q", tt.name)
 		})
 	}
 }

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -60,8 +60,12 @@ type searchIndex interface {
 type Service struct {
 	mu       sync.RWMutex
 	settings config.SearchSettings
-	index    searchIndex
-	indexDir string
+	// fuzziness resolves the edit distance applied to a field's match clause.
+	// A field rather than a direct call so tests can measure the ranking model
+	// at other settings without exporting anything.
+	fuzziness func(field string) int
+	index     searchIndex
+	indexDir  string
 }
 
 // Ensure Service implements Searcher
@@ -70,7 +74,8 @@ var _ Searcher = (*Service)(nil)
 // NewService creates a new search service
 func NewService(settings config.SearchSettings) *Service {
 	return &Service{
-		settings: settings,
+		settings:  settings,
+		fuzziness: fieldFuzziness,
 	}
 }
 
@@ -291,17 +296,22 @@ func (s *Service) boostedFieldQueries(queryStr string) []query.Query {
 		if f.boost <= 0 {
 			continue
 		}
-		queries = append(queries, fieldQuery(queryStr, f.name, f.boost))
+		queries = append(queries, fieldQuery(queryStr, f.name, f.boost, s.fuzziness(f.name)))
 	}
 	return queries
 }
 
-func fieldQuery(queryStr, field string, boost float64) *query.MatchQuery {
+func fieldQuery(queryStr, field string, boost float64, fuzziness int) *query.MatchQuery {
 	fieldQuery := bleve.NewMatchQuery(queryStr)
 	fieldQuery.SetField(field)
-	fieldQuery.SetFuzziness(1)
+	fieldQuery.SetFuzziness(fuzziness)
 	fieldQuery.SetBoost(boost)
 	return fieldQuery
+}
+
+// fieldFuzziness returns the edit distance applied to a field's match clause.
+func fieldFuzziness(string) int {
+	return 1
 }
 
 func fieldString(fields map[string]interface{}, field string) string {

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -310,7 +310,19 @@ func fieldQuery(queryStr, field string, boost float64, fuzziness int) *query.Mat
 }
 
 // fieldFuzziness returns the edit distance applied to a field's match clause.
-func fieldFuzziness(string) int {
+//
+// path_labels is matched exactly. It holds a small vocabulary of short path
+// segments, and unlike every other field its terms are duplicated nowhere
+// else — heading text is also indexed as content, but a path label comes from
+// the file path alone. Nearly every segment therefore has a neighbour within
+// one edit, and fuzzing the field retrieves documents on terms they do not
+// contain: the label "readme" stems to one edit from a query for "readiness",
+// which filled ranks 2 through 5 of the result page with README chunks that
+// never mention it.
+func fieldFuzziness(field string) int {
+	if field == domain.FieldPathLabels {
+		return 0
+	}
 	return 1
 }
 

--- a/internal/search/testdata/README.md
+++ b/internal/search/testdata/README.md
@@ -26,6 +26,12 @@ turns a measurement into a tautology that still passes:
 - `curated/docs/observability.md` declares `dashboards` as a keyword and never
   writes the word; `corpus/docs/troubleshooting.md` mentions one dashboard in
   passing. The pair isolates `keywords` against `content`.
+- `README.md`'s path label `readme` must stay within one edit distance of the
+  query `readiness`; the golden cases that measure fuzzy matching through
+  `path_labels` depend on that stem overlap.
+- No corpus document may match the negative-control probes `deploymnet` or
+  `authorisation`; the golden cases that pin what edit-distance-1 matching
+  does *not* rescue depend on both terms coming back empty.
 
 Adding documents is safe. Removing or renaming one of the above needs the
 matching golden case updated in the same change.


### PR DESCRIPTION
Closes #85.

## Summary

Every indexed field was matched with bleve edit-distance-1 fuzziness. This keeps that on four fields and drops it on `path_labels`, which is where the measured damage came from. Also closes the two boost-validation gaps #84 knowingly left open, since they live in the same validator this branch already opens.

**This is a ranking change** — every deployment will see different results for some queries. The golden harness's verbose output differs between `master` and this branch; among pre-existing cases only the `readiness` query moved, and only as described below.

## Why `path_labels` specifically

It is a small vocabulary of short path segments, and the only indexed field whose terms are duplicated nowhere else — heading text is also indexed as content, but a path label comes from the file path alone. Nearly every segment therefore has a neighbour within one edit, so fuzzing it retrieves documents on words they do not contain. Measured: a query for `readiness` matched the path label `readme` and filled ranks 2-5 with README chunks that never mention it.

Note the harm is **retrieval pollution, not rank inversion** — the answering page was already rank 1 with a 3.4x margin. Bleve downweights a distance-1 match by 0.5 internally (`search_multi_term.go:192-196`), which handles ordering; what it does not do is keep junk out of a `max_results=10` page.

## What fuzziness still buys, and what it never did

Dropping it everywhere was the original plan and the measurement rejected it. Single-character typos go from a correct rank-1 answer to zero results, so the branch keeps them:

| probe | fuzzy | exact | shipped |
|---|---|---|---|
| `authentcation` | rank 1 | **0 results** | rank 1 |
| `compation` | rank 1 | **0 results** | rank 1 |
| `cheksums` | rank 1 | **0 results** | rank 1 |
| `kubernets` | rank 1 | rank 1 | rank 1 — the stemmer alone |
| `deploymnet` | 0 results | 0 results | 0 results |
| `authorisation` | 0 results | 0 results | 0 results |

The last three are controls. Without them the table reads as "fuzziness fixes typos", which is false: it rescues one dropped, added or altered character *in the stem*, and nothing else.

Two alternatives were measured and rejected, and are recorded in `docs/configuration.md` so they are not rediscovered. A minimum matching prefix is inert — `readiness` and `readme` stem to `readi`/`readm` and already share four characters. Bleve's automatic fuzziness is worse: it raises terms longer than five characters to distance 2.

## Validation changes (previously accepted, now fatal)

Both were found by the review of #90 and deferred; #84 already set the precedent that an invalid boost is fatal at startup.

- **All five boosts at `0`** produced a clauseless disjunction, which bleve answers with `MatchNoneSearcher` — every real query returned nothing, with no error, while `*` still returned everything. An individual `0` stays legal.
- **Boosts above `math.Sqrt(math.MaxFloat64)`** are now rejected. Note this is a *conservative sanity cap, not an overflow guarantee*: bleve squares `boost x idf` (`scorer_term.go:112-115`), not `boost`, so scoring can still degenerate below the cap. The true threshold depends on corpus idf and clause count, neither knowable at validation time. The comment, the error string and the docs all say this rather than claiming more.

## Reviewer notes

- No new configuration surface. A `search.fuzziness` key was drafted and rejected — #91 and #92 may replace the retrieval model wholesale, which would leave the knob a permanent contract for a tradeoff that no longer exists.
- Honest limit: the corpus is 41 chunks we wrote ourselves, and the README is demoted rather than excluded — `readiness` returns 8 candidates, not 2.
- Each of the five commits builds and passes `make test` standalone.