### PR TITLE
fix(search): build the in-memory index with scorch and index in memory by default

### DIFF
--- a/docs/SPECIFICATIONS.md
+++ b/docs/SPECIFICATIONS.md
@@ -205,9 +205,9 @@ A check is debounced to at most once every 2 seconds — a burst of requests ins
 
 This applies identically to both discovery modes (legacy `mcp-resources/` and configured indexing) and to both transports — there is no way to scope refresh to one or disable it. Every error on this path (a failed walk, discovery, parse, or index rebuild) is logged and swallowed: the previously published catalog and index stay in place and the next debounce interval retries from scratch. This is deliberately different from the fatal startup errors listed elsewhere on this page — a malformed document must never take down a server that has already been serving successfully.
 
-A content-change rebuild holds the search index's write lock for its duration, so a concurrent `search` call briefly blocks until the rebuild finishes. For the zero-config, locally-indexed case this is on the order of milliseconds; for a large curated corpus served over SSE to many concurrent clients, it is a real (if brief) pause on every edit, with no configuration to opt out of it.
+A content-change rebuild holds the search index's write lock for its duration, so a concurrent `search` call briefly blocks until the rebuild finishes. For the zero-config, locally-indexed case this is on the order of milliseconds; for a large curated corpus served over SSE to many concurrent clients, it is a real (if brief) pause on every edit, with no configuration to opt out of it. Because the replacement index is built before the previous one is released, a rebuild also holds two complete indexes at once — under the default in-memory mode, that is twice the index's memory for its duration.
 
-Persistence across restarts is still not part of this release: nothing is written to disk, and the catalog/index are rebuilt from scratch every time the process starts, independent of the mid-session refresh described here.
+Persistence across restarts is still not part of this release: the catalog and index are rebuilt from scratch every time the process starts, independent of the mid-session refresh described here. The index is held in memory by default; under `ACDC_MCP_SEARCH_IN_MEMORY=false` it is written to a temporary directory that is discarded on shutdown, so neither mode survives a restart.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,6 +28,7 @@ When the same setting is specified in multiple places, the following priority ap
 | `--search-path-boost` | — | `ACDC_MCP_SEARCH_PATH_BOOST` | Boost for path label (`path_labels`) matches | `1.25` |
 | `--search-content-boost` | — | `ACDC_MCP_SEARCH_CONTENT_BOOST` | Boost for content matches | `1.0` |
 | `--search-result-mode` | — | `ACDC_MCP_SEARCH_RESULT_MODE` | Search output detail: `references` (chunk citations only) or `content` (citations plus the full matched chunk body) | `references` |
+| — | — | `ACDC_MCP_SEARCH_IN_MEMORY` | Hold the search index in memory instead of on disk | `true` |
 
 ### What the search boosts actually do
 
@@ -98,6 +99,22 @@ Two alternatives were measured and rejected. A minimum matching prefix does not 
 that collide here already share their first four characters. Bleve's automatic mode is worse — it
 raises the tolerance to two characters for any term longer than five, which widens exactly the
 problem described above.
+
+### Where the index lives
+
+The search index is held in memory by default. It is rebuilt from the content
+directory at startup and on every refresh, and it is never reopened, so
+persisting it to disk buys nothing back.
+
+Set `ACDC_MCP_SEARCH_IN_MEMORY=false` to build it on disk instead, under a
+temporary directory. That is worth doing for a large curated catalog. The
+in-memory index builds about twice as fast at every size measured and answers
+queries faster up to at least a thousand chunks, but by roughly ten thousand
+the on-disk index has overtaken it and answers about twice as fast — and it
+holds its data in memory-mapped segments the operating system can reclaim
+under pressure, where the in-memory index costs a few hundred megabytes of Go
+heap at that size. Where the two cross over depends on the shape of the
+corpus.
 
 ## Authentication Settings
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -109,12 +109,16 @@ persisting it to disk buys nothing back.
 Set `ACDC_MCP_SEARCH_IN_MEMORY=false` to build it on disk instead, under a
 temporary directory. That is worth doing for a large curated catalog. The
 in-memory index builds about twice as fast at every size measured and answers
-queries faster up to at least a thousand chunks, but by roughly ten thousand
-the on-disk index has overtaken it and answers about twice as fast — and it
-holds its data in memory-mapped segments the operating system can reclaim
-under pressure, where the in-memory index costs a few hundred megabytes of Go
-heap at that size. Where the two cross over depends on the shape of the
-corpus.
+queries faster up to at least a thousand chunks, but by roughly fifteen
+thousand the on-disk index has overtaken it and answers about twice as fast —
+and it holds its data in memory-mapped segments the operating system can
+reclaim under pressure, where the in-memory index costs a couple of hundred
+megabytes of Go heap at that size. Where the two cross over depends on the
+shape of the corpus.
+
+Size a deployment for twice that figure. A refresh builds the replacement
+index in full before releasing the previous one, so a content change briefly
+holds two complete indexes at once.
 
 ## Authentication Settings
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26
 
 require (
 	github.com/blevesearch/bleve/v2 v2.6.0
+	github.com/blevesearch/bleve_index_api v1.3.11
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/spf13/cobra v1.10.2
@@ -47,7 +48,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.24.2 // indirect
 	github.com/bkielbasa/cyclop v1.2.3 // indirect
-	github.com/blevesearch/bleve_index_api v1.3.11 // indirect
 	github.com/blevesearch/geo v0.2.5 // indirect
 	github.com/blevesearch/go-faiss v1.1.0 // indirect
 	github.com/blevesearch/go-porterstemmer v1.0.3 // indirect

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -107,6 +107,7 @@ func LoadSettingsWithFlags(flags *pflag.FlagSet) (*Settings, error) {
 	v.SetDefault("search.path_boost", DefaultPathBoost)
 	v.SetDefault("search.content_boost", DefaultContentBoost)
 	v.SetDefault("search.result_mode", SearchResultModeReferences)
+	v.SetDefault("search.in_memory", true)
 	v.SetDefault("cross_ref", false)
 	v.SetDefault("auth.type", AuthTypeNone)
 

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -119,6 +119,7 @@ func LoadSettingsWithFlags(flags *pflag.FlagSet) (*Settings, error) {
 	// BindEnv only returns an error if the key is empty, which cannot happen
 	// with hardcoded keys. Errors are intentionally discarded here.
 	_ = v.BindEnv("search.max_results", "ACDC_MCP_SEARCH_MAX_RESULTS")
+	_ = v.BindEnv("search.in_memory", "ACDC_MCP_SEARCH_IN_MEMORY")
 	_ = v.BindEnv("search.keywords_boost", "ACDC_MCP_SEARCH_KEYWORDS_BOOST")
 	_ = v.BindEnv("search.heading_boost", "ACDC_MCP_SEARCH_HEADING_BOOST")
 	_ = v.BindEnv("search.path_boost", "ACDC_MCP_SEARCH_PATH_BOOST")

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -989,3 +989,27 @@ func TestLoadSettings_MalformedBoostIsRejected(t *testing.T) {
 	require.Nil(t, settings)
 	require.Contains(t, err.Error(), "search.heading_boost")
 }
+
+// TestLoadSettings_InMemoryEnvVarOverridesDefault covers both directions
+// deliberately. search.in_memory has no CLI flag, so this env var is the only
+// supported way to choose the index kind, and it must work whichever way the
+// default points.
+func TestLoadSettings_InMemoryEnvVarOverridesDefault(t *testing.T) {
+	tests := []struct {
+		value    string
+		expected bool
+	}{
+		{value: "true", expected: true},
+		{value: "false", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			t.Setenv("ACDC_MCP_SEARCH_IN_MEMORY", tt.value)
+
+			settings, err := LoadSettings()
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, settings.Search.InMemory)
+		})
+	}
+}

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -16,6 +16,7 @@ func TestLoadSettings_Defaults(t *testing.T) {
 	_ = os.Unsetenv("ACDC_MCP_PORT")
 	_ = os.Unsetenv("ACDC_MCP_AUTH_TYPE")
 	_ = os.Unsetenv("ACDC_MCP_URI_SCHEME")
+	_ = os.Unsetenv("ACDC_MCP_SEARCH_IN_MEMORY")
 
 	settings, err := LoadSettings()
 	if err != nil {
@@ -42,6 +43,9 @@ func TestLoadSettings_Defaults(t *testing.T) {
 	}
 	if settings.CrossRef != false {
 		t.Errorf("Expected default cross_ref false, got %v", settings.CrossRef)
+	}
+	if !settings.Search.InMemory {
+		t.Error("Expected search.in_memory to default to true")
 	}
 }
 

--- a/internal/search/golden_test.go
+++ b/internal/search/golden_test.go
@@ -53,9 +53,7 @@ type goldenQuery struct {
 	finding string
 }
 
-// goldenService indexes the given corpora through the production discovery and
-// chunking path, so the harness measures the scorer against the documents it
-// actually sees rather than against hand-built chunks.
+// goldenService indexes the given corpora with the harness's default settings.
 func goldenService(t *testing.T, corpora ...string) *Service {
 	t.Helper()
 	return goldenServiceWith(t, testSettings(), corpora...)

--- a/internal/search/golden_test.go
+++ b/internal/search/golden_test.go
@@ -61,7 +61,10 @@ func goldenService(t *testing.T, corpora ...string) *Service {
 	return goldenServiceWith(t, testSettings(), corpora...)
 }
 
-func goldenServiceWith(t *testing.T, settings config.SearchSettings, corpora ...string) *Service {
+// corpusChunks discovers chunks through the production discovery and chunking
+// path, so tests measure the scorer against the documents it actually sees
+// rather than against hand-built chunks.
+func corpusChunks(t *testing.T, corpora ...string) []domain.Chunk {
 	t.Helper()
 
 	index := &domain.IndexMetadata{Include: []string{"**/*.md"}}
@@ -72,10 +75,15 @@ func goldenServiceWith(t *testing.T, settings config.SearchSettings, corpora ...
 		require.NotEmpty(t, result.Chunks, "corpus %s produced no chunks", corpus)
 		chunks = append(chunks, result.Chunks...)
 	}
+	return chunks
+}
+
+func goldenServiceWith(t *testing.T, settings config.SearchSettings, corpora ...string) *Service {
+	t.Helper()
 
 	service := NewService(settings)
 	t.Cleanup(service.Close)
-	indexChunks(t, service, chunks)
+	indexChunks(t, service, corpusChunks(t, corpora...))
 	return service
 }
 

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/blevesearch/bleve/v2"
+	"github.com/blevesearch/bleve/v2/index/scorch"
 	"github.com/blevesearch/bleve/v2/mapping"
 	"github.com/blevesearch/bleve/v2/search/query"
 	"github.com/sha1n/mcp-acdc-server/internal/config"
@@ -14,10 +15,19 @@ import (
 )
 
 var (
-	newMemoryIndex = bleve.NewMemOnly
-	makeTempDir    = os.MkdirTemp
-	removeAll      = os.RemoveAll
-	newDiskIndex   = bleve.New
+	// The in-memory index is scorch with an empty path, not bleve.NewMemOnly,
+	// which builds an upsidedown index. Two engines meant a mapping feature
+	// scorch supports could be silently ignored in memory — bleve reports no
+	// error for a scoring model an index kind cannot honour — so the in-memory
+	// mode could rank differently from the on-disk mode. An empty path makes
+	// scorch skip persistence entirely, which is safe here because the index
+	// is always rebuilt from source and never reopened.
+	newMemoryIndex = func(m mapping.IndexMapping) (bleve.Index, error) {
+		return bleve.NewUsing("", m, scorch.Name, scorch.Name, nil)
+	}
+	makeTempDir  = os.MkdirTemp
+	removeAll    = os.RemoveAll
+	newDiskIndex = bleve.New
 )
 
 // SearchResult is a chunk returned by a search.

--- a/internal/search/service_test.go
+++ b/internal/search/service_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/blevesearch/bleve/v2"
 	"github.com/blevesearch/bleve/v2/mapping"
+	bleveindex "github.com/blevesearch/bleve_index_api"
 	"github.com/sha1n/mcp-acdc-server/internal/config"
 	"github.com/sha1n/mcp-acdc-server/internal/domain"
 	"github.com/stretchr/testify/require"
@@ -523,5 +524,93 @@ func TestSearch_ReadsHeadingAndPathBoostsFromSettings(t *testing.T) {
 		results, err := service.Search("oauth", 10)
 		require.NoError(t, err)
 		require.Empty(t, results, "no clause can match once path and content boosts are zero")
+	})
+}
+
+// rankedScore is a ranking projection: the identity of a hit and its score,
+// without the snippet, whose highlight fragments are allowed to differ.
+type rankedScore struct {
+	URI   string
+	Score float64
+}
+
+func rankedScores(results []SearchResult) []rankedScore {
+	out := make([]rankedScore, 0, len(results))
+	for _, result := range results {
+		out = append(out, rankedScore{URI: result.ChunkURI, Score: result.Score})
+	}
+	return out
+}
+
+// searchThrough runs the production query shape against a caller-supplied
+// index, bypassing Service.newIndex so a test can choose the index kind.
+func searchThrough(t *testing.T, idx searchIndex, chunks []domain.Chunk, query string) []rankedScore {
+	t.Helper()
+
+	stream := make(chan domain.Chunk, len(chunks))
+	for _, chunk := range chunks {
+		stream <- chunk
+	}
+	close(stream)
+	require.NoError(t, batchIndex(context.Background(), idx, stream))
+
+	service := NewService(testSettings())
+	service.index = idx
+	t.Cleanup(service.Close)
+
+	results, err := service.Search(query, 10)
+	require.NoError(t, err)
+	require.NotEmpty(t, results, "query %q retrieved nothing", query)
+	return rankedScores(results)
+}
+
+// TestSearch_MemoryAndDiskIndexesHonourTheSameMapping pins the invariant that
+// search.in_memory selects storage and never relevance: both index kinds must
+// apply the same index mapping.
+//
+// The probe is BM25 scoring, which scorch implements and upsidedown does not.
+// bleve does not report an error for a scoring model the index kind cannot
+// support — it silently scores TF-IDF instead, because bm25ScoreMetrics leaves
+// avgDocLength at 0 when the reader is not an index.BM25Reader and the scorer
+// branches on avgDocLength > 0. ACDC does not ship BM25; it is used here only
+// because it is a mapping feature whose absence is otherwise invisible.
+//
+// This asserts on Score, which the golden harness conventions forbid. That
+// convention exists because absolute scores move with library upgrades and
+// with corpus size. The assertion here is that two index kinds agree with each
+// other, on one corpus and one library version, which is invariant to both.
+func TestSearch_MemoryAndDiskIndexesHonourTheSameMapping(t *testing.T) {
+	chunks := corpusChunks(t, zeroConfigCorpus)
+
+	t.Run("a mapping feature only one index kind supports", func(t *testing.T) {
+		bm25Mapping := func(t *testing.T) mapping.IndexMapping {
+			t.Helper()
+			m, ok := buildMapping().(*mapping.IndexMappingImpl)
+			require.True(t, ok, "buildMapping must return *mapping.IndexMappingImpl")
+			m.ScoringModel = bleveindex.BM25Scoring
+			return m
+		}
+
+		memIndex, err := newMemoryIndex(bm25Mapping(t))
+		require.NoError(t, err)
+		diskIndex, err := newDiskIndex(filepath.Join(t.TempDir(), "idx"), bm25Mapping(t))
+		require.NoError(t, err)
+
+		require.Equal(t,
+			searchThrough(t, diskIndex, chunks, "authentication"),
+			searchThrough(t, memIndex, chunks, "authentication"),
+			"the in-memory index ignored the mapping's scoring model")
+	})
+
+	t.Run("the shipped mapping", func(t *testing.T) {
+		memIndex, err := newMemoryIndex(buildMapping())
+		require.NoError(t, err)
+		diskIndex, err := newDiskIndex(filepath.Join(t.TempDir(), "idx"), buildMapping())
+		require.NoError(t, err)
+
+		require.Equal(t,
+			searchThrough(t, diskIndex, chunks, "authentication"),
+			searchThrough(t, memIndex, chunks, "authentication"),
+			"search.in_memory changed the ranking, which it must never do")
 	})
 }


### PR DESCRIPTION
## Summary

Closes #91, which asked whether to adopt BM25 in place of bleve's default TF-IDF. **BM25 was measured and declined.** The measurement instead exposed two real defects, which is what this PR fixes, and the second of those made a third change worth shipping: the search index is now held in memory by default.

No ranking changes. The golden harness output is byte-identical to `master` across all 160 logged rank lines, scores included.

## Why BM25 was declined

The issue's premise was that two findings in the measured baseline were artifacts of TF-IDF. Both reproduce under BM25:

- `compaction` — the heading page still beats the curated `keywords` match, and the margin *widens*: 2.6x under TF-IDF, 5.3x under BM25.
- the `content_boost` sweep on `checksums` still converges without crossing (0.3759/0.2504 under TF-IDF, 0.4551/0.2421 under BM25). The #84 boosts are no more able to move a ranking under BM25.

On the 12 golden queries BM25 changes nothing. On a repository-scale corpus (1,240 chunks) it reorders the top 10 on 10/10 queries, but every change is a reshuffle *within the document that was already correct* — no query gained or lost a relevant document. Adopting a model that reorders every result at scale, on no measured improvement, is what the harness exists to prevent.

Likely reason, worth recording: chunking already does BM25's job. Ranking is per chunk and a chunk is a heading section, so documents reach the scorer pre-normalized for length.

## Changes

**`fix(search)`: the in-memory index is built with scorch.** `bleve.NewMemOnly` builds an **upsidedown** index, which does not implement `index.BM25Reader`. bleve reports no error when an index kind cannot honour its mapping's scoring model — it silently falls back to TF-IDF. So the in-memory and on-disk modes could rank differently with no diagnostic, and the golden harness runs in-memory while production ran on disk. That made the harness unable to answer the question #91 asked. One engine now serves both.

**`fix(config)`: `ACDC_MCP_SEARCH_IN_MEMORY` now works.** It never did — `search.in_memory` had no `BindEnv`, and viper's `AutomaticEnv` does not resolve nested keys through `Unmarshal`. The setting was reachable only from a `.env` file. This had to land before the default flipped, or there would be no supported way back to disk.

**`feat(search)`: in-memory is the default.** The index is rebuilt from source at startup and on every refresh and is never reopened, so persisting it buys nothing back. Measured, same engine both sides:

| corpus | build (mem → disk) | Go heap (mem → disk) | query (mem → disk) | temp files |
|---|---|---|---|---|
| 49 chunks | 8 ms → 19 ms | 1.7 → 1.4 MiB | 0.45 → 0.7 ms | 0 → 0.4 MiB |
| 1,240 chunks | 0.25 s → 0.57 s | ~19 → ~1 MiB | 1.8 → 2.2 ms | 0 → ~9 MiB |
| 15,157 chunks | 3.1 s → 6.2 s | ~220 → ~0 MiB | 13.2 → **6.7 ms** | 0 → 85 MiB |

Zero-config repositories sit far below the crossover. `ACDC_MCP_SEARCH_IN_MEMORY=false` selects the on-disk index above it, where it queries about twice as fast and holds its data in reclaimable mapped segments rather than Go heap.

## Reviewer notes

- **Peak memory is twice the documented figure.** `Service.Index` builds the replacement index in full before releasing the old one, so a refresh briefly holds two complete indexes. That was always true; under the new default it costs heap. Documented in both `configuration.md` and `SPECIFICATIONS.md`.
- **User-visible default change, not a breaking interface change.** No config key, CLI flag, or signature moves. Labelled accordingly — no `major`.
- `search.in_memory` is now the only search setting with no CLI flag while also selecting a default. Left as env-var-only per #82's "no new configuration surface" rule; worth revisiting if it causes friction.
- `batchSize` is 100 and scorch runs with no merger in memory mode, leaving ~152 unmerged segments at 15k chunks. That is plausibly the real mechanism behind the query crossover the docs attribute to corpus shape. Not addressed here.
