### PR TITLE
feat(search): add a --search-in-memory flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ readinessProbe:
 | `--search-max-results` | `-m` | `ACDC_MCP_SEARCH_MAX_RESULTS` | `10` |
 | `--search-keywords-boost` | — | `ACDC_MCP_SEARCH_KEYWORDS_BOOST` | `3.0` |
 | `--search-result-mode` | — | `ACDC_MCP_SEARCH_RESULT_MODE` | `references` |
+| `--search-in-memory` | — | `ACDC_MCP_SEARCH_IN_MEMORY` | `true` |
 | `--auth-type` | `-a` | `ACDC_MCP_AUTH_TYPE` | `none` |
 
 For full configuration options including authentication, see [Configuration Reference](docs/configuration.md).

--- a/docs/SPECIFICATIONS.md
+++ b/docs/SPECIFICATIONS.md
@@ -29,6 +29,7 @@ The server is configured via environment variables, command-line flags, or a `.e
 | `ACDC_MCP_SEARCH_PATH_BOOST` | `--search-path-boost` | Boost factor for path label (`path_labels`) matches. | `1.25` |
 | `ACDC_MCP_SEARCH_CONTENT_BOOST` | `--search-content-boost` | Boost factor for content matches. | `1.0` |
 | `ACDC_MCP_SEARCH_RESULT_MODE` | `--search-result-mode` | Search output detail: `references` or `content`. | `references` |
+| `ACDC_MCP_SEARCH_IN_MEMORY` | `--search-in-memory` | Hold the search index in memory instead of on disk. | `true` |
 | `ACDC_MCP_AUTH_TYPE` | `--auth-type`, `-a` | Authentication mode for SSE: `none`, `basic`, `apikey`. | `none` |
 | `ACDC_MCP_AUTH_BASIC_USERNAME` | `--auth-basic-username`, `-u` | Username for Basic Auth. | - |
 | `ACDC_MCP_AUTH_BASIC_PASSWORD` | `--auth-basic-password`, `-P` | Password for Basic Auth. | - |
@@ -207,7 +208,7 @@ This applies identically to both discovery modes (legacy `mcp-resources/` and co
 
 A content-change rebuild holds the search index's write lock for its duration, so a concurrent `search` call briefly blocks until the rebuild finishes. For the zero-config, locally-indexed case this is on the order of milliseconds; for a large curated corpus served over SSE to many concurrent clients, it is a real (if brief) pause on every edit, with no configuration to opt out of it. Because the replacement index is built before the previous one is released, a rebuild also holds two complete indexes at once — under the default in-memory mode, that is twice the index's memory for its duration.
 
-Persistence across restarts is still not part of this release: the catalog and index are rebuilt from scratch every time the process starts, independent of the mid-session refresh described here. The index is held in memory by default; under `ACDC_MCP_SEARCH_IN_MEMORY=false` it is written to a temporary directory that is discarded on shutdown, so neither mode survives a restart.
+Persistence across restarts is still not part of this release: the catalog and index are rebuilt from scratch every time the process starts, independent of the mid-session refresh described here. The index is held in memory by default; under `--search-in-memory=false` (or `ACDC_MCP_SEARCH_IN_MEMORY=false`) it is written to a temporary directory that is discarded on shutdown, so neither mode survives a restart.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,7 +28,7 @@ When the same setting is specified in multiple places, the following priority ap
 | `--search-path-boost` | — | `ACDC_MCP_SEARCH_PATH_BOOST` | Boost for path label (`path_labels`) matches | `1.25` |
 | `--search-content-boost` | — | `ACDC_MCP_SEARCH_CONTENT_BOOST` | Boost for content matches | `1.0` |
 | `--search-result-mode` | — | `ACDC_MCP_SEARCH_RESULT_MODE` | Search output detail: `references` (chunk citations only) or `content` (citations plus the full matched chunk body) | `references` |
-| — | — | `ACDC_MCP_SEARCH_IN_MEMORY` | Hold the search index in memory instead of on disk | `true` |
+| `--search-in-memory` | — | `ACDC_MCP_SEARCH_IN_MEMORY` | Hold the search index in memory instead of on disk | `true` |
 
 ### What the search boosts actually do
 
@@ -106,15 +106,15 @@ The search index is held in memory by default. It is rebuilt from the content
 directory at startup and on every refresh, and it is never reopened, so
 persisting it to disk buys nothing back.
 
-Set `ACDC_MCP_SEARCH_IN_MEMORY=false` to build it on disk instead, under a
-temporary directory. That is worth doing for a large curated catalog. The
-in-memory index builds about twice as fast at every size measured and answers
-queries faster up to at least a thousand chunks, but by roughly fifteen
-thousand the on-disk index has overtaken it and answers about twice as fast —
-and it holds its data in memory-mapped segments the operating system can
-reclaim under pressure, where the in-memory index costs a couple of hundred
-megabytes of Go heap at that size. Where the two cross over depends on the
-shape of the corpus.
+Pass `--search-in-memory=false`, or set `ACDC_MCP_SEARCH_IN_MEMORY=false`, to
+build it on disk instead, under a temporary directory. That is worth doing for
+a large curated catalog. The in-memory index builds about twice as fast at
+every size measured and answers queries faster up to at least a thousand
+chunks, but by roughly fifteen thousand the on-disk index has overtaken it and
+answers about twice as fast — and it holds its data in memory-mapped segments
+the operating system can reclaim under pressure, where the in-memory index
+costs a couple of hundred megabytes of Go heap at that size. Exactly where the
+two cross over has not been measured, and neither has the reason.
 
 Size a deployment for twice that figure. A refresh builds the replacement
 index in full before releasing the previous one, so a content change briefly

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -15,6 +15,10 @@ func RegisterFlags(flags *pflag.FlagSet) {
 	flags.Float64("search-title-boost", 0, "Boost for document title matches (default: 2.0)")
 	flags.Float64("search-content-boost", 0, "Boost for content matches (default: 1.0)")
 	flags.String("search-result-mode", "", "Search output mode: references or content (default: references)")
+	// Unlike its neighbours this default is non-zero, so pflag prints its own
+	// "(default true)" in --help; stating it in the usage text too would
+	// duplicate it.
+	flags.Bool("search-in-memory", true, "Hold the search index in memory instead of on disk")
 	flags.StringP("uri-scheme", "s", "", "URI scheme for resources (default: acdc)")
 	flags.Bool("cross-ref", false, "Transform relative markdown links to resource URIs (default: false)")
 	flags.StringP("auth-type", "a", "", "Authentication type: none, basic, or apikey (default: none)")

--- a/internal/app/cli_test.go
+++ b/internal/app/cli_test.go
@@ -165,3 +165,30 @@ func TestCLI_FlagParsing_SearchPathBoost(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 7.5, settings.Search.PathBoost)
 }
+
+func TestCLI_FlagParsing_SearchInMemory(t *testing.T) {
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	RegisterFlags(flags)
+	require.NoError(t, flags.Set("search-in-memory", "false"))
+
+	settings, err := config.LoadSettingsWithFlags(flags)
+
+	require.NoError(t, err)
+	require.False(t, settings.Search.InMemory)
+}
+
+// TestCLI_SearchInMemoryDefaultsToTrueWhenFlagIsNotPassed pins the priority
+// this setting depends on: registering a bool flag must not itself decide the
+// index kind. Viper reads a bound flag only once pflag reports it changed, and
+// falls back to SetDefault before the flag's own default value — measured, so
+// the flag's default is cosmetic and shows only in --help. Registering the
+// flag would otherwise be a silent way to flip a default set elsewhere.
+func TestCLI_SearchInMemoryDefaultsToTrueWhenFlagIsNotPassed(t *testing.T) {
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	RegisterFlags(flags)
+
+	settings, err := config.LoadSettingsWithFlags(flags)
+
+	require.NoError(t, err)
+	require.True(t, settings.Search.InMemory)
+}

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -151,6 +151,7 @@ func LoadSettingsWithFlags(flags *pflag.FlagSet) (*Settings, error) {
 		_ = v.BindPFlag("search.title_boost", flags.Lookup("search-title-boost"))
 		_ = v.BindPFlag("search.content_boost", flags.Lookup("search-content-boost"))
 		_ = v.BindPFlag("search.result_mode", flags.Lookup("search-result-mode"))
+		_ = v.BindPFlag("search.in_memory", flags.Lookup("search-in-memory"))
 		_ = v.BindPFlag("auth.type", flags.Lookup("auth-type"))
 		_ = v.BindPFlag("auth.basic.username", flags.Lookup("auth-basic-username"))
 		_ = v.BindPFlag("auth.basic.password", flags.Lookup("auth-basic-password"))


### PR DESCRIPTION
## Summary

Follow-up to #95. `search.in_memory` selects which index kind the server builds and, since #95, carries a default of `true` — but it was the only search setting with no CLI flag, reachable solely from the environment or a `.env` file. This adds `--search-in-memory`.

## Changes

- `--search-in-memory` registered in `internal/app/cli.go` and bound in `LoadSettingsWithFlags`, so the documented priority holds: CLI flag > environment > `.env` > default. Verified against the built binary in all four combinations, including `ACDC_MCP_SEARCH_IN_MEMORY=false --search-in-memory=true` resolving to `true`.
- `docs/configuration.md`, `docs/SPECIFICATIONS.md`, and the `README.md` quick table all gain the flag; `SPECIFICATIONS.md` also gains the `ACDC_MCP_SEARCH_IN_MEMORY` row it never had.

Two notes for the reviewer:

**The flag's own default is cosmetic.** Viper reads a bound pflag only once pflag reports it *changed*, and falls back to `SetDefault` before the flag's `DefValue`. Measured: flipping the pflag default to `false` leaves the resolved default `true`. It is declared `true` so `--help` prints the truth, and `TestCLI_SearchInMemoryDefaultsToTrueWhenFlagIsNotPassed` pins that registering a flag cannot silently flip a default set elsewhere. The comment on that test says exactly this, because the obvious guess about the priority order is wrong.

**One prose correction rides along.** `docs/configuration.md` previously attributed the in-memory/on-disk query crossover to "the shape of the corpus". That was a guess. The crossing point was never bisected — it sits somewhere between the 1,240-chunk and 15,157-chunk measurements — and the likelier mechanism is that scorch runs no merger in memory mode, leaving roughly 152 unmerged segments at 15k chunks with `batchSize` at 100. The sentence now says the location and the reason are both unmeasured, which is what is actually known.

