### PR TITLE
perf(search): index only the declared fields

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,6 +100,21 @@ that collide here already share their first four characters. Bleve's automatic m
 raises the tolerance to two characters for any term longer than five, which widens exactly the
 problem described above.
 
+### How much of a query has to match
+
+A document is retrieved when it matches **any one** term of the query. Ordering the rest is left to
+scoring: matching more terms of the query generally ranks a document higher, though a single rare
+term can still outscore several common ones. A search for `helm chart readiness` finds the Helm
+section on two of its terms and the readiness section on one, and ranks them in that order.
+
+Requiring *every* term was measured and rejected. Bleve applies that requirement within a single
+field rather than across the document, and two of the three fields that discriminate between
+documents without frontmatter — the heading path and the path labels — are a handful of words each.
+They can almost never hold a whole query, so requiring every term silently removes those two from
+the ranking and leaves the document body as the only field that can still match. Measured across
+21 queries on two corpora, that changed the leading result on eight and improved none; on a small
+documentation set it made ordinary multi-word queries return nothing at all.
+
 ### Where the index lives
 
 The search index is held in memory by default. It is rebuilt from the content
@@ -108,13 +123,14 @@ persisting it to disk buys nothing back.
 
 Pass `--search-in-memory=false`, or set `ACDC_MCP_SEARCH_IN_MEMORY=false`, to
 build it on disk instead, under a temporary directory. That is worth doing for
-a large curated catalog. The in-memory index builds about twice as fast at
-every size measured and answers queries faster up to at least a thousand
-chunks, but by roughly fifteen thousand the on-disk index has overtaken it and
-answers about twice as fast — and it holds its data in memory-mapped segments
-the operating system can reclaim under pressure, where the in-memory index
-costs a couple of hundred megabytes of Go heap at that size. Exactly where the
-two cross over has not been measured, and neither has the reason.
+a large curated catalog. The in-memory index builds roughly two to three times
+as fast at every size measured and answers queries faster up to at least a
+thousand chunks, but by roughly fifteen thousand the on-disk index has
+overtaken it and answers roughly 1.6–1.75× faster (about 9 ms against 16 ms at
+that size) — and it holds its data in memory-mapped segments the operating
+system can reclaim under pressure, where the in-memory index costs a bit over
+a hundred megabytes of Go heap at that size. Exactly where the two cross over
+has not been measured, and neither has the reason.
 
 Size a deployment for twice that figure. A refresh builds the replacement
 index in full before releasing the previous one, so a content change briefly

--- a/internal/search/golden_test.go
+++ b/internal/search/golden_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/blevesearch/bleve/v2"
+	bleveQuery "github.com/blevesearch/bleve/v2/search/query"
 	"github.com/sha1n/mcp-acdc-server/internal/config"
 	"github.com/sha1n/mcp-acdc-server/internal/content"
 	"github.com/sha1n/mcp-acdc-server/internal/domain"
@@ -217,6 +219,17 @@ func TestGolden_ZeroConfigRanking(t *testing.T) {
 				"Both leading chunks now come from the page that answers the query; the README is demoted, not excluded.",
 			top:   "acdc://docs/deployment/kubernetes#readiness",
 			ranks: map[string]int{"acdc://README": 3},
+		},
+		{
+			name:    "one term of a multi-word query is enough to retrieve",
+			corpora: corpus,
+			query:   "helm chart readiness",
+			rationale: "No chunk carries all three terms. Every field clause is a MatchQuery left at its default OR operator, " +
+				"so the Helm section leads on two terms and the Readiness section still reaches rank 2 on one. " +
+				"Requiring every term instead returns nothing at all for this query: the operator applies within a single field, " +
+				"and no field here holds the whole query. Measured and declined in #92.",
+			top:    "acdc://docs/deployment/kubernetes#helm-chart",
+			within: map[string]int{"acdc://docs/deployment/kubernetes#readiness": 2},
 		},
 	}
 
@@ -561,6 +574,68 @@ func TestGolden_FuzzinessRecallProbes(t *testing.T) {
 					require.Equal(t, 1, rankOf(results, setting.want), "%s\n%q under the %s policy", tt.rationale, tt.probe, setting.label)
 				})
 			}
+		})
+	}
+}
+
+// fieldClauseCandidates counts what one field's clause retrieves on its own,
+// built the way Service.Search builds it.
+func fieldClauseCandidates(t *testing.T, service *Service, field, queryStr string, operator bleveQuery.MatchQueryOperator) int {
+	t.Helper()
+
+	clause := bleve.NewMatchQuery(queryStr)
+	clause.SetField(field)
+	clause.SetFuzziness(service.fuzziness(field))
+	clause.SetOperator(operator)
+
+	request := bleve.NewSearchRequest(clause)
+	request.Size = 100
+
+	result, err := service.index.Search(request)
+	require.NoError(t, err)
+	return len(result.Hits)
+}
+
+// TestGolden_RequiringEveryTermEmptiesTheShortFields measures why #92 declined
+// MatchQueryOperatorAnd, and is the regression gate on that decision together
+// with the golden case above.
+//
+// The operator applies inside a field clause, not across a document, so
+// requiring every term requires them all in one field. heading_path,
+// source_title and path_labels are short by construction — a file path is a
+// handful of labels, a heading path a handful of words — and cannot hold a
+// whole query. On a query every field retrieves under the shipped operator,
+// requiring every term takes all four to zero and leaves a five-field ranking
+// model with nothing to rank.
+//
+// Expectations are measured, not desired. A change means the retrieval model
+// moved.
+func TestGolden_RequiringEveryTermEmptiesTheShortFields(t *testing.T) {
+	const probe = "401 unauthorized troubleshooting"
+
+	service := goldenService(t, zeroConfigCorpus)
+
+	tests := []struct {
+		field string
+		// wantAny is the candidate count under the shipped OR operator.
+		wantAny int
+		// wantAll is the count when every term is required instead.
+		wantAll int
+	}{
+		{domain.FieldHeadingPath, 5, 0},
+		{domain.FieldSourceTitle, 5, 0},
+		{domain.FieldPathLabels, 5, 0},
+		{domain.FieldContent, 6, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.field, func(t *testing.T) {
+			anyTerm := fieldClauseCandidates(t, service, tt.field, probe, bleveQuery.MatchQueryOperatorOr)
+			everyTerm := fieldClauseCandidates(t, service, tt.field, probe, bleveQuery.MatchQueryOperatorAnd)
+			t.Logf("%s — any term: %d candidates, every term: %d", tt.field, anyTerm, everyTerm)
+
+			require.Equal(t, tt.wantAny, anyTerm, "%s under the shipped operator", tt.field)
+			require.Equal(t, tt.wantAll, everyTerm, "%s when every term is required", tt.field)
 		})
 	}
 }

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -185,7 +185,9 @@ func buildMapping() mapping.IndexMapping {
 
 	searchableText := bleve.NewTextFieldMapping()
 	searchableText.Store = true
-	searchableText.IncludeInAll = true
+	// Nothing queries bleve's composite _all field: every clause Search builds
+	// names an explicit field. Composing into it would index every token twice.
+	searchableText.IncludeInAll = false
 	searchableText.Analyzer = "en"
 
 	lineNumber := bleve.NewNumericFieldMapping()
@@ -193,6 +195,11 @@ func buildMapping() mapping.IndexMapping {
 	lineNumber.IncludeInAll = false
 
 	chunkMapping := bleve.NewDocumentMapping()
+	// Index exactly the fields declared below. Dynamic mapping would also index
+	// the Chunk fields with no entry here — section_fragment, fragment, part,
+	// part_count — under the standard analyzer, where no query reads them and
+	// their tokens leak into _all past the IncludeInAll settings above.
+	chunkMapping.Dynamic = false
 	for _, field := range []string{
 		domain.FieldChunkID,
 		domain.FieldSourceID,

--- a/internal/search/service_test.go
+++ b/internal/search/service_test.go
@@ -614,3 +614,73 @@ func TestSearch_MemoryAndDiskIndexesHonourTheSameMapping(t *testing.T) {
 			"search.in_memory changed the ranking, which it must never do")
 	})
 }
+
+// TestSearch_HighlightsMatchedContent covers the fragment Search returns as a
+// result's Snippet. The highlight is requested with no field list, so bleve
+// resolves it against the fields recorded in each hit's Locations — the
+// fields that actually matched — rather than through the index mapping's
+// default field, which is why the composite _all field being empty does not
+// affect it.
+func TestSearch_HighlightsMatchedContent(t *testing.T) {
+	service := goldenService(t, zeroConfigCorpus)
+
+	results, err := service.Search("bearer token", goldenCandidates)
+	require.NoError(t, err)
+	require.NotEmpty(t, results)
+	require.Contains(t, results[0].Snippet, "<mark>",
+		"the leading result must carry a highlighted fragment, not the raw chunk body")
+}
+
+// TestSearch_CompositeAllFieldIsEmpty pins that nothing is written to bleve's
+// composite _all field. Every clause Search builds names an explicit field, so
+// populating _all would index every token of five fields for no reader at all.
+//
+// Two probes are required because _all can be fed by two different analyzers,
+// and each one only shows up under its own probe:
+//
+//   - "kubernet" is the "en" stem the mapped text fields' analyzer would write
+//     into _all if IncludeInAll were true on those fields. _all itself is
+//     always queried with the index mapping's default analyzer — "standard",
+//     never "en" — so a query for the unstemmed word "kubernetes" never
+//     reaches those tokens; only the stem does.
+//   - "kubernetes" is the unstemmed word bleve's dynamic mapping would write
+//     under the standard analyzer for any Chunk field left unmapped
+//     (section_fragment, fragment, part, part_count) if dynamic mapping were
+//     left on. The stem probe cannot catch that leak: dynamic mapping never
+//     produces the "en" stem.
+//
+// Both probes must return zero hits, or the corresponding mapping setting has
+// regressed.
+//
+// The field cannot be asserted away by name: IndexMappingImpl creates it
+// unconditionally, so index.Fields() lists _all whether or not anything feeds
+// it. Emptiness is only observable through a query.
+func TestSearch_CompositeAllFieldIsEmpty(t *testing.T) {
+	service := goldenService(t, zeroConfigCorpus)
+
+	for _, probeTerm := range []string{"kubernet", "kubernetes"} {
+		t.Run(probeTerm, func(t *testing.T) {
+			probe := bleve.NewMatchQuery(probeTerm)
+			probe.SetField("_all")
+			request := bleve.NewSearchRequest(probe)
+			request.Size = goldenCandidates
+
+			result, err := service.index.Search(request)
+			require.NoError(t, err)
+			require.Empty(t, result.Hits, "no field may be composed into _all")
+		})
+	}
+
+	t.Run("unmapped Chunk fields are not indexed", func(t *testing.T) {
+		index, ok := service.index.(bleve.Index)
+		require.True(t, ok, "service.index must be a bleve.Index to reach Fields()")
+
+		fields, err := index.Fields()
+		require.NoError(t, err)
+
+		for _, unmapped := range []string{"section_fragment", "fragment", "part", "part_count"} {
+			require.NotContains(t, fields, unmapped,
+				"dynamic mapping must not index Chunk fields with no explicit mapping")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Answers #92: requiring every term of a multi-word query (`MatchQueryOperatorAnd`) was measured against the golden harness (#83) and **declined**. No operator change ships — every `MatchQuery` keeps its default OR with `SetMin(1)`.

What ships instead is the dead weight the measurement walked into. `buildMapping` no longer populates Bleve's composite `_all` field, and no longer lets dynamic mapping index four `domain.Chunk` fields nothing reads.

## Why AND was declined

**The operator applies within a field clause, not across a document.** `boostedFieldQueries` builds one `MatchQuery` per field, so requiring every term requires them all in *one* field — and `heading_path`, `source_title` and `path_labels` are short by construction. Across twelve repository-scale queries, `source_title` and `path_labels` return **zero** candidates under AND on **10 of 12**. AND collapses the five-field model to content-only, the exact inverse of the baseline's finding that those fields are the only discriminating ones without frontmatter.

Measured across 21 queries on two corpora (47 chunks and 1,240), AND improved rank 1 on **zero** and degraded it on **eight**; on the small corpus two of nine queries returned nothing at all. Examples:

| query | OR | per-field AND |
|---|---|---|
| `helm chart readiness` (the issue's own example) | rank 1 `#helm-chart` | **no results** |
| `401 unauthorized troubleshooting` | rank 1 `#requests-fail-with-401` | **no results** |
| `executing an implementation plan` (1,240) | `executing-plans/SKILL#overview` | `plans/…worktree-rototill#option-3-keep-as-is` |

It is not a narrowing, either: on `how do i rotate a bearer token` AND drops OR's ranks 1–4 and keeps its rank 5. AND retrieval is orthogonal to score order.

Both middle grounds the issue proposed fail for the same structural reason. `SetMin(n-1)` preserves rank 1 but still kills the short fields — 3-of-4 terms in a path is as impossible as 4-of-4. A document-level filter on `_all` drops the correct answer whenever a section omits one query word. There is no latency motive: OR runs 1.15–3.03 ms against AND's 1.07–2.38 ms at 1,240 chunks.

## Changes

- **`perf(search): index only the declared fields`** — two lines in `buildMapping`, and they are inseparable. `IncludeInAll = false` alone leaves `_all` fed by the dynamically-mapped fields; `Dynamic = false` alone leaves the five mapped fields composed into it. At 14,880 chunks the pair cuts build 2,863 → 1,936 ms, Go heap 179.4 → 111.9 MiB, and on-disk footprint 67.0 → 44.1 MiB; about a third of each at both scales measured.

  **Ranking-neutral, and proven so:** the golden report's 111 rank lines are byte-identical to `master`, scores included, as are highlight fragments.

- **`test(search): pin that any one term of a query retrieves`** — the regression gate on the decision. A golden case whose terms are spread across fields (rank 1 today, zero results under AND) plus a measurement test recording the per-field collapse, so a future reader sees the mechanism and not just a rank assertion.

- **`docs(search): state how much of a query has to match`** — documents the retrieval behaviour for the first time, and corrects the in-memory/on-disk figures that the mapping change invalidated.

## Two traps worth knowing before touching this

- **`index.Fields()` still lists `_all` afterwards.** `IndexMappingImpl` creates the composite field unconditionally; it is simply empty, and emptiness is only observable through a query.
- **A single `_all` probe gates only half the change.** `_all` is queried with the `standard` analyzer while holding `en`-stemmed tokens from the mapped fields and `standard` tokens from the dynamic ones, so the stem `kubernet` catches `IncludeInAll` and the unstemmed `kubernetes` catches dynamic mapping. `TestSearch_CompositeAllFieldIsEmpty` tables both — the first version of it left `Dynamic` ungated with the whole suite green.
