### PR TITLE
fix(search): fill the result page against the per-source cap

### DIFF
--- a/docs/SPECIFICATIONS.md
+++ b/docs/SPECIFICATIONS.md
@@ -129,7 +129,7 @@ Chunking is not specific to configured indexing: regardless of which discovery m
 -   **Chunk boundaries**: A new chunk starts at *every* heading, of any level — a chunk's content never includes its subsections' content, though its `heading_path` still records the full ancestry (e.g. `["Configuration", "Authentication"]`). Content before the first heading forms its own chunk, addressed with the reserved fragment `document`. A heading whose text has no letters or digits (e.g. `# !!!`) falls back to the fragment `section`.
 -   **Soft splitting**: A section exceeding a soft limit of **4,000 Unicode code points** is further split along block boundaries into multiple parts, each still tagged with the section's full heading path.
 -   **Fragment URIs**: An unsplit section is `<document-uri>#<heading-slug>` (or `<document-uri>#document` for the pre-heading preamble). A split section's parts are `<document-uri>#<heading-slug>~1`, `~2`, ... — every part, including the first, carries the suffix. Reading the bare `#<heading-slug>` of a split section reconstructs the full section by joining its parts. Duplicate heading text produces de-duplicated slugs (`#overview-1`, `#overview-2`, ...).
--   **Result diversity**: `search` fetches up to `ACDC_MCP_SEARCH_MAX_RESULTS` × 5 candidates internally, then caps results per source document before returning up to the configured limit: 1 chunk per document in `references` mode, 2 in `content` mode.
+-   **Result diversity**: `search` caps results per source document before returning up to `ACDC_MCP_SEARCH_MAX_RESULTS`: 1 chunk per document in `references` mode, 2 in `content` mode. Because the cap discards candidates, the internal candidate window adapts — it starts at `ACDC_MCP_SEARCH_MAX_RESULTS` × 5 and widens ×4 for up to two further retrievals (×20, ×80) while the page is short and candidates remain, so a document with many matching sections does not shorten the page.
 -   **Path labels**: Each chunk is also ranked on path labels derived from the document's relative path (split on `/`, `-`, `_`, whitespace, and camelCase boundaries; lowercased; deduplicated), indexed with a 1.25x boost — see `path_labels` below.
 -   **Duplicate identity**: Startup fails if two discovered documents or chunks resolve to the same URI or ID — for example, `guide.md` and `guide.markdown` selected side by side both produce the URI `<scheme>://guide`. This applies to both discovery modes.
 
@@ -243,7 +243,7 @@ Used for remote connections.
     *   **Fuzzy Search**: Matches terms with an edit distance of 1 on four of the five indexed fields; `path_labels` is matched exactly.
     *   **Stemming**: Uses the standard English analyzer for language-aware matching.
     *   **Highlighting**: Generates dynamic snippets with search term context.
-    *   **Result Diversity**: Caps results per source document (1 in `references` mode, 2 in `content` mode) so results aren't dominated by a single document.
+    *   **Result Diversity**: Caps results per source document (1 in `references` mode, 2 in `content` mode) so results aren't dominated by a single document, over-fetching candidates — and widening that window when the cap discards them — so the cap does not shorten the page instead.
 *   **Indexed Fields (Default Boosts)**:
     *   `chunk_id`, `source_id`, `source_uri`, `chunk_uri`, `source_path` (Stored, Identifier)
     *   `source_title` (Stored, Indexed, Boost x2.0)

--- a/docs/authoring-resources.md
+++ b/docs/authoring-resources.md
@@ -128,7 +128,9 @@ A section that exceeds a soft limit of **4,000 Unicode code points** is further 
 
 ### Result Diversity
 
-To keep results varied across documents, the `search` tool over-fetches candidate chunks internally (5x the configured result limit) and then applies a per-document cap before returning up to the configured limit: `references` mode keeps at most one chunk per source document; `content` mode keeps at most two.
+To keep results varied across documents, the `search` tool over-fetches candidate chunks internally and then applies a per-document cap before returning up to the configured limit: `references` mode keeps at most one chunk per source document; `content` mode keeps at most two.
+
+The cap discards candidates, so the over-fetch adapts rather than being fixed. The candidate window starts at 5x the result limit and widens 4x for up to two further retrievals (20x, then 80x) while the page is still short and candidates remain. A document with many matching sections therefore costs the page nothing: its extra chunks are replaced by other documents rather than leaving gaps. A page can still come back short — when the corpus genuinely holds fewer matching documents than the limit, or when one document's matching sections outnumber the widest candidate window.
 
 ### Fragment Reads
 

--- a/internal/mcp/search_fill_test.go
+++ b/internal/mcp/search_fill_test.go
@@ -1,0 +1,239 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/sha1n/mcp-acdc-server/internal/config"
+	"github.com/sha1n/mcp-acdc-server/internal/domain"
+	"github.com/sha1n/mcp-acdc-server/internal/search"
+	"github.com/stretchr/testify/require"
+)
+
+// These cases drive the per-source cap through a real index and the real
+// ranking model. Every other presenter test feeds hand-built SearchResult
+// values, so none of them can see the cap and the scorer disagreeing about how
+// many distinct sources the candidate window holds.
+
+// floodedCorpus builds a corpus in which one document owns the leading ranks:
+// floodChunks strongly matching sections in a single source, plus otherSources
+// documents that match the same query once and more weakly.
+func floodedCorpus(floodChunks, otherSources int) []domain.Chunk {
+	chunks := make([]domain.Chunk, 0, floodChunks+otherSources)
+
+	for i := 0; i < floodChunks; i++ {
+		chunks = append(chunks, domain.Chunk{
+			ID:          fmt.Sprintf("flood-%d", i),
+			SourceID:    "flood",
+			SourceURI:   "acdc://flood",
+			ChunkURI:    fmt.Sprintf("acdc://flood#section-%d", i),
+			SourceTitle: "Widget Handbook",
+			SourcePath:  "docs/widget-handbook.md",
+			PathLabels:  []string{"docs", "widget", "handbook"},
+			HeadingPath: []string{"Widget Handbook", fmt.Sprintf("Widget detail %d", i)},
+			Content:     "Widget widget widget. Everything about the widget in detail.",
+		})
+	}
+
+	for i := 0; i < otherSources; i++ {
+		chunks = append(chunks, domain.Chunk{
+			ID:          fmt.Sprintf("other-%d-a", i),
+			SourceID:    fmt.Sprintf("other-%d", i),
+			SourceURI:   fmt.Sprintf("acdc://other-%d", i),
+			ChunkURI:    fmt.Sprintf("acdc://other-%d#one", i),
+			SourceTitle: fmt.Sprintf("Note %d", i),
+			SourcePath:  fmt.Sprintf("docs/notes/note-%d.md", i),
+			PathLabels:  []string{"docs", "notes", fmt.Sprintf("note-%d", i)},
+			HeadingPath: []string{fmt.Sprintf("Note %d", i)},
+			Content:     "A passing mention of a widget among unrelated prose.",
+		})
+		chunks = append(chunks, domain.Chunk{
+			ID:          fmt.Sprintf("other-%d-b", i),
+			SourceID:    fmt.Sprintf("other-%d", i),
+			SourceURI:   fmt.Sprintf("acdc://other-%d", i),
+			ChunkURI:    fmt.Sprintf("acdc://other-%d#two", i),
+			SourceTitle: fmt.Sprintf("Note %d", i),
+			SourcePath:  fmt.Sprintf("docs/notes/note-%d.md", i),
+			PathLabels:  []string{"docs", "notes", fmt.Sprintf("note-%d", i)},
+			HeadingPath: []string{fmt.Sprintf("Note %d", i), "Aside"},
+			Content:     "Another passing mention of a widget among unrelated prose.",
+		})
+	}
+
+	return chunks
+}
+
+func indexedService(t *testing.T, chunks []domain.Chunk) *search.Service {
+	t.Helper()
+
+	service := search.NewService(config.SearchSettings{
+		MaxResults:    10,
+		InMemory:      true,
+		KeywordsBoost: config.DefaultKeywordsBoost,
+		HeadingBoost:  config.DefaultHeadingBoost,
+		TitleBoost:    config.DefaultTitleBoost,
+		PathBoost:     config.DefaultPathBoost,
+		ContentBoost:  config.DefaultContentBoost,
+	})
+	t.Cleanup(service.Close)
+
+	stream := make(chan domain.Chunk, len(chunks))
+	for _, chunk := range chunks {
+		stream <- chunk
+	}
+	close(stream)
+	require.NoError(t, service.Index(context.Background(), stream))
+
+	return service
+}
+
+// searchPageURIs runs the search tool and returns the chunk URIs it rendered.
+func searchPageURIs(t *testing.T, service search.Searcher, mode config.SearchResultMode, query string) []string {
+	t.Helper()
+
+	handler := NewSearchToolHandler(service, noopRevalidator{}, config.SearchSettings{MaxResults: 10, ResultMode: mode})
+	result, _, err := handler(context.Background(), nil, SearchToolArgument{Query: query})
+	require.NoError(t, err)
+
+	text := result.Content[0].(*mcp.TextContent).Text
+	var uris []string
+	for _, line := range strings.Split(text, "\n") {
+		// Only the header line of a result carries its URI. A snippet can
+		// contain a markdown link of its own, so matching "](" anywhere would
+		// count chunk content as results.
+		if !strings.HasPrefix(line, "- **") {
+			continue
+		}
+		if open := strings.LastIndex(line, "]("); open >= 0 {
+			uris = append(uris, strings.TrimSuffix(line[open+2:], ")"))
+		}
+	}
+	return uris
+}
+
+// chunksPerSource counts the rendered chunks each source document contributed.
+func chunksPerSource(uris []string) map[string]int {
+	counts := make(map[string]int, len(uris))
+	for _, uri := range uris {
+		source, _, _ := strings.Cut(uri, "#")
+		counts[source]++
+	}
+	return counts
+}
+
+func maxChunksPerSource(uris []string) int {
+	most := 0
+	for _, count := range chunksPerSource(uris) {
+		most = max(most, count)
+	}
+	return most
+}
+
+// A document that floods the leading ranks must not shrink the page. With 60
+// strongly matching chunks in one source, the first candidate window holds that
+// source alone, and the per-source cap discards all but one of them.
+func TestSearchToolHandler_FloodedRanksStillFillThePage(t *testing.T) {
+	service := indexedService(t, floodedCorpus(60, 12))
+
+	t.Run("references keeps one chunk per source and still fills the page", func(t *testing.T) {
+		uris := searchPageURIs(t, service, config.SearchResultModeReferences, "widget")
+
+		require.Len(t, uris, 10)
+		require.Equal(t, 1, maxChunksPerSource(uris))
+	})
+
+	t.Run("content keeps two chunks per source and still fills the page", func(t *testing.T) {
+		uris := searchPageURIs(t, service, config.SearchResultModeContent, "widget")
+
+		require.Len(t, uris, 10)
+		require.Equal(t, 2, maxChunksPerSource(uris))
+		require.Equal(t, 2, chunksPerSource(uris)["acdc://flood"])
+	})
+}
+
+// The widening is bounded on both sides: a corpus that cannot fill the page
+// costs one retrieval, and a corpus that can never fill it stops at the ceiling
+// instead of walking the whole candidate set.
+func TestSearchToolHandler_CandidateWindowWidensOnlyAsFarAsNeeded(t *testing.T) {
+	tests := []struct {
+		name           string
+		chunks         []domain.Chunk
+		wantResults    int
+		wantRetrievals []int
+		wantRationale  string
+	}{
+		{
+			name:           "candidates exhausted, so one retrieval",
+			chunks:         floodedCorpus(3, 2),
+			wantResults:    3,
+			wantRetrievals: []int{50},
+			wantRationale:  "a short candidate set cannot grow, so widening the window buys nothing",
+		},
+		{
+			name:           "page fills once the flood is out of the way",
+			chunks:         floodedCorpus(60, 12),
+			wantResults:    10,
+			wantRetrievals: []int{50, 200},
+			wantRationale:  "60 flooding chunks own the first window; the second reaches the other documents",
+		},
+		{
+			name:           "a full page stops the widening even with candidates left over",
+			chunks:         floodedCorpus(60, 200),
+			wantResults:    10,
+			wantRetrievals: []int{50, 200},
+			wantRationale:  "the second window is truncated, so only the full page can stop the widening here",
+		},
+		{
+			name:           "a flood deeper than the ceiling still shortens the page",
+			chunks:         floodedCorpus(900, 3),
+			wantResults:    1,
+			wantRetrievals: []int{50, 200, 800},
+			wantRationale:  "candidates never run out, so only the retrieval budget stops the widening — the page is short by design rather than by accident",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			counting := &countingSearcher{Searcher: indexedService(t, test.chunks)}
+
+			uris := searchPageURIs(t, counting, config.SearchResultModeReferences, "widget")
+
+			require.Len(t, uris, test.wantResults, test.wantRationale)
+			require.Equal(t, test.wantRetrievals, counting.candidateLimits, test.wantRationale)
+		})
+	}
+}
+
+// Nothing validates search.max_results above 0, so a non-positive limit must
+// terminate the widening rather than loop on a page that can never fill.
+func TestSearchToolHandler_NonPositiveLimitRetrievesOnce(t *testing.T) {
+	for _, limit := range []int{0, -1} {
+		t.Run(fmt.Sprintf("limit=%d", limit), func(t *testing.T) {
+			counting := &countingSearcher{Searcher: indexedService(t, floodedCorpus(60, 12))}
+			handler := NewSearchToolHandler(counting, noopRevalidator{}, config.SearchSettings{
+				MaxResults: limit,
+				ResultMode: config.SearchResultModeReferences,
+			})
+
+			result, _, err := handler(context.Background(), nil, SearchToolArgument{Query: "widget"})
+
+			require.NoError(t, err)
+			require.Contains(t, result.Content[0].(*mcp.TextContent).Text, "No results found")
+			require.Len(t, counting.candidateLimits, 1)
+		})
+	}
+}
+
+// countingSearcher records every candidate window it is asked for.
+type countingSearcher struct {
+	search.Searcher
+	candidateLimits []int
+}
+
+func (s *countingSearcher) Search(query string, candidateLimit int) ([]search.SearchResult, error) {
+	s.candidateLimits = append(s.candidateLimits, candidateLimit)
+	return s.Searcher.Search(query, candidateLimit)
+}

--- a/internal/mcp/search_presenter.go
+++ b/internal/mcp/search_presenter.go
@@ -8,7 +8,46 @@ import (
 	"github.com/sha1n/mcp-acdc-server/internal/search"
 )
 
-const candidateMultiplier = 5
+const (
+	// candidateMultiplier sizes the first candidate window against the result limit.
+	candidateMultiplier = 5
+	// candidateGrowthFactor widens the window on each further retrieval.
+	candidateGrowthFactor = 4
+	// maxCandidateRetrievals bounds the widening. Query cost grows roughly
+	// linearly with the window, so the ceiling is what keeps a flooded query from
+	// paying for the whole corpus.
+	maxCandidateRetrievals = 3
+)
+
+// fillSearchPage retrieves candidates and selects a page from them, widening the
+// candidate window while the page is short and the candidate set was truncated.
+// The per-source cap discards candidates, so a document occupying the leading
+// ranks would otherwise shrink the page rather than merely lose its own
+// duplicates — a fixed window returns whatever survives the cap.
+//
+// Each round selects from a single Search call rather than accumulating across
+// rounds: a refresh may swap the index between retrievals, and a page assembled
+// from two index generations could carry a stale chunk beside its replacement.
+func fillSearchPage(searcher search.Searcher, query string, mode config.SearchResultMode, limit int) ([]search.SearchResult, error) {
+	window := limit * candidateMultiplier
+
+	for retrieval := 1; ; retrieval++ {
+		results, err := searcher.Search(query, window)
+		if err != nil {
+			return nil, err
+		}
+
+		selected := selectSearchResults(results, mode, limit)
+		// A short result set means the candidates are exhausted, so a wider
+		// window cannot add anything. Comparisons are >=, not ==, so a
+		// non-positive limit terminates on the first retrieval.
+		if len(selected) >= limit || len(results) < window || retrieval >= maxCandidateRetrievals {
+			return selected, nil
+		}
+
+		window *= candidateGrowthFactor
+	}
+}
 
 func selectSearchResults(results []search.SearchResult, mode config.SearchResultMode, limit int) []search.SearchResult {
 	if limit <= 0 {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -52,13 +52,11 @@ func NewSearchToolHandler(searchService search.Searcher, revalidator Revalidator
 		// Args are already validated and unmarshaled by SDK via jsonschema tags
 		slog.Info("Search request", "query", args.Query)
 
-		results, err := searchService.Search(args.Query, settings.MaxResults*candidateMultiplier)
+		selected, err := fillSearchPage(searchService, args.Query, settings.ResultMode, settings.MaxResults)
 		if err != nil {
 			slog.Error("Search failed", "query", args.Query, "error", err)
 			return nil, nil, err
 		}
-
-		selected := selectSearchResults(results, settings.ResultMode, settings.MaxResults)
 
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{


### PR DESCRIPTION
## Summary

The per-source result cap discards candidates, so a document whose sections own the leading ranks used to **shorten the page** rather than merely lose its own duplicates: the fixed `MaxResults × 5` candidate window held that one document, and the cap threw away all but one (`references`) or two (`content`) of its chunks. The candidate window now widens ×4 for up to two further retrievals while the page is short and candidates remain.

This settles #88 by re-scoping it. The issue's original premise — one document monopolizing the page — is false at the tool level and has been since #70; `selectSearchResults` caps it. What reaches the client is the *other* consequence of the same flooding, and it is measurable.

## Changes

- `fillSearchPage` (`internal/mcp/search_presenter.go`) replaces the single `Search` + `selectSearchResults` pair in the search tool handler. Windows: `limit × 5`, `× 20`, `× 80`.
- Three stop conditions, each independently gated by a test: the page filled, the candidate set was exhausted (`len(results) < window`), or the retrieval budget is spent.
- Each retrieval **re-selects** from a single `Search` call rather than accumulating across rounds — a mid-session refresh can swap the index between retrievals, and a page assembled from two index generations could carry a stale chunk beside its replacement.
- `selectSearchResults` is unchanged, signature and behavior; the cap stays a presentation policy keyed on `SearchResultMode`, and nothing under `internal/search/` changes (golden harness output is byte-identical).
- No new configuration surface — the multiplier, growth factor and retrieval budget are unexported constants.

## Measured

8,082-chunk corpus, default `references` mode, `max_results` 10 — before → after:

| | before | after |
|---|---|---|
| queries returning a full page | 5 / 12 | **12 / 12** |
| worst page | 3 results from 3 sources | 10 from 10 |
| already-full queries | 1 retrieval | 1 retrieval, unchanged cost |

Query cost is roughly linear in the window (9.7 ms at 50 candidates → 90 ms at 2000), which is why the window widens only where the cap bit: the 7 short queries now cost 21–43 ms, the 5 already-full ones are untouched, and a small corpus exhausts its candidates in the first retrieval.

Two limits kept deliberately: `references` mode still caps at 1 chunk per document, and a document with more matching sections than the widest window (800 candidates at the default limit) can still return a short page — pinned by a test.

Closes #88