### PR TITLE
fix(resources): resolve the working directory of a relative content dir

### DIFF
--- a/internal/resources/discovery.go
+++ b/internal/resources/discovery.go
@@ -428,12 +428,16 @@ func hasVolumePrefix(pattern string) bool {
 	return len(pattern) >= 2 && pattern[1] == ':' && ((pattern[0] >= 'a' && pattern[0] <= 'z') || (pattern[0] >= 'A' && pattern[0] <= 'Z'))
 }
 
+// canonicalPath absolutizes before resolving symlinks, so that a relative input
+// resolves the working-directory prefix too. The reverse order leaves a relative
+// content root unresolved while every walked file below it -- reached as an
+// absolute path -- resolves, and containment then rejects the whole selection.
 func canonicalPath(filePath string) (string, error) {
-	resolved, err := filepath.EvalSymlinks(filePath)
+	absolute, err := filepath.Abs(filePath)
 	if err != nil {
 		return "", err
 	}
-	return filepath.Abs(resolved)
+	return filepath.EvalSymlinks(absolute)
 }
 
 func withinRoot(root, candidate string) bool {

--- a/internal/resources/discovery_test.go
+++ b/internal/resources/discovery_test.go
@@ -120,6 +120,43 @@ func TestDiscover_ConfiguredSkipsSymlinksAndPreservesContainment(t *testing.T) {
 	require.Equal(t, []string{"acdc://docs/inside"}, sourceURIs(result.Sources))
 }
 
+func TestDiscover_RelativeContentDirUnderSymlinkedWorkingDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks requires additional permissions on Windows")
+	}
+	physical := symlinkFreeTempDir(t)
+	writeFile(t, physical, "docs/guide.md", "# Guide\n\nUseful guide.\n")
+	writeFile(t, physical, "content/docs/guide.md", "# Guide\n\nUseful guide.\n")
+
+	// The working directory must reach the content through a symlink. macOS supplies
+	// one for free under /tmp and /var and Linux does not, so the link is created here
+	// and the temporary directories are resolved first, leaving this the only symlink
+	// in play on either platform.
+	link := filepath.Join(symlinkFreeTempDir(t), "link")
+	require.NoError(t, os.Symlink(physical, link))
+	t.Chdir(link)
+	workingDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.Equal(t, link, workingDir, "the working directory must keep the symlink unresolved for this case to gate anything")
+
+	tests := []struct {
+		name       string
+		contentDir string
+	}{
+		{name: "nested directory", contentDir: "./content"},
+		{name: "working directory itself", contentDir: "."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := Discover(context.Background(), content.NewContentProvider(tt.contentDir), &domain.IndexMetadata{
+				Include: []string{"docs/**/*.md"},
+			}, "acdc")
+			require.NoError(t, err)
+			require.Equal(t, []string{"acdc://docs/guide"}, sourceURIs(result.Sources))
+		})
+	}
+}
+
 func TestDiscover_LegacySkipsInvalidFilesAndBuildsChunks(t *testing.T) {
 	root := t.TempDir()
 	writeFile(t, root, "mcp-resources/valid.md", "---\nname: Valid\ndescription: Valid description\n---\n# Valid\n\nBody.\n")
@@ -526,6 +563,13 @@ func recordingDiscoveryOps(descended *[]string) discoveryOps {
 		})
 	}
 	return ops
+}
+
+func symlinkFreeTempDir(t *testing.T) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+	return resolved
 }
 
 func writeFile(t *testing.T, root, name, body string) string {


### PR DESCRIPTION
## Summary

A relative `--content-dir` failed startup with `selected file escapes content root` whenever the
working directory sat under a symlink — on macOS, any directory under `/tmp`. The README quickstart
uses a relative `--content-dir`, so this is on the first path a new user takes. Closes #93.

`canonicalPath` resolved symlinks before absolutizing. For a relative input `EvalSymlinks` only
inspects the symlink components literally present in the string, so the content root kept the
unresolved working-directory prefix, while every walked file — reached as an absolute path — did
resolve. Containment then rejected the entire selection. Swapping the two calls resolves both sides
identically.

## Changes

- `canonicalPath` absolutizes first, then resolves symlinks.
- The regression case creates its own symlink and `t.Chdir`s through it, rather than relying on
  `/tmp` or `t.TempDir()` being symlinked — those are on macOS and are not on Linux, so a test that
  merely chdirs into `t.TempDir()` is green on CI with or without the fix. Both temporary
  directories are resolved first, leaving the test's own link the only one in play on either
  platform. Verified failing on Linux against the unfixed code, not only on macOS.
- Two relative forms are covered because they fail differently: `./content` produces the reported
  containment error, while `.` makes `filepath.WalkDir` see a symlink rather than a directory at the
  walk root, so it descends nowhere and discovery reports `configured index matched no files`.
- Legacy `mcp-resources` mode was checked and is unaffected: `selectLegacyFiles` derives each
  relative path from the walk path and never re-canonicalizes a file, so it has no containment check
  to trip.
- One error path moves: a nonexistent relative content dir now fails on the absolute path rather
  than the relative one. `internal/app/metadata.go` stats the content dir earlier and normally
  reports first.

Verified beyond the suite by running the quickstart shape by hand from a symlinked working
directory, before and after: the unfixed binary reproduces the issue's exact error, and the fixed
binary starts, indexes, and answers a `search` call over stdio.

`codecov/project` reports -0.10%: the new `filepath.Abs` error branch is the one uncovered
statement. It is unreachable in practice — `os.Getwd` is served from a cache after any `Chdir`, so
`Abs` fails only when the process's initial working directory is already gone — and the alternative
is discarding an error, which is worse than the dip. Same precedent as `repoBaseName`'s post-`Abs`
guards. `codecov/patch` is green.
