### PR TITLE
perf(search): stop the in-memory index fanning out across unmerged segments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ GOARCH_ARM := "arm"
 
 MODFLAGS=-mod=readonly
 
+# Extra flags forwarded to the benchmark binary, e.g.
+# make bench BENCHFLAGS="-corpus=$HOME/docs -corpus-dup=2"
+BENCHFLAGS ?=
+
 # Use linker flags to provide version/build settings
 LDFLAGS=-ldflags "-w -s -X=main.Version=$(VERSION) -X=main.Build=$(BUILD) -X=main.ProgramName=$(PROGRAMNAME)"
 
@@ -79,6 +83,12 @@ coverage: install
 .PHONY: coverage-html
 coverage-html: coverage
 	go tool cover -html=coverage.out
+
+## bench: Runs the search measurement benchmarks (not a regression gate). Pass BENCHFLAGS="-corpus=... -corpus-dup=..." to measure a real corpus
+.PHONY: bench
+bench: install
+	@echo "  >  Running search benchmarks..."
+	go test $(MODFLAGS) -timeout=0 -run '^$$' -bench=. -benchmem ./internal/search/ $(BENCHFLAGS)
 
 ## clean: Removes build artifacts
 .PHONY: clean

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -122,19 +122,31 @@ directory at startup and on every refresh, and it is never reopened, so
 persisting it to disk buys nothing back.
 
 Pass `--search-in-memory=false`, or set `ACDC_MCP_SEARCH_IN_MEMORY=false`, to
-build it on disk instead, under a temporary directory. That is worth doing for
-a large curated catalog. The in-memory index builds roughly two to three times
-as fast at every size measured and answers queries faster up to at least a
-thousand chunks, but by roughly fifteen thousand the on-disk index has
-overtaken it and answers roughly 1.6–1.75× faster (about 9 ms against 16 ms at
-that size) — and it holds its data in memory-mapped segments the operating
-system can reclaim under pressure, where the in-memory index costs a bit over
-a hundred megabytes of Go heap at that size. Exactly where the two cross over
-has not been measured, and neither has the reason.
+build it on disk instead, under a temporary directory. An in-memory index
+accumulates one segment per indexing batch and never compacts them; raising
+the default batch size from 100 to 1000 cut segment count roughly 10× (207
+segments to 21) and roughly halved in-memory query latency (9.21 ms to
+4.87 ms). At 20,678 chunks — a 10,339-chunk corpus duplicated, which doubles
+posting-list length but leaves the term dictionary at its original size —
+in-memory builds about 1.3× faster than on disk (1.90 s against 2.42 s) and
+answers queries only about 10% slower (4.87 ms against 4.41 ms). On-disk's
+remaining edge is its merger, which leaves it with fewer segments still (10
+against 21); at equal segment counts the two kinds measure
+indistinguishably. These figures time the search engine answering one
+query, below the MCP tool clients call. That tool retries — up to twice,
+with a wider candidate window — only if the result page is still short and
+the candidate set was truncated; treat these figures as a floor, not an
+end-to-end number.
 
-Size a deployment for twice that figure. A refresh builds the replacement
-index in full before releasing the previous one, so a content change briefly
-holds two complete indexes at once.
+`--search-in-memory=false` also pays off when Go heap matters more than
+query speed: the on-disk index holds its data in memory-mapped segments the
+operating system can reclaim under pressure, where in-memory's Go heap runs
+roughly 100 MiB at that size against single-digit MiB on disk.
+
+Size a deployment for twice the index's own memory footprint — twice that
+roughly 100 MiB at the scale above, for an in-memory index. A refresh builds the
+replacement index in full before releasing the previous one, so a content
+change briefly holds two complete indexes at once.
 
 ## Authentication Settings
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -44,6 +44,7 @@ make build-docker
 | `make build-docker` | Build Docker image |
 | `make test` | Run all tests |
 | `make coverage` | Run tests with coverage report |
+| `make bench` | Run the search measurement benchmarks |
 | `make lint` | Run linters (go vet, golangci-lint, format check) |
 | `make format` | Format source files |
 | `make clean` | Remove build artifacts |
@@ -57,6 +58,37 @@ make test
 # Run tests with coverage
 make coverage
 ```
+
+## Search Benchmarks
+
+`make bench` reports index build time, query latency, segment count and Go
+heap for the in-memory and on-disk indexes at several batch sizes. It is a
+measurement instrument, not a regression gate — it asserts nothing about
+timings or sizes.
+
+The default corpus (`internal/search/testdata/corpus`) is far too small to
+compare anything: every batch size collapses into a single batch, so both
+index kinds report one segment. Point it at a real corpus instead, and
+optionally repeat that corpus to reach a larger scale:
+
+```bash
+make bench BENCHFLAGS="-corpus=$HOME/docs -corpus-dup=2"
+```
+
+`BENCHFLAGS` is forwarded to the test binary. When invoking `go test`
+directly, the package path must come **before** these flags:
+
+```bash
+# Works
+go test ./internal/search/ -run '^$' -bench=. -corpus-dup=2
+
+# Fails with a misleading "no Go files in ."
+go test -corpus-dup=2 ./internal/search/
+```
+
+`-corpus` and `-corpus-dup` are registered by the test binary rather than by
+`go test`, so `go test` consumes the unknown flag itself and never sees the
+package path that follows it.
 
 ## Code Style
 

--- a/internal/search/bench_test.go
+++ b/internal/search/bench_test.go
@@ -1,0 +1,362 @@
+// Measurement instrument, not a regression gate.
+//
+// Nothing here asserts a timing or a size, and `go test` never runs it —
+// benchmarks execute only under -bench, which `make bench` supplies. The
+// figures it reports are inputs to a decision, so each one travels with its
+// own provenance: the corpus is named by flag and its chunk count is
+// reported alongside every measurement.
+//
+// The corpus is built through the production chunking path rather than
+// hand-assembled, because term-dictionary size and posting-list length are
+// what a query fanning out across many segments actually costs. A synthetic
+// corpus of one repeated string measures segment counts correctly and query
+// latency not at all.
+//
+// The default corpus is small enough that every batch size collapses into a
+// single batch, so a meaningful run names a real corpus:
+//
+//	go test ./internal/search/ -run '^$' -bench=. -corpus=$HOME/docs -corpus-dup=2
+//
+// The package path must come before -corpus and -corpus-dup. Those flags are
+// registered by the test binary, not by `go test`, so `go test -corpus-dup=2
+// ./internal/search/` fails with a misleading "no Go files in ." — `go test`
+// consumes the unknown flag itself and never sees the package path.
+package search
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/blevesearch/bleve/v2"
+	"github.com/blevesearch/bleve/v2/index/scorch"
+	"github.com/sha1n/mcp-acdc-server/internal/content"
+	"github.com/sha1n/mcp-acdc-server/internal/domain"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	benchCorpusDir = flag.String("corpus", filepath.Join("testdata", "corpus"),
+		"directory of Markdown files the benchmarks index")
+	benchCorpusDup = flag.Int("corpus-dup", 1,
+		"how many times to repeat the corpus, with distinct identifiers, to reach a target scale")
+)
+
+type benchIndexKind struct {
+	name string
+	open func(tb testing.TB) (bleve.Index, func())
+}
+
+func benchIndexKinds() []benchIndexKind {
+	return []benchIndexKind{
+		{
+			name: "memory",
+			open: func(tb testing.TB) (bleve.Index, func()) {
+				tb.Helper()
+				index, err := newMemoryIndex(buildMapping())
+				require.NoError(tb, err)
+				return index, func() {}
+			},
+		},
+		{
+			name: "disk",
+			open: func(tb testing.TB) (bleve.Index, func()) {
+				tb.Helper()
+				dir := filepath.Join(tb.TempDir(), "index")
+				index, err := newDiskIndex(dir, buildMapping())
+				require.NoError(tb, err)
+				return index, func() { _ = os.RemoveAll(dir) }
+			},
+		},
+	}
+}
+
+// benchBatchSizes spans the shipped default up to one batch for the whole
+// corpus, which is the only way to reach a single root segment in memory.
+func benchBatchSizes(corpusSize int) []int {
+	sizes := []int{defaultBatchSize, 1000, 10000}
+	kept := sizes[:0]
+	for _, size := range sizes {
+		if size < corpusSize {
+			kept = append(kept, size)
+		}
+	}
+	return append(kept, corpusSize)
+}
+
+// benchCorpus loads every Markdown file under dir through ParseMarkdown ->
+// BuildSourceDocument -> ChunkMarkdown, so path_labels, keywords, heading
+// paths and content are populated exactly as they are at runtime. A file the
+// production path would reject is skipped, as discovery skips it under the
+// lenient policy.
+func benchCorpus(tb testing.TB, dir string, dup int) []domain.Chunk {
+	tb.Helper()
+
+	var (
+		chunks []domain.Chunk
+		files  int
+	)
+	walkErr := filepath.WalkDir(dir, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+			return nil
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		parsed, err := content.ParseMarkdown(raw, content.FrontmatterOptional)
+		if err != nil {
+			return nil
+		}
+		relative, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		relative = filepath.ToSlash(relative)
+		source, err := content.BuildSourceDocument(parsed, content.SourceOptions{
+			URI:          "acdc://bench/" + relative,
+			FilePath:     path,
+			RelativePath: relative,
+			Raw:          raw,
+		})
+		if err != nil {
+			return nil
+		}
+		fileChunks, err := content.ChunkMarkdown(source, parsed)
+		if err != nil {
+			return nil
+		}
+		files++
+		chunks = append(chunks, fileChunks...)
+		return nil
+	})
+	require.NoError(tb, walkErr)
+	require.NotEmpty(tb, chunks, "no Markdown chunks under %s", dir)
+	tb.Logf("corpus %s: %d files, %d chunks, dup %d", dir, files, len(chunks), dup)
+
+	if dup <= 1 {
+		return chunks
+	}
+	scaled := make([]domain.Chunk, 0, len(chunks)*dup)
+	for copyIndex := 0; copyIndex < dup; copyIndex++ {
+		for _, chunk := range chunks {
+			if copyIndex > 0 {
+				suffix := fmt.Sprintf("~%d", copyIndex)
+				chunk.ID += suffix
+				chunk.SourceID += suffix
+				chunk.SourceURI += suffix
+				chunk.ChunkURI += suffix
+			}
+			scaled = append(scaled, chunk)
+		}
+	}
+	tb.Logf("corpus scaled to %d chunks", len(scaled))
+	return scaled
+}
+
+func chunkStream(chunks []domain.Chunk) <-chan domain.Chunk {
+	stream := make(chan domain.Chunk, len(chunks))
+	for _, chunk := range chunks {
+		stream <- chunk
+	}
+	close(stream)
+	return stream
+}
+
+// rootSegments counts the segments a query must fan out across.
+//
+// It counts the live root snapshot rather than reading scorch's
+// num_root_memorysegments stat: introduceSegment stores that stat from the
+// previous root before appending the batch's own segment, and only the
+// merger and persister loops refresh it afterwards. Neither loop runs when
+// the index has no path, so on an in-memory index the stat is permanently
+// one short.
+func rootSegments(tb testing.TB, index bleve.Index) float64 {
+	tb.Helper()
+
+	internal, err := index.Advanced()
+	require.NoError(tb, err)
+	scorchIndex, ok := internal.(*scorch.Scorch)
+	require.True(tb, ok, "expected a scorch index")
+
+	reader, err := scorchIndex.Reader()
+	require.NoError(tb, err)
+	defer func() { require.NoError(tb, reader.Close()) }()
+
+	snapshot, ok := reader.(*scorch.IndexSnapshot)
+	require.True(tb, ok, "expected a scorch index snapshot")
+	return float64(len(snapshot.Segments()))
+}
+
+// settledRootSegments waits for the root snapshot to stop moving, then counts
+// it.
+//
+// batchIndex returns as soon as the last batch is introduced, but on disk
+// scorch's persister and merger keep working afterwards, so both the segment
+// count and the process heap read at that moment describe a pipeline
+// mid-flight and vary run to run on identical input. Polling until the count
+// holds still reports the index a caller would actually query.
+//
+// An index with no path skips the poll entirely: scorch gates both background
+// loops on a non-empty path, so nothing can move the root snapshot once the
+// last batch is in, and a wait would only cost the in-memory measurements
+// their turnaround.
+//
+// The wait is bounded: a pipeline that never settles yields a logged, moving
+// figure rather than a benchmark that hangs.
+//
+// Settling makes the figure describe a quiescent index; it does not make the
+// resting count identical run to run. At batch sizes small enough to introduce
+// hundreds of segments, how many of them the on-disk persister groups into
+// each file segment depends on when it happens to wake, so the count it comes
+// to rest at still moves by a few between runs.
+func settledRootSegments(tb testing.TB, index bleve.Index) float64 {
+	tb.Helper()
+
+	if index.Name() == "" {
+		return rootSegments(tb, index)
+	}
+
+	const (
+		pollInterval  = 100 * time.Millisecond
+		stableSamples = 5
+		maxWait       = 30 * time.Second
+	)
+
+	deadline := time.Now().Add(maxWait)
+	segments := rootSegments(tb, index)
+	for stable := 1; stable < stableSamples; {
+		if time.Now().After(deadline) {
+			tb.Logf("root segments still moving after %s; reporting %.0f", maxWait, segments)
+			break
+		}
+		time.Sleep(pollInterval)
+		current := rootSegments(tb, index)
+		if current == segments {
+			stable++
+			continue
+		}
+		segments, stable = current, 1
+	}
+	return segments
+}
+
+// heapAllocMiB reports live Go heap after a collection. Callers subtract two
+// readings to size what was built between them; see the heapMiB metric for
+// what that difference does and does not mean.
+func heapAllocMiB() float64 {
+	runtime.GC()
+	var stats runtime.MemStats
+	runtime.ReadMemStats(&stats)
+	return float64(stats.HeapAlloc) / (1 << 20)
+}
+
+func BenchmarkIndexBuild(b *testing.B) {
+	corpus := benchCorpus(b, *benchCorpusDir, *benchCorpusDup)
+	for _, kind := range benchIndexKinds() {
+		for _, batchSize := range benchBatchSizes(len(corpus)) {
+			b.Run(fmt.Sprintf("%s/batch=%d", kind.name, batchSize), func(b *testing.B) {
+				var segments, heapMiB float64
+				for b.Loop() {
+					b.StopTimer()
+					index, cleanup := kind.open(b)
+					stream := chunkStream(corpus)
+					baseline := heapAllocMiB()
+					b.StartTimer()
+
+					require.NoError(b, batchIndex(context.Background(), index, stream, batchSize))
+
+					b.StopTimer()
+					segments = settledRootSegments(b, index)
+					// heapMiB is a magnitude indicator, not the index's heap.
+					// The baseline is taken once the corpus and the channel
+					// buffered from it already exist, and that buffer has
+					// drained into garbage by the time this reading collects,
+					// so the difference is the index's heap less the buffer's:
+					// an understatement, and one that grows with the corpus. An
+					// on-disk index keeps its segments in mmap rather than on
+					// the Go heap and can retain less than the buffer released,
+					// which is why its figure can come out below zero.
+					heapMiB = heapAllocMiB() - baseline
+					require.NoError(b, index.Close())
+					cleanup()
+					b.StartTimer()
+				}
+				b.ReportMetric(float64(len(corpus)), "chunks")
+				b.ReportMetric(segments, "segments")
+				b.ReportMetric(heapMiB, "heapMiB")
+			})
+		}
+	}
+}
+
+// benchQueries are answered against whichever corpus is configured. They are
+// ordinary documentation phrasings rather than terms tuned to one corpus, so
+// the same set stays meaningful when -corpus changes.
+var benchQueries = []string{
+	"authentication",
+	"how do i configure the search index",
+	"token rotation",
+	"content directory layout",
+}
+
+func BenchmarkQuery(b *testing.B) {
+	corpus := benchCorpus(b, *benchCorpusDir, *benchCorpusDup)
+	for _, kind := range benchIndexKinds() {
+		for _, batchSize := range benchBatchSizes(len(corpus)) {
+			b.Run(fmt.Sprintf("%s/batch=%d", kind.name, batchSize), func(b *testing.B) {
+				index, cleanup := kind.open(b)
+				b.Cleanup(func() {
+					_ = index.Close()
+					cleanup()
+				})
+				require.NoError(b, batchIndex(context.Background(), index, chunkStream(corpus), batchSize))
+
+				// Set the field directly rather than calling Index: the index is
+				// already built, and Service.Close would then close it twice.
+				service := NewService(testSettings())
+				service.index = index
+
+				// A query that matches nothing is far cheaper than one that
+				// retrieves, and would quietly bias the whole measurement
+				// towards the empty-result path. Run each query once before the
+				// timed loop and fail on an empty result: this asserts that the
+				// measurement is meaningful, never how fast or how large it is.
+				for _, benchQuery := range benchQueries {
+					results, err := service.Search(benchQuery, 0)
+					require.NoError(b, err)
+					require.NotEmpty(b, results,
+						"query %q retrieved nothing from corpus %s; it measures the empty-result path, not query latency",
+						benchQuery, *benchCorpusDir)
+					b.Logf("query %q: %d results", benchQuery, len(results))
+				}
+
+				// Settle before timing so every iteration queries the same
+				// index rather than one the persister and merger are still
+				// reshaping.
+				b.Logf("segments before the timed loop: %.0f", settledRootSegments(b, index))
+
+				query := 0
+				for b.Loop() {
+					_, err := service.Search(benchQueries[query%len(benchQueries)], 0)
+					require.NoError(b, err)
+					query++
+				}
+				b.StopTimer()
+
+				b.ReportMetric(float64(len(corpus)), "chunks")
+				b.ReportMetric(settledRootSegments(b, index), "segments")
+			})
+		}
+	}
+}

--- a/internal/search/bench_test.go
+++ b/internal/search/bench_test.go
@@ -31,6 +31,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -78,10 +79,17 @@ func benchIndexKinds() []benchIndexKind {
 	}
 }
 
-// benchBatchSizes spans the shipped default up to one batch for the whole
-// corpus, which is the only way to reach a single root segment in memory.
+// benchBatchSizes spans a deliberately segment-heavy point, the shipped
+// default, a bucket an order of magnitude above it, and one batch for the
+// whole corpus — the only way to reach a single root segment in memory. The
+// segment-heavy point is fixed at 100 rather than derived from
+// defaultBatchSize: it exists to reproduce the many-segment comparison point
+// that motivated the shipped default in the first place, which only stays a
+// distinct measurement if it does not move in lockstep with that default.
+// dedupeInts tolerates the two coinciding, e.g. if the default is ever 100
+// again.
 func benchBatchSizes(corpusSize int) []int {
-	sizes := []int{defaultBatchSize, 1000, 10000}
+	sizes := dedupeInts([]int{100, defaultBatchSize, 10000})
 	kept := sizes[:0]
 	for _, size := range sizes {
 		if size < corpusSize {
@@ -89,6 +97,18 @@ func benchBatchSizes(corpusSize int) []int {
 		}
 	}
 	return append(kept, corpusSize)
+}
+
+// dedupeInts returns the sorted, duplicate-free contents of sizes.
+func dedupeInts(sizes []int) []int {
+	sort.Ints(sizes)
+	out := sizes[:0]
+	for i, size := range sizes {
+		if i == 0 || size != sizes[i-1] {
+			out = append(out, size)
+		}
+	}
+	return out
 }
 
 // benchCorpus loads every Markdown file under dir through ParseMarkdown ->

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -98,7 +98,7 @@ func (s *Service) Index(ctx context.Context, chunks <-chan domain.Chunk) error {
 	if err != nil {
 		return err
 	}
-	if err := batchIndex(ctx, index, chunks); err != nil {
+	if err := batchIndex(ctx, index, chunks, defaultBatchSize); err != nil {
 		_ = index.Close()
 		if indexDir != "" {
 			_ = removeAll(indexDir)
@@ -143,9 +143,14 @@ func (s *Service) newIndex() (searchIndex, string, error) {
 	return index, indexDir, nil
 }
 
-func batchIndex(ctx context.Context, index BatchIndexer, chunks <-chan domain.Chunk) error {
+// defaultBatchSize is how many chunks Service.Index accumulates before
+// introducing a segment. In memory scorch runs no merger goroutine
+// (scorch.go gates both background loops on a non-empty path), so this
+// also fixes the number of segments a query fans out across.
+const defaultBatchSize = 100
+
+func batchIndex(ctx context.Context, index BatchIndexer, chunks <-chan domain.Chunk, batchSize int) error {
 	batch := index.NewBatch()
-	batchSize := 100
 	count := 0
 
 	for {

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -145,9 +145,14 @@ func (s *Service) newIndex() (searchIndex, string, error) {
 
 // defaultBatchSize is how many chunks Service.Index accumulates before
 // introducing a segment. In memory scorch runs no merger goroutine
-// (scorch.go gates both background loops on a non-empty path), so this
-// also fixes the number of segments a query fans out across.
-const defaultBatchSize = 100
+// (scorch.go gates both background loops on a non-empty path), so this also
+// fixes the number of segments a query fans out across — which is why it is
+// this large rather than a round hundred: query latency scales with segment
+// count, and a handful of segments performs indistinguishably from a single
+// one, so the batch size only needs to keep the segment count small, not
+// minimize it. Raising it further buys little further query latency for a
+// steep rise in build-time heap, since a batch is held in memory whole.
+const defaultBatchSize = 1000
 
 func batchIndex(ctx context.Context, index BatchIndexer, chunks <-chan domain.Chunk, batchSize int) error {
 	batch := index.NewBatch()

--- a/internal/search/service_test.go
+++ b/internal/search/service_test.go
@@ -422,14 +422,14 @@ func TestService_BatchIndexFailures(t *testing.T) {
 		stream := make(chan domain.Chunk, 1)
 		stream <- domain.Chunk{Content: "invalid"}
 		close(stream)
-		require.ErrorContains(t, batchIndex(context.Background(), index, stream), "failed to add chunk to batch")
+		require.ErrorContains(t, batchIndex(context.Background(), index, stream, defaultBatchSize), "failed to add chunk to batch")
 	})
 	t.Run("reports final batch failure", func(t *testing.T) {
 		stream := make(chan domain.Chunk, 1)
 		stream <- domain.Chunk{ID: "chunk", Content: "valid"}
 		close(stream)
 		mock := &mockBatchIndexer{realIndex: index, batchErr: errors.New("batch failed")}
-		require.ErrorContains(t, batchIndex(context.Background(), mock, stream), "failed to execute final batch index")
+		require.ErrorContains(t, batchIndex(context.Background(), mock, stream, defaultBatchSize), "failed to execute final batch index")
 	})
 	t.Run("reports full batch failure", func(t *testing.T) {
 		stream := make(chan domain.Chunk, 100)
@@ -438,7 +438,7 @@ func TestService_BatchIndexFailures(t *testing.T) {
 		}
 		close(stream)
 		mock := &mockBatchIndexer{realIndex: index, batchErr: errors.New("batch failed")}
-		require.ErrorContains(t, batchIndex(context.Background(), mock, stream), "failed to execute batch index")
+		require.ErrorContains(t, batchIndex(context.Background(), mock, stream, defaultBatchSize), "failed to execute batch index")
 	})
 }
 
@@ -552,7 +552,7 @@ func searchThrough(t *testing.T, idx searchIndex, chunks []domain.Chunk, query s
 		stream <- chunk
 	}
 	close(stream)
-	require.NoError(t, batchIndex(context.Background(), idx, stream))
+	require.NoError(t, batchIndex(context.Background(), idx, stream, defaultBatchSize))
 
 	service := NewService(testSettings())
 	service.index = idx

--- a/internal/search/service_test.go
+++ b/internal/search/service_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/blevesearch/bleve/v2"
@@ -432,20 +433,27 @@ func TestService_BatchIndexFailures(t *testing.T) {
 		require.ErrorContains(t, batchIndex(context.Background(), mock, stream, defaultBatchSize), "failed to execute final batch index")
 	})
 	t.Run("reports full batch failure", func(t *testing.T) {
-		stream := make(chan domain.Chunk, 100)
-		for i := 0; i < 100; i++ {
+		// A batch size chosen independently of defaultBatchSize: this subtest
+		// exercises the mid-stream flush (a batch reaching batchSize while more
+		// chunks remain), not the constant's production value.
+		const batchSize = 2
+		stream := make(chan domain.Chunk, batchSize)
+		for i := 0; i < batchSize; i++ {
 			stream <- domain.Chunk{ID: fmt.Sprintf("chunk-%d", i), Content: "valid"}
 		}
 		close(stream)
 		mock := &mockBatchIndexer{realIndex: index, batchErr: errors.New("batch failed")}
-		require.ErrorContains(t, batchIndex(context.Background(), mock, stream, defaultBatchSize), "failed to execute batch index")
+		require.ErrorContains(t, batchIndex(context.Background(), mock, stream, batchSize), "failed to execute batch index")
 	})
 }
 
 func TestService_IndexRebuildsAndBatchesChunks(t *testing.T) {
 	service := NewService(testSettings())
 	defer service.Close()
-	chunks := make([]domain.Chunk, 150)
+	// Indexed through Service.Index, which takes no batch-size argument and
+	// always batches at defaultBatchSize: the corpus must exceed that constant
+	// for the rebuild below to flush more than one batch.
+	chunks := make([]domain.Chunk, defaultBatchSize+50)
 	for i := range chunks {
 		chunks[i] = domain.Chunk{ID: fmt.Sprintf("chunk-%d", i), SourceID: "source", SourceURI: "acdc://source", ChunkURI: fmt.Sprintf("acdc://source#%d", i), Content: "content"}
 	}
@@ -613,6 +621,125 @@ func TestSearch_MemoryAndDiskIndexesHonourTheSameMapping(t *testing.T) {
 			searchThrough(t, memIndex, chunks, "authentication"),
 			"search.in_memory changed the ranking, which it must never do")
 	})
+}
+
+// syntheticCorpusChunks builds n chunks whose content genuinely differs: each
+// carries a topic word repeated a varying number of times (so term frequency,
+// and therefore score, differs chunk to chunk), shared filler text, and a
+// unique marker so no two chunks are identical.
+func syntheticCorpusChunks(n int) []domain.Chunk {
+	topics := []string{"alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel", "india", "juliet"}
+	const filler = "the system processes requests through a configured pipeline that handles each case differently depending on context and load"
+
+	chunks := make([]domain.Chunk, n)
+	for i := 0; i < n; i++ {
+		topic := topics[i%len(topics)]
+		reps := 1 + i%7
+		content := strings.Repeat(topic+" ", reps) + filler + fmt.Sprintf(" marker%d", i)
+		chunks[i] = domain.Chunk{
+			ID:        fmt.Sprintf("chunk-%d", i),
+			SourceID:  fmt.Sprintf("source-%d", i),
+			SourceURI: fmt.Sprintf("acdc://source-%d", i),
+			ChunkURI:  fmt.Sprintf("acdc://source-%d#chunk", i),
+			Content:   content,
+		}
+	}
+	return chunks
+}
+
+// batchIndexedService indexes chunks into a fresh in-memory index at the
+// given batch size and attaches it to a Service the way searchThrough does,
+// but keeping the batch size a parameter rather than fixing it at
+// defaultBatchSize.
+func batchIndexedService(t *testing.T, chunks []domain.Chunk, batchSize int) *Service {
+	t.Helper()
+
+	idx, err := newMemoryIndex(buildMapping())
+	require.NoError(t, err)
+
+	stream := make(chan domain.Chunk, len(chunks))
+	for _, chunk := range chunks {
+		stream <- chunk
+	}
+	close(stream)
+	require.NoError(t, batchIndex(context.Background(), idx, stream, batchSize))
+
+	service := NewService(testSettings())
+	service.index = idx
+	t.Cleanup(service.Close)
+	return service
+}
+
+// serviceRootSegments counts the segments a query against service fans out
+// across. No settling is needed: these services index in memory, where scorch
+// runs neither the persister nor the merger, so the root snapshot is final the
+// moment batchIndex returns.
+func serviceRootSegments(t *testing.T, service *Service) int {
+	t.Helper()
+
+	idx, ok := service.index.(bleve.Index)
+	require.True(t, ok, "expected a bleve index")
+	return int(rootSegments(t, idx))
+}
+
+// TestSearch_RankingIsIndependentOfBatchSize pins the invariant defaultBatchSize
+// depends on: the batch size only bounds how many segments the in-memory index
+// ends up with, and must never influence which documents match or how they
+// score. The golden harness's corpus is 41 chunks, which forms a single batch
+// at any batch size of 100 or larger, so a golden-report diff across the
+// batch-size change is empty for a trivial reason — it never exercises more
+// than one segment. This test builds a synthetic corpus of 300 chunks with
+// varied content instead, so that the two sides genuinely differ in segment
+// count, and checks that they agree anyway.
+//
+// The segment counts are asserted rather than assumed. The whole test rests on
+// the two indexes being segmented differently, and a batch size that stopped
+// producing that difference would leave the test comparing two identical
+// indexes while still passing. The many-segment side is pinned at a literal
+// 100 so it stays a fixed comparison point; the other side uses
+// defaultBatchSize so this keeps covering the value actually shipped, which is
+// why its expected segment count is stated as a relation rather than a number.
+//
+// This asserts on Score, which the golden harness's rank-only convention
+// forbids elsewhere. That convention exists because absolute scores drift
+// across library upgrades and across corpus sizes, so pinning a score also
+// pins those incidental things. Here the two sides being compared share both
+// the library version and the corpus — the only thing that differs is segment
+// count — so a score difference could only come from segment count itself,
+// which is exactly what this test exists to rule out. This is the same
+// exception TestSearch_MemoryAndDiskIndexesHonourTheSameMapping takes, for
+// the same reason: the invariant under test is agreement between two
+// configurations of one index, not an absolute value.
+func TestSearch_RankingIsIndependentOfBatchSize(t *testing.T) {
+	const (
+		corpusSize      = 300
+		manySegmentSize = 100
+	)
+	chunks := syntheticCorpusChunks(corpusSize)
+
+	manySegments := batchIndexedService(t, chunks, manySegmentSize)
+	defaultBatched := batchIndexedService(t, chunks, defaultBatchSize)
+
+	manyCount := serviceRootSegments(t, manySegments)
+	defaultCount := serviceRootSegments(t, defaultBatched)
+	require.Equal(t, corpusSize/manySegmentSize, manyCount,
+		"batch size %d over %d chunks must yield one segment per batch", manySegmentSize, corpusSize)
+	require.Less(t, defaultCount, manyCount,
+		"batch size %d must segment the corpus differently from batch size %d, or this test compares two identically segmented indexes",
+		defaultBatchSize, manySegmentSize)
+
+	for _, query := range []string{"alpha", "delta", "hotel", "juliet", "marker137"} {
+		t.Run(query, func(t *testing.T) {
+			manyResults, err := manySegments.Search(query, 50)
+			require.NoError(t, err)
+			defaultResults, err := defaultBatched.Search(query, 50)
+			require.NoError(t, err)
+			require.NotEmpty(t, manyResults, "query %q retrieved nothing", query)
+
+			require.Equal(t, rankedScores(defaultResults), rankedScores(manyResults),
+				"batch size changed ranking or score for query %q", query)
+		})
+	}
 }
 
 // TestSearch_HighlightsMatchedContent covers the fragment Search returns as a


### PR DESCRIPTION
## Summary

Closes #97.

An in-memory scorch index is opened with an empty path, and scorch gates both its persister and merger loops on the path being non-empty. Neither runs, so segment count equals the number of indexing batches and never decreases — roughly 200 segments at 20k chunks with the old batch size of 100, all of which every query fans out across.

Measurement confirms segment count is the whole mechanism, and raising `defaultBatchSize` from 100 to 1000 roughly halves in-memory query latency while *also* cutting build time and heap.

## What the measurement found

At 20,678 chunks, in-memory, varying only the batch size:

| segments | 207 | 21 | 3 | 1 |
|---|---|---|---|---|
| query | 9.21 ms | 4.87 ms | 4.54 ms | 4.63 ms |

**At equal segment counts the two index kinds are indistinguishable** — 3 segments: 4.54 ms in memory against 4.62 ms on disk; 1 segment: 4.63 against 4.63. That rules out the zap segment format as an explanation, which is what the previous documentation had implicitly assumed.

`batch=1000` was chosen because it beats the old default on all three axes at both measured scales — query 9.21 → 4.87 ms, build 2.34 → 1.90 s, Go heap 128 → 90 MiB. `batch=10000` buys a further 7% on query for +91 MiB, a bad trade when a refresh briefly holds two complete indexes.

## Review notes

- **The on-disk path regresses about 19% on query** (3.69 → 4.41 ms), because it was already benefiting from merged, compacted segments and the constant is shared. Accepted deliberately rather than introducing kind-specific sizing; in-memory has been the default since #91. That figure is also the least reproducible in the matrix — on-disk segment counts were still settling between runs.
- **Ranking neutrality is shown, not asserted.** The golden report is byte-identical across the change, all 116 rank lines with scores — but that is weak evidence here, since the 41-chunk golden corpus forms a single batch at any size ≥ 100. The real evidence is a new test that indexes 300 varied synthetic chunks at both batch sizes, asserts the two sides genuinely segment differently (3 against 1), and compares results including `Score`.
- **Every figure is `search.Service`-layer**, below the MCP handler's widening candidate windows. That is why the documentation states no "switch to disk above N chunks" threshold — naming one would need a handler-layer measurement this work did not perform.
- **Corpus provenance:** `~/.claude/plugins`, 952 Markdown files, 10,339 chunks, duplicated ×2 for the larger scale. Duplication doubles posting-list length but leaves the term dictionary at the original size, so 20,678 is not identical to a naturally occurring corpus of that size. Noted in the docs too.

## Also included

`make bench` and `internal/search/bench_test.go` — a committed measurement instrument, so the next change to this constant does not rebuild the rig from scratch. It asserts nothing about timings and never runs under `make test` or CI, since benchmarks need `-bench`. Pass `BENCHFLAGS="-corpus=... -corpus-dup=..."` to point it at a real corpus; the bundled corpus is too small for batch size to matter.

Two known limits are documented in the code rather than fixed: the reported `heapMiB` is a delta against a baseline taken once the corpus buffer exists, so it understates index heap and can read negative; and the on-disk resting segment count at `batch=100` is genuinely timing-dependent. No claim in the documentation rests on either.

## Note for whoever next moves `defaultBatchSize`

Three separate places had silently coupled themselves to the literal `100`, and one of them — the benchmark's own low bucket — was derived from `defaultBatchSize`, so raising the constant deleted the segment-heavy comparison point from the matrix with the suite still green. All three are fixed, but the documentation still names `100` and `1000` in prose with nothing pinning them to the constant.
