### PR TITLE
chore(search): tidy the batch-size documentation and test helpers

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -122,21 +122,29 @@ directory at startup and on every refresh, and it is never reopened, so
 persisting it to disk buys nothing back.
 
 Pass `--search-in-memory=false`, or set `ACDC_MCP_SEARCH_IN_MEMORY=false`, to
-build it on disk instead, under a temporary directory. An in-memory index
-accumulates one segment per indexing batch and never compacts them; raising
-the default batch size from 100 to 1000 cut segment count roughly 10× (207
-segments to 21) and roughly halved in-memory query latency (9.21 ms to
-4.87 ms). At 20,678 chunks — a 10,339-chunk corpus duplicated, which doubles
-posting-list length but leaves the term dictionary at its original size —
-in-memory builds about 1.3× faster than on disk (1.90 s against 2.42 s) and
-answers queries only about 10% slower (4.87 ms against 4.41 ms). On-disk's
-remaining edge is its merger, which leaves it with fewer segments still (10
-against 21); at equal segment counts the two kinds measure
-indistinguishably. These figures time the search engine answering one
-query, below the MCP tool clients call. That tool retries — up to twice,
-with a wider candidate window — only if the result page is still short and
-the candidate set was truncated; treat these figures as a floor, not an
-end-to-end number.
+build it on disk instead, under a temporary directory.
+
+The figures below were measured at 20,678 chunks — a 10,339-chunk corpus
+duplicated, which doubles posting-list length but leaves the term dictionary at
+its original size.
+
+A segment is an independent sub-index that every query must search in turn, so
+query latency grows with how many an index holds. An in-memory index
+accumulates one per indexing batch and never merges them, which is why the
+batch size is tuned to keep that count small: it settles at 21 segments and a
+4.87 ms query, against 207 segments and 9.21 ms had batches been ten times
+smaller.
+
+At that size in-memory builds about 1.3× faster than on disk (1.90 s against
+2.42 s) and answers queries only about 10% slower (4.87 ms against 4.41 ms).
+On-disk's remaining edge is its merger, which leaves it with fewer segments
+still (10 against 21); at equal segment counts the two kinds measure
+indistinguishably.
+
+These figures time the search engine answering one query, below the MCP tool
+clients call. That tool retries — up to twice, with a wider candidate window —
+only if the result page is still short and the candidate set was truncated;
+treat these figures as a floor, not an end-to-end number.
 
 `--search-in-memory=false` also pays off when Go heap matters more than
 query speed: the on-disk index holds its data in memory-mapped segments the

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -152,6 +152,10 @@ func (s *Service) newIndex() (searchIndex, string, error) {
 // one, so the batch size only needs to keep the segment count small, not
 // minimize it. Raising it further buys little further query latency for a
 // steep rise in build-time heap, since a batch is held in memory whole.
+//
+// Changing this invalidates the segment counts and latencies quoted in
+// docs/configuration.md under "Where the index lives"; re-measure with
+// `make bench` against a real corpus and update them together.
 const defaultBatchSize = 1000
 
 func batchIndex(ctx context.Context, index BatchIndexer, chunks <-chan domain.Chunk, batchSize int) error {

--- a/internal/search/service_test.go
+++ b/internal/search/service_test.go
@@ -550,9 +550,10 @@ func rankedScores(results []SearchResult) []rankedScore {
 	return out
 }
 
-// searchThrough runs the production query shape against a caller-supplied
-// index, bypassing Service.newIndex so a test can choose the index kind.
-func searchThrough(t *testing.T, idx searchIndex, chunks []domain.Chunk, query string) []rankedScore {
+// indexInto indexes chunks into idx at the given batch size and attaches the
+// result to a Service, bypassing Service.newIndex so a test can choose the
+// index kind and the batch size independently.
+func indexInto(t *testing.T, idx searchIndex, chunks []domain.Chunk, batchSize int) *Service {
 	t.Helper()
 
 	stream := make(chan domain.Chunk, len(chunks))
@@ -560,11 +561,20 @@ func searchThrough(t *testing.T, idx searchIndex, chunks []domain.Chunk, query s
 		stream <- chunk
 	}
 	close(stream)
-	require.NoError(t, batchIndex(context.Background(), idx, stream, defaultBatchSize))
+	require.NoError(t, batchIndex(context.Background(), idx, stream, batchSize))
 
 	service := NewService(testSettings())
 	service.index = idx
 	t.Cleanup(service.Close)
+	return service
+}
+
+// searchThrough runs the production query shape against a caller-supplied
+// index, bypassing Service.newIndex so a test can choose the index kind.
+func searchThrough(t *testing.T, idx searchIndex, chunks []domain.Chunk, query string) []rankedScore {
+	t.Helper()
+
+	service := indexInto(t, idx, chunks, defaultBatchSize)
 
 	results, err := service.Search(query, 10)
 	require.NoError(t, err)
@@ -648,26 +658,13 @@ func syntheticCorpusChunks(n int) []domain.Chunk {
 }
 
 // batchIndexedService indexes chunks into a fresh in-memory index at the
-// given batch size and attaches it to a Service the way searchThrough does,
-// but keeping the batch size a parameter rather than fixing it at
-// defaultBatchSize.
+// given batch size.
 func batchIndexedService(t *testing.T, chunks []domain.Chunk, batchSize int) *Service {
 	t.Helper()
 
 	idx, err := newMemoryIndex(buildMapping())
 	require.NoError(t, err)
-
-	stream := make(chan domain.Chunk, len(chunks))
-	for _, chunk := range chunks {
-		stream <- chunk
-	}
-	close(stream)
-	require.NoError(t, batchIndex(context.Background(), idx, stream, batchSize))
-
-	service := NewService(testSettings())
-	service.index = idx
-	t.Cleanup(service.Close)
-	return service
+	return indexInto(t, idx, chunks, batchSize)
 }
 
 // serviceRootSegments counts the segments a query against service fans out
@@ -685,10 +682,10 @@ func serviceRootSegments(t *testing.T, service *Service) int {
 // TestSearch_RankingIsIndependentOfBatchSize pins the invariant defaultBatchSize
 // depends on: the batch size only bounds how many segments the in-memory index
 // ends up with, and must never influence which documents match or how they
-// score. The golden harness's corpus is 41 chunks, which forms a single batch
-// at any batch size of 100 or larger, so a golden-report diff across the
-// batch-size change is empty for a trivial reason — it never exercises more
-// than one segment. This test builds a synthetic corpus of 300 chunks with
+// score. The golden harness's corpus is far smaller than defaultBatchSize and
+// so forms a single batch, which makes a golden-report diff across a
+// batch-size change empty for a trivial reason — it never exercises more than
+// one segment. This test builds a synthetic corpus of 300 chunks with
 // varied content instead, so that the two sides genuinely differ in segment
 // count, and checks that they agree anyway.
 //


### PR DESCRIPTION
## Summary

Residual cleanup left over from #97. No behaviour change — one code comment, one docs section, and a test-helper extraction.

## Changes

- **`docs/configuration.md`, "Where the index lives"** — the section used *segment* without ever defining it, and described the batch-size change as a before/after pair of literals (`100` → `1000`) that nothing pinned to `defaultBatchSize`. It now defines the term, states current behaviour instead of the delta, and introduces the measured corpus once rather than naming "20,678 chunks" in two consecutive sentences. Every measured figure is unchanged.
- **`internal/search/service.go`** — `defaultBatchSize` now says that moving it invalidates the figures in that docs section. Prose cannot be pinned to a constant by a linter, so this is the only coupling available; #97 hit the same literal-`100` drift in four separate places.
- **`internal/search/service_test.go`** — extracts `indexInto` from `searchThrough` and `batchIndexedService`, which had converged on the same body, and drops a hardcoded "41 chunks" from a comment that would drift as testdata grows.

## Verification

No production behaviour changes, so there is no failing test to write first. `make format && make lint && make test` all green; the helper extraction is mechanical and covered by the tests that already call both helpers.