### PR TITLE
test(testkit): report the real startup error on the stdio path

### DIFF
--- a/tests/integration/testkit/acdc_service.go
+++ b/tests/integration/testkit/acdc_service.go
@@ -77,7 +77,9 @@ func (s *acdcService) Start() (map[string]any, error) {
 	}
 
 	go func() {
-		s.errChan <- s.runner(ctx, params, s.flags, "testkit")
+		err := s.runner(ctx, params, s.flags, "testkit")
+		s.closeStdioPipes(err)
+		s.errChan <- err
 	}()
 
 	if transport == "stdio" {
@@ -118,6 +120,19 @@ func (s *acdcService) Start() (map[string]any, error) {
 	}
 
 	return nil, fmt.Errorf("server failed to start after %v", s.StartTimeout)
+}
+
+// closeStdioPipes hands the reason the server stopped to whoever is on the other end of
+// the pipes. A server that failed before reaching its transport never reads stdin nor
+// writes stdout, and io.Pipe has no buffer, so a client would otherwise block on its
+// first write instead of learning why startup failed.
+func (s *acdcService) closeStdioPipes(cause error) {
+	if s.stdinReader != nil {
+		_ = s.stdinReader.CloseWithError(cause)
+	}
+	if s.stdoutWriter != nil {
+		_ = s.stdoutWriter.CloseWithError(cause)
+	}
 }
 
 func (s *acdcService) Stop() error {

--- a/tests/integration/testkit/client_test.go
+++ b/tests/integration/testkit/client_test.go
@@ -2,6 +2,9 @@ package testkit
 
 import (
 	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -131,15 +134,46 @@ type clientMockTB struct {
 
 func (m *clientMockTB) Fatalf(format string, args ...any) {
 	m.failed = true
-	m.fatalMsg = format
+	m.fatalMsg = fmt.Sprintf(format, args...)
 	// Panic to stop execution like real Fatalf does
-	panic(fatalPanic{msg: format})
+	panic(fatalPanic{msg: m.fatalMsg})
 }
 
 func (m *clientMockTB) Helper() {}
 
 func (m *clientMockTB) TempDir() string {
 	return m.tempDir
+}
+
+func TestNewStdioTestClient_StartError(t *testing.T) {
+	mockT := &clientMockTB{TB: t, tempDir: t.TempDir()}
+	missingContentDir := filepath.Join(t.TempDir(), "missing")
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer func() {
+			if r := recover(); r != nil {
+				if _, ok := r.(fatalPanic); !ok {
+					panic(r)
+				}
+			}
+		}()
+		NewStdioTestClientForDir(mockT, missingContentDir)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Expected the startup failure to be reported without waiting for the connect deadline")
+	}
+
+	if !mockT.failed {
+		t.Fatal("Expected NewStdioTestClientForDir to fail for a missing content directory")
+	}
+	if !strings.Contains(mockT.fatalMsg, "not found or not a directory") {
+		t.Errorf("Expected the reported failure to name the startup error, got %q", mockT.fatalMsg)
+	}
 }
 
 func TestNewSSETestClient_StartError(t *testing.T) {

--- a/tests/integration/testkit/testkit_test.go
+++ b/tests/integration/testkit/testkit_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -188,6 +189,56 @@ func TestACDCService_StartExit(t *testing.T) {
 	_, err := service.Start()
 	if err == nil || err.Error() != "server exited unexpectedly: exit early" {
 		t.Errorf("Expected exit early error, got %v", err)
+	}
+}
+
+func TestACDCService_StdioStartFailureClosesThePipesWithTheStartupError(t *testing.T) {
+	flags := NewTestFlags(t, t.TempDir(), &FlagOptions{Transport: "stdio"})
+
+	service := NewACDCService("stdio-start-failure", flags)
+	acdc := service.(*acdcService)
+	startErr := errors.New("startup failed")
+	acdc.runner = func(ctx context.Context, params app.RunParams, flags *pflag.FlagSet, version string) error {
+		return startErr
+	}
+
+	props, err := service.Start()
+	if err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	defer func() { _ = service.Stop() }()
+
+	stdin := props["acdc.stdin"].(io.WriteCloser)
+	stdout := props["acdc.stdout"].(io.ReadCloser)
+
+	// A client writes its request before reading the response, so both directions
+	// must fail rather than block on a server that is no longer running.
+	writeErr := make(chan error, 1)
+	go func() {
+		_, err := stdin.Write([]byte("{}\n"))
+		writeErr <- err
+	}()
+	readErr := make(chan error, 1)
+	go func() {
+		_, err := stdout.Read(make([]byte, 1))
+		readErr <- err
+	}()
+
+	for _, c := range []struct {
+		direction string
+		errs      chan error
+	}{
+		{"stdin write", writeErr},
+		{"stdout read", readErr},
+	} {
+		select {
+		case err := <-c.errs:
+			if !errors.Is(err, startErr) {
+				t.Errorf("%s: expected the startup error, got %v", c.direction, err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Errorf("%s: still blocked after the server failed to start", c.direction)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #80.

## What the issue got right, and what measurement changed

The gap is real: `testkit`'s stdio `Start()` returns without any readiness check, so a server that fails before reaching its transport leaves the client with nothing to diagnose.

Two corrections from measuring it:

- **It is not a ~10s connect deadline — it hangs.** The client's *first write* of the `initialize` request blocks: `io.Pipe` is unbuffered and the failed server never reads `stdin`. The context deadline cannot unblock a synchronous pipe write, so the test holds until the `go test` timeout. Stack dump confirmed at `io.(*pipe).write` under `mcp.(*ioConn).Write`.
- **Draining `errChan` on connect failure, as filed, would race the deadline rather than replace it.** Closing the pipes with the runner's error is smaller and removes the wait entirely.

## The change

When the runner returns, `closeStdioPipes` closes both pipes with that error. `io.Pipe` hands a `CloseWithError` cause to the other side, so the client's blocked write fails immediately with the real reason.

Before (missing content directory): blocks until the test times out.
After:

```
Failed to connect client: connection closed: calling "initialize": client is closing:
failed to resolve content directory /.../missing: not found or not a directory
```

Both closes are load-bearing, verified by sabotaging each separately: without the `stdout` close the client reports a bare `EOF`; without the `stdin` close a client that is not concurrently reading still blocks.

No parity-by-polling: stdio has no readiness signal, so any poll would be a sleep racing the runner. Closing the pipes reports the failure whenever it happens, without a timing assumption.

## Verification

- Both tests watched RED first — service-level assertions timed out on a blocked pipe in each direction; the client-level test did not report at all within 5s.
- `make format && make lint && make test` green; `go test -race -count=1 ./tests/integration/...` green.
- `docker run --rm --user 1000:1000 ... golang:1.26-alpine go test ./tests/integration/...` green.

Test-infrastructure only — no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011eAy9Y7jcAjM1Aexd22xdR