### PR TITLE
test(config): restore environment variables the settings tests clear

### DIFF
--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -12,11 +12,12 @@ import (
 
 func TestLoadSettings_Defaults(t *testing.T) {
 	// Clear env vars to ensure defaults are used
-	// Note: Can't use t.Setenv to clear, so we still need os.Unsetenv here
-	_ = os.Unsetenv("ACDC_MCP_PORT")
-	_ = os.Unsetenv("ACDC_MCP_AUTH_TYPE")
-	_ = os.Unsetenv("ACDC_MCP_URI_SCHEME")
-	_ = os.Unsetenv("ACDC_MCP_SEARCH_IN_MEMORY")
+	unsetEnvForTest(t,
+		"ACDC_MCP_PORT",
+		"ACDC_MCP_AUTH_TYPE",
+		"ACDC_MCP_URI_SCHEME",
+		"ACDC_MCP_SEARCH_IN_MEMORY",
+	)
 
 	settings, err := LoadSettings()
 	if err != nil {
@@ -123,6 +124,10 @@ func TestLoadSettings_APIKeys_EnvVar_ViperSingleElement(t *testing.T) {
 }
 
 func TestLoadSettings_EnvFile(t *testing.T) {
+	// Environment variables outrank a config file in viper, so the keys under
+	// assertion have to be absent for the file to be observable at all.
+	unsetEnvForTest(t, "ACDC_MCP_HOST", "ACDC_MCP_PORT")
+
 	// Create temporary .env file
 	// Note: Viper config files use keys matching the mapstructure tags (or lowercase),
 	// NOT the environment variable keys with prefixes.
@@ -200,7 +205,7 @@ func TestLoadSettingsWithFlags_EnvOverridesDefault(t *testing.T) {
 
 // TestLoadSettingsWithFlags_NilFlags is same as LoadSettings behavior
 func TestLoadSettingsWithFlags_NilFlags(t *testing.T) {
-	_ = os.Unsetenv("ACDC_MCP_PORT")
+	unsetEnvForTest(t, "ACDC_MCP_PORT")
 
 	settings, err := LoadSettingsWithFlags(nil)
 	if err != nil {
@@ -217,14 +222,7 @@ func TestLoadSettingsWithFlags_NilFlags(t *testing.T) {
 // default: with no flag and no env var, content_dir is the process working
 // directory itself, not a "content" subdirectory beneath it.
 func TestLoadSettings_ContentDirDefaultsToWorkingDirectory(t *testing.T) {
-	// Note: Can't use t.Setenv to clear, so restore manually.
-	prevContentDir, hadContentDir := os.LookupEnv("ACDC_MCP_CONTENT_DIR")
-	_ = os.Unsetenv("ACDC_MCP_CONTENT_DIR")
-	t.Cleanup(func() {
-		if hadContentDir {
-			_ = os.Setenv("ACDC_MCP_CONTENT_DIR", prevContentDir)
-		}
-	})
+	unsetEnvForTest(t, "ACDC_MCP_CONTENT_DIR")
 
 	wd, err := os.Getwd()
 	require.NoError(t, err)
@@ -1014,6 +1012,66 @@ func TestLoadSettings_InMemoryEnvVarOverridesDefault(t *testing.T) {
 			settings, err := LoadSettings()
 			require.NoError(t, err)
 			require.Equal(t, tt.expected, settings.Search.InMemory)
+		})
+	}
+}
+
+// unsetEnvForTest clears the named environment variables for the duration of the
+// test and restores each one that was set beforehand. testing.T offers Setenv but
+// no counterpart that clears, so the capture and restore have to be explicit.
+func unsetEnvForTest(t testing.TB, keys ...string) {
+	t.Helper()
+
+	for _, key := range keys {
+		prev, had := os.LookupEnv(key)
+		_ = os.Unsetenv(key)
+		if had {
+			t.Cleanup(func() { _ = os.Setenv(key, prev) })
+		}
+	}
+}
+
+// TestUnsetEnvForTest_RestoresOnlyPreviouslySetVariables pins both halves of the
+// contract: a variable that was set comes back with its original value, and one
+// that was absent stays absent rather than reappearing as an empty string, which
+// LoadSettings cannot distinguish from unset for every key.
+func TestUnsetEnvForTest_RestoresOnlyPreviouslySetVariables(t *testing.T) {
+	const key = "ACDC_MCP_TEST_UNSET_HELPER"
+	const value = "original"
+
+	tests := []struct {
+		name       string
+		setUpfront bool
+	}{
+		{name: "restores a variable that was set", setUpfront: true},
+		{name: "leaves a variable that was unset alone", setUpfront: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// t.Setenv establishes a known baseline and undoes itself, so the
+			// arrangement never depends on the helper under test.
+			t.Setenv(key, value)
+			if !tt.setUpfront {
+				require.NoError(t, os.Unsetenv(key))
+			}
+
+			cleared := false
+			t.Run("under the helper", func(t *testing.T) {
+				unsetEnvForTest(t, key)
+
+				_, present := os.LookupEnv(key)
+				require.False(t, present, "helper must clear the variable")
+				cleared = true
+			})
+			require.True(t, cleared, "the subtest asserting the cleared state must have run")
+
+			// Subtest cleanups have run by the time t.Run returns.
+			restored, present := os.LookupEnv(key)
+			require.Equal(t, tt.setUpfront, present)
+			if tt.setUpfront {
+				require.Equal(t, value, restored)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Closes #81.

## Problem

`TestLoadSettings_Defaults` and `TestLoadSettingsWithFlags_NilFlags` unset `ACDC_MCP_*` variables without restoring them, mutating the process environment for every later test in `internal/config`. The issue names three variables; measured on `560d046` there are **five** across two sites — `ACDC_MCP_SEARCH_IN_MEMORY` was added by #91, after #81 was filed.

There is still no `t.Unsetenv` in go1.26.5 (`testing.T` exposes `Setenv` and `Chdir` only), so the `LookupEnv`-capture / `t.Cleanup`-restore shape #78 used for `ACDC_MCP_CONTENT_DIR` remains the only option.

## Change

Five keys across two sites is enough duplication to justify a helper, so the capture/restore is factored into `unsetEnvForTest(t, keys...)`, local to the test file, and the three `os.Unsetenv` sites (including #78's hand-rolled block) now call it.

The helper restores **only variables that were set beforehand**. Restoring an absent variable as `""` is a different bug — `LoadSettings` cannot distinguish `""` from absent for every key — so both arms are tabled.

## The leak was load-bearing, and that is the finding

The issue calls the leak "latent — not currently causing failures". True as filed, but only because a later test was *relying* on it: `TestLoadSettings_EnvFile` asserts a `.env` file supplies `host` and `port`, and an ambient `ACDC_MCP_PORT` legitimately outranks a config file in viper. It passed only because `TestLoadSettings_Defaults` happened to clear that variable first. Measured: with `ACDC_MCP_PORT=9999` in the environment, the fix alone turns the package red on `Expected port 7000, got 9999`.

That test now declares its own precondition rather than inheriting one from file ordering.

## Verification

TDD, with the helper tested directly — a leak between two tests is not directly observable, and asserting on Go's deterministic within-package ordering would make the test a trap for whoever reorders the file. Instead the helper runs inside a `t.Run` subtest and the assertion happens after `t.Run` returns, since subtest cleanups run first. Both arms were confirmed RED independently:

| implementation | failing arm |
|---|---|
| unset, no restore | `restores a variable that was set` |
| unconditional `os.Setenv(key, prev)` | `leaves a variable that was unset alone` |
| `if had` guard | green |

- `make format && make lint && make test` — clean, 0 lint issues, all packages pass.
- `go test -shuffle=on ./internal/config/` ×5, clean environment — pass. Order-independence is what the fix buys.
- Same ×5 with `ACDC_MCP_PORT`, `ACDC_MCP_AUTH_TYPE`, `ACDC_MCP_URI_SCHEME`, `ACDC_MCP_SEARCH_IN_MEMORY`, `ACDC_MCP_CONTENT_DIR` and `ACDC_MCP_HOST` all preset — pass.

Nothing in `internal/config` is parallel, and `t.Setenv` panics under `t.Parallel`, so none was added.

No production code changes; `_test.go` files never enter the coverage denominator. The cross-platform container check is not indicated — this touches no path or process behavior — and was skipped deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011eAy9Y7jcAjM1Aexd22xdR