### PR TITLE
build(release): replace deprecated brews with homebrew_casks

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -66,18 +66,25 @@ changelog:
       - '^docs:'
       - '^test:'
 
-brews:
+homebrew_casks:
   - name: acdc-mcp
+    ids:
+      - nix
+    binaries:
+      - acdc-mcp
     repository:
       owner: sha1n
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
 
-    # Homepage placeholder
     homepage: "https://github.com/sha1n/mcp-acdc-server"
-
-    # Description placeholder
     description: "MCP ACDC Server"
 
-    # Directory in the repository to put the formula.
-    directory: Formula
+    # Released binaries are neither signed nor notarized, so Gatekeeper would
+    # otherwise refuse to run them.
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/acdc-mcp"]
+          end

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ cd examples/docker-local-content
 docker-compose up -d
 ```
 
-**Homebrew:**
+**Homebrew (macOS):**
 ```bash
 brew install sha1n/tap/acdc-mcp
 acdc-mcp
@@ -59,10 +59,11 @@ acdc-mcp --content-dir ./content
 docker pull sha1n/mcp-acdc-server:latest
 ```
 
-### Homebrew
+### Homebrew (macOS)
 ```bash
 brew install sha1n/tap/acdc-mcp
 ```
+Linux and Windows users can download a release archive or use the Docker image.
 
 ### Build from Source
 See [Development Guide](docs/development.md) for build instructions.


### PR DESCRIPTION
## Summary

`goreleaser check` failed with `DEPRECATED: brews should not be used anymore`. GoReleaser deprecated the `brews` section in favour of `homebrew_casks`, which is now the supported way to publish pre-built binaries to a tap. This migrates the config and re-points the tap output from `Formula/` to the cask default (`Casks/`).

## Changes

- `brews` → `homebrew_casks`, scoped to the `nix` archive with `binaries: [acdc-mcp]`. Dropped `directory: Formula` — casks require the default `Casks/`.
- Added a `postflight` hook that strips `com.apple.quarantine`. Our release binaries are neither signed nor notarized, so without it Gatekeeper refuses to run the installed binary.
- **Behaviour change:** Homebrew only installs casks on macOS. `brew install sha1n/tap/acdc-mcp` no longer works on Linux, even though the generated cask carries `on_linux` URLs. README updated to say so; Linux users take the release archive or the Docker image.

## Companion PR

sha1n/homebrew-tap#4 is the tap-side half: it seeds `Casks/acdc-mcp.rb`, adds `tap_migrations.json`, and deletes `Formula/acdc-mcp.rb` (which would otherwise keep shadowing the cask). Because that PR seeds the cask by hand, the two can land in either order — but this one must not ship without it, or the next release recreates the formula alongside the cask.

## Verification

- `goreleaser check` — clean, no deprecation warnings.
- `goreleaser release --snapshot --clean --skip=publish,docker,validate` — generated `dist/homebrew/Casks/acdc-mcp.rb` with correct darwin/linux URLs, `binary "acdc-mcp"`, and the postflight hook.
