### PR TITLE
docs(docker): publish a Docker Hub overview from the repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
     outputs:
       src: ${{ steps.filter.outputs.src }}
       docker: ${{ steps.filter.outputs.docker }}
+      dockerhub_description: ${{ steps.filter.outputs.dockerhub_description }}
     steps:
       - uses: actions/checkout@v7
       - uses: dorny/paths-filter@v4
@@ -35,6 +36,11 @@ jobs:
             docker:
               - '**'
               - '!({README.md,GEMINI.md,LICENSE,.gitignore,.goreleaser.yaml,.github/**,docs/**,examples/**,tests/**,bin/**,build/**,dist/**,*.out})'
+            # The 'docker' job builds and pushes the image but never publishes the
+            # repository overview, so the description needs its own trigger.
+            dockerhub_description:
+              - 'docs/dockerhub-overview.md'
+              - '.github/workflows/ci.yml'
 
   test:
     needs: changes
@@ -100,6 +106,37 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # Publishes docs/dockerhub-overview.md as the Docker Hub repository overview.
+  # Deliberately not a dependency of status-check: it only runs on the default
+  # branch, so a Docker Hub API failure should not retroactively fail CI.
+  # The overview duplicates the configuration tables in docs/configuration.md and
+  # the two must stay in sync.
+  # Docker Hub's Markdown renderer supports neither GitHub alert syntax ([!NOTE],
+  # [!IMPORTANT], ...) nor raw HTML, so the overview must stick to plain Markdown
+  # and plain blockquotes.
+  dockerhub-description:
+    needs: changes
+    if: |
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/master' &&
+      needs.changes.outputs.dockerhub_description == 'true'
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+      - name: Update Docker Hub repository overview
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          # Requires a Docker Hub PAT with read/write/delete scope; the
+          # read/write scope that suffices for image pushes is rejected here.
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ secrets.DOCKERHUB_USERNAME }}/mcp-acdc-server
+          readme-filepath: ./docs/dockerhub-overview.md
+          short-description: "Agent Content Discovery Companion (ACDC) — MCP server for searchable AI-agent access to Markdown"
 
   # This job acts as a bridge for documentation-only PRs to satisfy status checks
   status-check:

--- a/README.md
+++ b/README.md
@@ -85,8 +85,10 @@ acdc-mcp --transport sse --content-dir ./content
 ```
 
 ### Docker
+The image defaults to the `stdio` transport, so serving over HTTP requires setting `ACDC_MCP_TRANSPORT=sse` — publishing the port alone is not enough:
 ```bash
 docker run -p 8080:8080 \
+  -e ACDC_MCP_TRANSPORT=sse \
   -v $(pwd)/content:/app/content \
   sha1n/mcp-acdc-server:latest
 ```
@@ -190,4 +192,4 @@ See [Development Guide](docs/development.md) for building, testing, and contribu
 
 ## 📄 License
 
-MIT License - see [LICENSE](LICENSE) for details.
+Apache License 2.0 - see [LICENSE](LICENSE) for details.

--- a/docs/dockerhub-overview.md
+++ b/docs/dockerhub-overview.md
@@ -1,0 +1,220 @@
+# mcp-acdc-server
+
+**Agent Content Discovery Companion (ACDC) MCP Server**
+
+A Model Context Protocol (MCP) server that gives AI agents searchable access to your Markdown content. Full-text search powered by [Bleve](https://github.com/blevesearch/bleve), dual transport (stdio/SSE), and optional authentication.
+
+📦 **Source & full docs:** [github.com/sha1n/mcp-acdc-server](https://github.com/sha1n/mcp-acdc-server)
+
+---
+
+## Quick Start
+
+> **Important:** The image defaults to the **`stdio`** transport. To run it as an HTTP service you must set `ACDC_MCP_TRANSPORT=sse` — publishing port 8080 alone is not enough.
+
+**SSE (HTTP service):**
+
+```bash
+docker run -d --name acdc \
+  -p 8080:8080 \
+  -e ACDC_MCP_TRANSPORT=sse \
+  -v "$(pwd)/content:/app/content:ro" \
+  sha1n/mcp-acdc-server:latest
+
+curl http://localhost:8080/health   # -> 200 OK
+```
+
+**stdio (agent launches the process):**
+
+```bash
+docker run -i --rm \
+  -v "$(pwd)/content:/app/content:ro" \
+  sha1n/mcp-acdc-server:latest
+```
+
+### Zero-config content
+
+No manifest required. Mount any repository and the server indexes `README.md` and `docs/**/*.md` using built-in server identity and instructions:
+
+```bash
+docker run -d -p 8080:8080 -e ACDC_MCP_TRANSPORT=sse \
+  -v "$(pwd):/app/content:ro" sha1n/mcp-acdc-server:latest
+```
+
+Add an `mcp-metadata.yaml` to the content root to override the defaults — customize server identity and instructions, and add an `index` block to select Markdown by glob pattern. See the [Authoring Resources Guide](https://github.com/sha1n/mcp-acdc-server/blob/master/docs/authoring-resources.md).
+
+---
+
+## Image Details
+
+| | |
+|---|---|
+| **Platforms** | `linux/amd64`, `linux/arm64` |
+| **Base** | `alpine` |
+| **Exposed port** | `8080` |
+| **Working directory** | `/app` |
+| **Content mount point** | `/app/content` |
+
+Built-in environment defaults: `ACDC_MCP_CONTENT_DIR=/app/content`, `ACDC_MCP_HOST=0.0.0.0`, `ACDC_MCP_PORT=8080`.
+
+### Tags
+
+| Tag | Meaning |
+|---|---|
+| `latest` | Latest build of the default branch |
+| `0.7.0`, `0.7` | Semver release tags — pin these for reproducible deployments |
+| `master` | Default-branch builds |
+| `sha-<short>` | Immutable per-commit builds |
+
+---
+
+## Configuration
+
+Every setting is available as a CLI flag or an `ACDC_MCP_*` environment variable. Environment variables are the natural fit for containers.
+
+### Server
+
+| Environment Variable | Description | Default |
+|---|---|---|
+| `ACDC_MCP_CONTENT_DIR` | Path to the content directory | `/app/content` (in image) |
+| `ACDC_MCP_TRANSPORT` | `stdio` or `sse` | `stdio` |
+| `ACDC_MCP_HOST` | Bind host (SSE only) | `0.0.0.0` |
+| `ACDC_MCP_PORT` | Bind port (SSE only) | `8080` |
+| `ACDC_MCP_URI_SCHEME` | Resource URI scheme, e.g. `acdc://guides/setup` | `acdc` |
+| `ACDC_MCP_CROSS_REF` | Rewrite relative Markdown links into resource URIs | `false` |
+
+### Search
+
+| Environment Variable | Description | Default |
+|---|---|---|
+| `ACDC_MCP_SEARCH_MAX_RESULTS` | Maximum results returned | `10` |
+| `ACDC_MCP_SEARCH_RESULT_MODE` | `references` (citations) or `content` (citations plus chunk body) | `references` |
+| `ACDC_MCP_SEARCH_IN_MEMORY` | Hold the index in memory instead of on disk | `true` |
+| `ACDC_MCP_SEARCH_KEYWORDS_BOOST` | Weight for frontmatter keyword matches | `3.0` |
+| `ACDC_MCP_SEARCH_HEADING_BOOST` | Weight for heading-path matches | `2.5` |
+| `ACDC_MCP_SEARCH_TITLE_BOOST` | Weight for document-title matches | `2.0` |
+| `ACDC_MCP_SEARCH_PATH_BOOST` | Weight for path-label matches | `1.25` |
+| `ACDC_MCP_SEARCH_CONTENT_BOOST` | Weight for body-content matches | `1.0` |
+
+### Authentication (SSE only)
+
+| Environment Variable | Description | Default |
+|---|---|---|
+| `ACDC_MCP_AUTH_TYPE` | `none`, `basic`, or `apikey` | `none` |
+| `ACDC_MCP_AUTH_BASIC_USERNAME` | Basic auth username | — |
+| `ACDC_MCP_AUTH_BASIC_PASSWORD` | Basic auth password | — |
+| `ACDC_MCP_AUTH_API_KEYS` | Comma-separated API keys, sent as `X-API-Key` | — |
+
+```bash
+docker run -d -p 8080:8080 \
+  -e ACDC_MCP_TRANSPORT=sse \
+  -e ACDC_MCP_AUTH_TYPE=apikey \
+  -e ACDC_MCP_AUTH_API_KEYS=key1,key2 \
+  -v "$(pwd)/content:/app/content:ro" \
+  sha1n/mcp-acdc-server:latest
+```
+
+Startup fails fast on contradictory auth configuration — for example `basic` without credentials, or `basic` combined with API keys.
+
+Full reference: [Configuration Guide](https://github.com/sha1n/mcp-acdc-server/blob/master/docs/configuration.md).
+
+---
+
+## Health Check
+
+In SSE mode the server exposes an **unauthenticated** `/health` endpoint returning `200 OK`, suitable for Kubernetes probes and Compose health checks:
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 8080
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 8080
+```
+
+---
+
+## Docker Compose
+
+```yaml
+services:
+  mcp-acdc-server:
+    image: sha1n/mcp-acdc-server:latest
+    ports:
+      - "127.0.0.1:8080:8080"
+    environment:
+      - ACDC_MCP_CONTENT_DIR=/app/content
+      - ACDC_MCP_TRANSPORT=sse
+      - ACDC_MCP_HOST=0.0.0.0
+      - ACDC_MCP_PORT=8080
+    volumes:
+      - ./content:/app/content:ro
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 3s
+      start_period: 5s
+      retries: 3
+```
+
+Ready-made deployment and content-configuration examples live in [`examples/`](https://github.com/sha1n/mcp-acdc-server/tree/master/examples):
+
+- **[Local Content](https://github.com/sha1n/mcp-acdc-server/tree/master/examples/docker-local-content)** — direct bind mount, for rapid iteration.
+- **[Image Content](https://github.com/sha1n/mcp-acdc-server/tree/master/examples/docker-image-content)** — production-like init-container pattern that ships content as its own image.
+- **[Repository Docs](https://github.com/sha1n/mcp-acdc-server/tree/master/examples/repository-docs)** — chunk indexing over an existing repository's `docs/` directory.
+
+---
+
+## Connecting an Agent
+
+**Claude Code:**
+
+SSE:
+
+```bash
+claude mcp add --scope user --transport sse acdc http://<host>:8080/sse
+```
+
+stdio (the agent launches the container):
+
+```bash
+claude mcp add --scope user --transport stdio acdc -- docker run -i --rm -v "$(pwd)/content:/app/content:ro" sha1n/mcp-acdc-server:latest
+```
+
+**Gemini CLI:**
+
+SSE:
+
+```bash
+gemini mcp add --scope user --transport sse --trust acdc http://<host>:8080/sse
+```
+
+stdio (the agent launches the container):
+
+```bash
+gemini mcp add --scope user --transport stdio --trust acdc docker -- run -i --rm -v "$(pwd)/content:/app/content:ro" sha1n/mcp-acdc-server:latest
+```
+
+For authenticated servers, supply the `Authorization` or `X-API-Key` header through your client's configuration.
+
+---
+
+## Features
+
+- **Full-text search** — stemming, bounded fuzzy matching, and per-field boosting
+- **Dynamic resource discovery** — content directories scanned automatically
+- **Dynamic prompt discovery** — prompt templates scanned automatically
+- **Content refresh** — `search`, `read`, and resource reads re-check the content root (debounced to once every 2s) and rebuild in place, so mid-session edits appear without a restart
+- **MCP compliant** — works with any MCP-capable agent
+- **Dual transport** — `stdio` for local agents, `sse` for remote/containerized deployments
+- **Optional authentication** — basic auth or API keys
+
+---
+
+## License
+
+Apache-2.0 — see [LICENSE](https://github.com/sha1n/mcp-acdc-server/blob/master/LICENSE).

--- a/examples/docker-image-content/docker-compose.yml
+++ b/examples/docker-image-content/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - content-data:/app/content:ro
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:${ACDC_MCP_PORT:-8080}/health"]
+      test: ["CMD", "wget", "-qO-", "http://localhost:${ACDC_MCP_PORT:-8080}/health"]
       interval: 30s
       timeout: 3s
       start_period: 5s

--- a/examples/docker-local-content/docker-compose.yml
+++ b/examples/docker-local-content/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - ../sample-content:/app/content:ro
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:${ACDC_MCP_PORT:-8080}/health"]
+      test: ["CMD", "wget", "-qO-", "http://localhost:${ACDC_MCP_PORT:-8080}/health"]
       interval: 30s
       timeout: 3s
       start_period: 5s


### PR DESCRIPTION
## Summary

The Docker Hub overview was maintained by hand in the web UI and had drifted from what the server actually does. This adds `docs/dockerhub-overview.md` as the source of truth and a CI job that publishes it, so the page tracks the repo from here on.

## Changes

- **`docs/dockerhub-overview.md`** — written against the current code and verified against the published `latest` image. Covers the stdio/SSE distinction, zero-config content, the tag scheme, platforms and mount point, the full `ACDC_MCP_*` surface (including the five search boosts and `search-result-mode`, which the README's abridged table omits), auth, `/health`, Compose, and agent registration.
- **`dockerhub-description` CI job** — runs `peter-evans/dockerhub-description@v5` on default-branch pushes, scoped to `permissions: contents: read`.
- **README `docker run` fix** — the example showed `docker run -p 8080:8080 …`, but the image sets no `ACDC_MCP_TRANSPORT`, so it starts in stdio and the port mapping does nothing. Confirmed against the published image config: `Env` has exactly four entries and none is `ACDC_MCP_TRANSPORT`.
- **Compose health checks** — both examples probed with `curl`, which the runtime image does not contain. All four layers of `sha1n/mcp-acdc-server:latest` were inspected: no `curl` anywhere, and `usr/bin/wget` is a busybox symlink with the wget applet compiled in. They now use `wget -qO-`. As written before, those health checks could never have passed.
- **License correction** — the README and the overview both claimed MIT. `LICENSE` is Apache-2.0, and the image's `org.opencontainers.image.licenses` label agrees.

## Reviewer notes

**Docker Hub token scope — the one thing that can break on merge.** `peter-evans/dockerhub-description` needs a PAT with **`read/write/delete`** scope. `DOCKERHUB_TOKEN` only has to cover image pushes (`read/write`), so if it lacks `delete` the job fails on its first run. Worth confirming the token's scope, or minting a separate secret, before merging.

**The job is deliberately not in `status-check`'s `needs`.** It only runs on `master`, so it cannot gate PRs either way; keeping it out means a Docker Hub API hiccup can't retroactively redden an otherwise green build. A failure will still show the workflow run as red on the Actions tab.

**Pre-existing CI bug found here, deliberately not fixed.** The `src` and `docker` paths filters are a `'**'` pattern OR-ed with a `'!({…})'` one. `dorny/paths-filter` ORs the patterns in a list, and `!(…)` is a picomatch *extglob* rather than a negation — only a leading bare `!` negates — so the exclusions subtract nothing and both filters match every path. Every push and PR therefore runs the full test suite and the multi-arch build. Confirmed empirically: run `30933621020` on `48e5524`, whose changed files are entirely `.github/**`, `README.md` and `docs/**`, ran the `docker` job to `success` rather than skipping it. Fixing it changes what CI runs, so it belongs in its own PR. The new `dockerhub_description` filter is unaffected — it was evaluated under picomatch and matches only the overview and this workflow.

## Verification

`actionlint` passes on the modified workflow. The overview's claims were checked against the published image (pulled layer-by-layer from the registry API, no local Docker) and a locally built binary: stdio default, SSE via `ACDC_MCP_TRANSPORT=sse`, `/health` returning 200 and staying unauthenticated even under `--auth-type apikey`, `/sse` returning 401 without `X-API-Key`, zero-config indexing limited to `README.md` and `docs/**/*.md`, and every default in the config tables matching the startup logs. The publishing step itself can only be confirmed after merge.
